### PR TITLE
Resolves #2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,13 +19,13 @@ jobs:
           go-version: 1.17
 
       - name: Setup golangci-lint
-        uses: golangci/golangci-lint-action@v2.5.2
+        uses: golangci/golangci-lint-action@v3.1.0
         with:
-          version: v1.43.0
+          version: v1.45.0
           args: "--timeout 5m -v -c .golangci.yml"
 
       - name: Lint
-        run: /home/runner/golangci-lint-1.43.0-linux-amd64/golangci-lint run -v -c .golangci.yml
+        run: golangci-lint run -v -c .golangci.yml
 
       - name: Test
         run: make test coverage

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -19,11 +19,11 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
         id: go
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2.7.0
+        uses: goreleaser/goreleaser-action@v2
         with:
           args: release --rm-dist
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Load config from Config file, and from env vars. Use viper for that
 - Automatically alocates a random port, if the specified one is in-use
 
+## [0.1.16] - 2022-04-11
+## Changed
+- Reset upstream proxy configuration when PAC is used and a URL doesn't require proxy
+- Upgraded golang-ci version (CI pipeline)
+
 ## [0.1.15] - 2022-02-22
 ## Changed
 - Fix message logging level

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ doc:
 ifndef HAS_GODOC
 	$(error You must install godoc, run "go get golang.org/x/tools/cmd/godoc")
 endif
-	@echo "Open localhost:6060/pkg/github.com/saucelabs/forwarder/ in your browser\n"
+	@echo "Open http://localhost:6060/pkg/github.com/saucelabs/forwarder/ in your browser\n"
 	@godoc -http :6060
 
 ci: lint test coverage

--- a/pkg/proxy/doc.go
+++ b/pkg/proxy/doc.go
@@ -2,9 +2,10 @@
 // Use of this source code is governed by a MIT
 // license that can be found in the LICENSE file.
 
-// Package proxy provides a simple proxy. The proxy can be protected with basic
-// auth. It can also forward connections to a parent proxy, and authorize
+// Package proxy provides a simple forward proxy server. The proxy can be protected with
+// HTTP basic authentication.
+// It can also forward connections to a parent proxy, and authorize
 // connections against that. Both local, and parent credentials can be set via
 // environment variables. For local proxy credential, set `PROXY_CREDENTIAL`.
-// For remote proxy credential, set `PROXY_PARENT_CREDENTIAL`.
+// For parent proxy credential, set `PROXY_PARENT_CREDENTIAL`.
 package proxy

