### PR TITLE
Redirect standard logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Load config from Config file, and from env vars. Use viper for that
 - Automatically alocates a random port, if the specified one is in-use
 
+## [0.1.18] - 2022-04-13
+## Changed
+- Redirect standard output to configured logger
+
 ## [0.1.17] - 2022-04-12
 ## Changed
 - Log request and response at INFO level

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -5,9 +5,6 @@
 package cmd
 
 import (
-	"io/ioutil"
-	"log"
-	
 	"github.com/saucelabs/customerror"
 	"github.com/saucelabs/forwarder/pkg/proxy"
 	"github.com/spf13/cobra"
@@ -110,9 +107,6 @@ Note: Can't setup upstream, and PAC at the same time.
 		if err != nil {
 			cliLogger.Fatalln(customerror.NewFailedToError("run", customerror.WithError(err)))
 		}
-
-		// Disable standard logger, only sypl or other custom logs will be output
-		log.SetOutput(ioutil.Discard)
 
 		p.Run()
 	},

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -5,6 +5,9 @@
 package cmd
 
 import (
+	"io/ioutil"
+	"log"
+	
 	"github.com/saucelabs/customerror"
 	"github.com/saucelabs/forwarder/pkg/proxy"
 	"github.com/spf13/cobra"
@@ -107,6 +110,9 @@ Note: Can't setup upstream, and PAC at the same time.
 		if err != nil {
 			cliLogger.Fatalln(customerror.NewFailedToError("run", customerror.WithError(err)))
 		}
+
+		// Disable standard logger, only sypl or other custom logs will be output
+		log.SetOutput(ioutil.Discard)
 
 		p.Run()
 	},

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -7,6 +7,7 @@ package logger
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -118,9 +119,13 @@ func (pL *ProxyLogger) Printf(format string, v ...interface{}) {
 	pL.Logger.Debuglnf(format, v...)
 }
 
+type StandardLogger struct {
+	Logger *sypl.Sypl
+}
+
 // Write satisfies the standard logging interface. Default logging level will be
 // `Debug`.
-func (pL *ProxyLogger) Write(p []byte) (int, error) {
+func (pL *StandardLogger) Write(p []byte) (int, error) {
 	p = bytes.TrimSpace(p)
 	pL.Logger.Debug(string(p))
 	return len(p), nil
@@ -131,8 +136,13 @@ func (pL *ProxyLogger) Write(p []byte) (int, error) {
 func RedirectStandardLogs() {
 	log.SetFlags(0)
 	log.SetPrefix("")
-	proxyLogger := &ProxyLogger{
-		Logger: Get().New("standard"),
+	standardLogger := &StandardLogger{
+		Logger: Get().New("go"),
 	}
-	log.SetOutput(proxyLogger)
+	log.SetOutput(standardLogger)
+}
+
+// DisableStandardLogs disables logs created with the standard library global logger
+func DisableStandardLogs() {
+	log.SetOutput(ioutil.Discard)
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -5,10 +5,12 @@
 package logger
 
 import (
+	"bytes"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/go-playground/validator/v10"
@@ -112,5 +114,25 @@ type ProxyLogger struct {
 // Printf satisfies `goproxy` logging interface. Default logging level will be
 // `Debug`.
 func (pL *ProxyLogger) Printf(format string, v ...interface{}) {
+	format = strings.TrimSpace(format)
 	pL.Logger.Debuglnf(format, v...)
+}
+
+// Write satisfies the standard logging interface. Default logging level will be
+// `Debug`.
+func (pL *ProxyLogger) Write(p []byte) (int, error) {
+	p = bytes.TrimSpace(p)
+	pL.Logger.Debug(string(p))
+	return len(p), nil
+}
+
+// RedirectStandardLogs redirects logs created with the standard library global logger
+// to the ProxyLogger.
+func RedirectStandardLogs() {
+	log.SetFlags(0)
+	log.SetPrefix("")
+	proxyLogger := &ProxyLogger{
+		Logger: Get().New("standard"),
+	}
+	log.SetOutput(proxyLogger)
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -591,6 +591,9 @@ func New(
 	// Underlying proxy implementation setup.
 	//////
 
+	// Ensure any standard log messages use the proxy logger
+	logger.RedirectStandardLogs()
+
 	// Instantiate underlying proxy implementation. It can be abstracted in the
 	// future to allow easy swapping.
 	proxy := goproxy.NewProxyHttpServer()

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -591,8 +591,6 @@ func New(
 	// Underlying proxy implementation setup.
 	//////
 
-	// Ensure any standard log messages use the proxy logger
-	logger.RedirectStandardLogs()
 
 	// Instantiate underlying proxy implementation. It can be abstracted in the
 	// future to allow easy swapping.
@@ -605,6 +603,12 @@ func New(
 
 		proxy.Logger = proxyLogger
 		proxy.Verbose = true
+
+		// Ensure any standard log messages use the proxy logger
+		logger.RedirectStandardLogs()
+	
+	} else {
+		logger.DisableStandardLogs()
 	}
 
 	proxy.KeepDestinationHeaders = true

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -591,7 +591,6 @@ func New(
 	// Underlying proxy implementation setup.
 	//////
 
-
 	// Instantiate underlying proxy implementation. It can be abstracted in the
 	// future to allow easy swapping.
 	proxy := goproxy.NewProxyHttpServer()
@@ -604,9 +603,8 @@ func New(
 		proxy.Logger = proxyLogger
 		proxy.Verbose = true
 
-		// Ensure any standard log messages use the proxy logger
+		// Ensure any standard log messages use a configured logger
 		logger.RedirectStandardLogs()
-	
 	} else {
 		logger.DisableStandardLogs()
 	}


### PR DESCRIPTION
If the log level > INFO, redirect log messages created by the standard library's global logger to the configured proxy logger with `component=standard` and level `DEBUG`

If the log level <= `INFO`, then disable standard logging.