### PR TITLE
Revert standard log redirect

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -5,9 +5,7 @@
 package logger
 
 import (
-	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -117,32 +115,4 @@ type ProxyLogger struct {
 func (pL *ProxyLogger) Printf(format string, v ...interface{}) {
 	format = strings.TrimSpace(format)
 	pL.Logger.Debuglnf(format, v...)
-}
-
-type StandardLogger struct {
-	Logger *sypl.Sypl
-}
-
-// Write satisfies the standard logging interface. Default logging level will be
-// `Debug`.
-func (pL *StandardLogger) Write(p []byte) (int, error) {
-	p = bytes.TrimSpace(p)
-	pL.Logger.Debug(string(p))
-	return len(p), nil
-}
-
-// RedirectStandardLogs redirects logs created with the standard library global logger
-// to the ProxyLogger.
-func RedirectStandardLogs() {
-	log.SetFlags(0)
-	log.SetPrefix("")
-	standardLogger := &StandardLogger{
-		Logger: Get().New("go"),
-	}
-	log.SetOutput(standardLogger)
-}
-
-// DisableStandardLogs disables logs created with the standard library global logger
-func DisableStandardLogs() {
-	log.SetOutput(ioutil.Discard)
 }

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -5,15 +5,7 @@
 package logger
 
 import (
-	"log"
-	"strings"
 	"testing"
-	
-	"github.com/saucelabs/sypl"
-	"github.com/saucelabs/sypl/level"
-	"github.com/saucelabs/sypl/output"
-	"github.com/saucelabs/sypl/processor"
-	"github.com/saucelabs/sypl/shared"
 )
 
 func TestSetup(t *testing.T) {
@@ -65,33 +57,4 @@ func TestSetup(t *testing.T) {
 			}
 		})
 	}
-}
-
-
-func TestRedirectStandardLogs(t *testing.T) {
-	// set global proxy logger
-	proxyLogger = sypl.NewDefault("test", level.Debug)
-	defer func(){proxyLogger = nil}()
-
-	// proxyLogger sends output to a buffer
-	buffer, outputBuffer := output.SafeBuffer(level.Trace, processor.PrefixBasedOnMask(shared.DefaultTimestampFormat))
-	proxyLogger.AddOutputs(outputBuffer)
-
-	// test standard logger before and after redirect
-	beforeMsg := "Before redirect"
-	afterMsg := "After redirect" 
-	log.Println(beforeMsg)
-	
-	RedirectStandardLogs()
-	log.Println(afterMsg)
-
-	bufferStr := buffer.String()
-
-	if strings.Contains(bufferStr, beforeMsg) {
-		t.Errorf("%s should not appear in proxy logger: %s", beforeMsg, bufferStr)
-	}
-	if !strings.Contains(bufferStr, afterMsg) {
-		t.Errorf("%s should appear in proxy logger: %s", afterMsg, bufferStr)
-	}
-
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -602,11 +602,6 @@ func New(
 
 		proxy.Logger = proxyLogger
 		proxy.Verbose = true
-
-		// Ensure any standard log messages use a configured logger
-		logger.RedirectStandardLogs()
-	} else {
-		logger.DisableStandardLogs()
 	}
 
 	proxy.KeepDestinationHeaders = true


### PR DESCRIPTION
Revert standard log redirect. `RedirectStandardLogs` and `DiscardStandardLogs` may be moved to `sypl`, and called by the downstream library.