### PR TITLE
Improving proxy logging

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -57,19 +57,18 @@ func (o *Options) Default() {
 	}
 }
 
-// Get returns logger. If logger isn't setup, it will exit with fatal.
+// Get returns the logger. If the logger isn't configured, it will exit with fatal.
 func Get() *sypl.Sypl {
 	if proxyLogger == nil {
-		log.Fatalln("Logger needs setup")
+		log.Fatalln("Logger is not configired")
 	}
 
 	return proxyLogger
 }
 
-// Setup logger. If it fails to setup, it will exit with fatal.
+// Setup logger. If it fails to set up, it will exit with fatal.
 func Setup(o *Options) *sypl.Sypl {
-	// Do nothing, if already setup. Otherwise, can trigger race condition in
-	// goroutine cases.
+	// Do nothing, if the logger is already set up.
 	if proxyLogger != nil {
 		return proxyLogger
 	}
@@ -100,7 +99,7 @@ func Setup(o *Options) *sypl.Sypl {
 			"filePath":  o.FilePath,
 			"level":     o.Level,
 		},
-	}, level.Debug, "Logging setup")
+	}, level.Trace, "Logging is configured")
 
 	return proxyLogger
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -324,7 +324,7 @@ func setupUpstreamProxyConnection(ctx *goproxy.ProxyCtx, uri *url.URL) {
 
 	ctx.Proxy.ConnectDial = ctx.Proxy.NewConnectDialToProxyWithHandler(uri.String(), connectReqHandler)
 
-	logger.Get().Debuglnf("Connection to the upstream proxy %s is set up", uri.Redacted())
+	logger.Get().Tracelnf("Connection to the upstream proxy %s is set up", uri.Redacted())
 }
 
 // setupUpstreamProxyConnection dynamically forwards connections to an upstream
@@ -674,8 +674,8 @@ func New(
 
 	// HTTPS handler.
 	p.proxy.OnRequest().HandleConnectFunc(func(host string, ctx *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
-		logger.Get().Debugf("Handling %s request to %s\n", ctx.Req.Method, ctx.Req.Host)
-		logger.Get().Tracef("%q\n", dumpHeaders(ctx.Req))
+		logger.Get().Infof("%s %s -> %s\n", ctx.Req.Method, ctx.Req.RemoteAddr, ctx.Req.Host)
+		logger.Get().Debuglnf("%q", dumpHeaders(ctx.Req))
 
 		if err := p.setupHandlers(ctx); err != nil {
 			logger.Get().Errorlnf("Failed to setup handler (HTTPS) for request %s. %+v", ctx.Req.URL.Redacted(), err)
@@ -688,8 +688,8 @@ func New(
 
 	// HTTP handler.
 	p.proxy.OnRequest().DoFunc(func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
-		logger.Get().Debugf("Handling %s request to %s\n", req.Method, req.Host)
-		logger.Get().Tracef("%q\n", dumpHeaders(ctx.Req))
+		logger.Get().Infof("%s %s -> %s\n", req.Method, req.RemoteAddr, req.Host)
+		logger.Get().Debuglnf("%q", dumpHeaders(ctx.Req))
 
 		if err := p.setupHandlers(ctx); err != nil {
 			logger.Get().Errorlnf("Failed to setup handler (HTTP) for request %s. %+v", ctx.Req.URL.Redacted(), err)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -672,9 +672,8 @@ func New(
 		p.pacParser = pacParser
 	}
 
-	// HTTPS handler.
 	p.proxy.OnRequest().HandleConnectFunc(func(host string, ctx *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
-		logger.Get().Infof("%s %s -> %s\n", ctx.Req.Method, ctx.Req.RemoteAddr, ctx.Req.Host)
+		logger.Get().Infolnf("%s %s -> %s", ctx.Req.Method, ctx.Req.RemoteAddr, ctx.Req.Host)
 		logger.Get().Debuglnf("%q", dumpHeaders(ctx.Req))
 
 		if err := p.setupHandlers(ctx); err != nil {
@@ -686,9 +685,8 @@ func New(
 		return nil, host
 	})
 
-	// HTTP handler.
 	p.proxy.OnRequest().DoFunc(func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
-		logger.Get().Infof("%s %s -> %s\n", req.Method, req.RemoteAddr, req.Host)
+		logger.Get().Infolnf("%s %s -> %s", req.Method, req.RemoteAddr, req.Host)
 		logger.Get().Debuglnf("%q", dumpHeaders(ctx.Req))
 
 		if err := p.setupHandlers(ctx); err != nil {
@@ -703,6 +701,13 @@ func New(
 		}
 
 		return ctx.Req, nil
+	})
+
+	p.proxy.OnResponse().DoFunc(func(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
+		logger.Get().Infolnf("%s <- %s %v (%v bytes)",
+			resp.Request.RemoteAddr, resp.Request.Host, resp.Status, resp.ContentLength)
+
+		return resp
 	})
 
 	// Local proxy authentication.

--- a/pkg/proxy/utils.go
+++ b/pkg/proxy/utils.go
@@ -55,7 +55,7 @@ func dumpHeaders(req *http.Request) []byte {
 	requestDump, err := httputil.DumpRequest(req, false)
 	if err != nil {
 		return nil
-	} else {
-		return requestDump
 	}
+
+	return requestDump
 }

--- a/pkg/proxy/utils.go
+++ b/pkg/proxy/utils.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/gob"
 	"fmt"
+	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"os"
 	"strings"
@@ -47,4 +49,13 @@ func deepCopy(source, target interface{}) error {
 	}
 
 	return nil
+}
+
+func dumpHeaders(req *http.Request) []byte {
+	requestDump, err := httputil.DumpRequest(req, false)
+	if err != nil {
+		return nil
+	} else {
+		return requestDump
+	}
 }


### PR DESCRIPTION
This PR introduces slightly cleaner logging:

- Always log URL and request method (INFO level)
- Log request headers in DEBUG level
- Avoid logging messages that contain only static information, like `logger.Get().Debugln("Request handled by the HTTP handler")`