--- a/pkg/proxy/example_test.go
+++ b/pkg/proxy/example_test.go
@@ -53,6 +53,7 @@ func ExampleNew() {
 	// Target/end server.
 	//////
 
+	// Create a protected HTTP server. user1:pass1 base64-encoded is dXNlcjE6cGFzczE=.
 	targetServer := createMockedHTTPServer(http.StatusOK, "body", "dXNlcjE6cGFzczE=")
 
 	defer func() { targetServer.Close() }()
@@ -89,6 +90,7 @@ func ExampleNew() {
 	// PAC server.
 	//////
 
+	// Start a protected server (user:pass) serving PAC file.
 	pacServer := createMockedHTTPServer(http.StatusOK, pacText.String(), "dXNlcjpwYXNz")
 
 	defer func() { pacServer.Close() }()
@@ -115,9 +117,8 @@ func ExampleNew() {
 	//////
 	// Local proxy.
 	//
-	// It's protected with Basic Auth. Upstream proxy will be automatically, and
-	// dynamically setup via PAC, including credentials for proxies specified
-	// in the PAC content.
+	// It's protected with Basic Auth. Upstream proxy URL and credentials are determined
+	// per URL via PAC.
 	//////
 
 	localProxy, err := New(

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -347,16 +347,18 @@ func setupPACUpstreamProxyConnection(p *Proxy, ctx *goproxy.ProxyCtx) error {
 
 		if pacProxyURI == nil {
 			// Should only set up upstream if there's a proxy for the given URL, not
-			// `DIRECT`.
+			// `DIRECT`. Clear upstream proxy settings for this request.
 			logger.Get().Debugln("Found DIRECT rule for", urlToFindProxyFor)
+			resetUpstreamSettings(ctx)
 
 			return nil
 		}
 
 		setupUpstreamProxyConnection(ctx, pacProxyURI)
-	} else {
-		logger.Get().Debugln("Found no proxy for", urlToFindProxyFor)
 	}
+
+	logger.Get().Debugln("Found no proxy for", urlToFindProxyFor)
+	resetUpstreamSettings(ctx)
 
 	return nil
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -324,7 +324,7 @@ func setupUpstreamProxyConnection(ctx *goproxy.ProxyCtx, uri *url.URL) {
 
 	ctx.Proxy.ConnectDial = ctx.Proxy.NewConnectDialToProxyWithHandler(uri.String(), connectReqHandler)
 
-	logger.Get().Debuglnf("Set up forwarding connections to %s", uri.Redacted())
+	logger.Get().Debuglnf("Connection to the upstream proxy %s is set up", uri.Redacted())
 }
 
 // setupUpstreamProxyConnection dynamically forwards connections to an upstream
@@ -332,7 +332,7 @@ func setupUpstreamProxyConnection(ctx *goproxy.ProxyCtx, uri *url.URL) {
 func setupPACUpstreamProxyConnection(p *Proxy, ctx *goproxy.ProxyCtx) error {
 	urlToFindProxyFor := ctx.Req.URL.String()
 
-	logger.Get().Debuglnf("Finding proxy for %s", urlToFindProxyFor)
+	logger.Get().Tracelnf("Finding proxy for %s", urlToFindProxyFor)
 
 	pacProxies, err := p.pacParser.Find(urlToFindProxyFor)
 	if err != nil {
@@ -345,19 +345,16 @@ func setupPACUpstreamProxyConnection(p *Proxy, ctx *goproxy.ProxyCtx) error {
 		pacProxy := pacProxies[0]
 		pacProxyURI := pacProxy.GetURI()
 
-		if pacProxyURI == nil {
-			// Should only set up upstream if there's a proxy for the given URL, not
-			// `DIRECT`. Clear upstream proxy settings for this request.
-			logger.Get().Debugln("Found DIRECT rule for", urlToFindProxyFor)
-			resetUpstreamSettings(ctx)
+		// Should only set up upstream if there's a proxy and not `DIRECT`.
+		if pacProxyURI != nil {
+			setupUpstreamProxyConnection(ctx, pacProxyURI)
 
 			return nil
 		}
-
-		setupUpstreamProxyConnection(ctx, pacProxyURI)
 	}
 
 	logger.Get().Debugln("Found no proxy for", urlToFindProxyFor)
+	// Clear upstream proxy settings (if any) for this request.
 	resetUpstreamSettings(ctx)
 
 	return nil

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -324,7 +324,7 @@ func setupUpstreamProxyConnection(ctx *goproxy.ProxyCtx, uri *url.URL) {
 
 	ctx.Proxy.ConnectDial = ctx.Proxy.NewConnectDialToProxyWithHandler(uri.String(), connectReqHandler)
 
-	logger.Get().Debuglnf("Setup up forwarding connections to %s", uri.Redacted())
+	logger.Get().Debuglnf("Set up forwarding connections to %s", uri.Redacted())
 }
 
 // setupUpstreamProxyConnection dynamically forwards connections to an upstream
@@ -345,11 +345,15 @@ func setupPACUpstreamProxyConnection(p *Proxy, ctx *goproxy.ProxyCtx) error {
 		pacProxy := pacProxies[0]
 		pacProxyURI := pacProxy.GetURI()
 
-		// Should only do something if there's a proxy for the given URL, not
-		// `DIRECT`.
-		if pacProxyURI != nil {
-			setupUpstreamProxyConnection(ctx, pacProxyURI)
+		if pacProxyURI == nil {
+			// Should only set up upstream if there's a proxy for the given URL, not
+			// `DIRECT`.
+			logger.Get().Debugln("Found DIRECT rule for", urlToFindProxyFor)
+
+			return nil
 		}
+
+		setupUpstreamProxyConnection(ctx, pacProxyURI)
 	} else {
 		logger.Get().Debugln("Found no proxy for", urlToFindProxyFor)
 	}

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -158,6 +158,7 @@ func executeRequest(client *http.Client, uri string) (int, string, error) {
 // Tests
 //////
 
+//nolint:maintidx
 func TestNew(t *testing.T) {
 	//////
 	// Randomness automates port allocation, ensuring no collision happens


### PR DESCRIPTION
This PR affects only the case when PAC is used. Closes #2 

When PAC is used, each request may or may require an upstream proxy configuration.
This PR makes sure that, if a URL doesn't need an upstream proxy, the previous request upstream configuration is cleared.