### PR TITLE
response handler panics - resolves issue #10

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a MIT
 # license that can be found in the LICENSE file.
 
+---
 run:
   timeout: 1m
   skip-files:
@@ -25,7 +26,7 @@ linters:
 # Settings for specific linters
 linters-settings:
   gocognit:
-    min-complexity: 35
+    min-complexity: 40
 
   funlen:
     lines: 200

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Load config from Config file, and from env vars. Use viper for that
 - Automatically alocates a random port, if the specified one is in-use
 
+## [0.1.20] - 2022-04-21
+## Changed
+- Upgrade goproxy library to the latest master
+- Check that the response struct is allocated before logging its details
+
 ## [0.1.19] - 2022-04-18
 ## Changed
 - Revert the changes introduced in 0.1.18

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/eapache/go-resiliency v1.2.0
-	github.com/elazarl/goproxy v0.0.0-20220115173737-adb46da277ac
+	github.com/elazarl/goproxy v0.0.0-20220417044921-416226498f94
 	github.com/elazarl/goproxy/ext v0.0.0-20220115173737-adb46da277ac
 	github.com/go-playground/validator/v10 v10.10.0
 	github.com/saucelabs/customerror v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,8 @@ github.com/eapache/go-resiliency v1.2.0 h1:v7g92e/KSN71Rq7vSThKaWIq68fL4YHvWyiUK
 github.com/eapache/go-resiliency v1.2.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/elazarl/goproxy v0.0.0-20220115173737-adb46da277ac h1:XDAn206aIqKPdF5YczuuJXSQPx+WOen0Pxbxp5Fq8Pg=
 github.com/elazarl/goproxy v0.0.0-20220115173737-adb46da277ac/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
+github.com/elazarl/goproxy v0.0.0-20220417044921-416226498f94 h1:VIy7cdK7ufs7ctpTFkXJHm1uP3dJSnCGSPysEICB1so=
+github.com/elazarl/goproxy v0.0.0-20220417044921-416226498f94/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
 github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/elazarl/goproxy/ext v0.0.0-20220115173737-adb46da277ac h1:9yrT5tmn9Zc0ytWPASlaPwQfQMQYnRf0RSDe1XvHw0Q=
 github.com/elazarl/goproxy/ext v0.0.0-20220115173737-adb46da277ac/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -704,8 +704,12 @@ func New(
 	})
 
 	p.proxy.OnResponse().DoFunc(func(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
-		logger.Get().Debuglnf("%s <- %s %v (%v bytes)",
-			resp.Request.RemoteAddr, resp.Request.Host, resp.Status, resp.ContentLength)
+		if resp != nil {
+			logger.Get().Debuglnf("%s <- %s %v (%v bytes)",
+				resp.Request.RemoteAddr, resp.Request.Host, resp.Status, resp.ContentLength)
+		} else {
+			logger.Get().Tracelnf("%s <- %s response is empty", ctx.Req.Host, ctx.Req.RemoteAddr)
+		}
 
 		return resp
 	})


### PR DESCRIPTION
Resolves the issue #10 
It seems that, under certain conditions, the response struct that is passed to the custom logging handler is not allocated.
Nil response [is handled](https://github.com/elazarl/goproxy/blob/ec48516/proxy.go#L126) in goproxy so the forwarder could just let goproxy log the debugging info.

Example:

```
07:56:52.285 GET 127.0.0.1:64756 -> dpm.demdex.net
07:56:52.430 127.0.0.1:64756 <- dpm.demdex.net 200 OK (59 bytes)
07:56:52.608 GET 127.0.0.1:64756 -> beap.gemini.yahoo.com
07:56:52.719 beap.gemini.yahoo.com <- 127.0.0.1:64756 response is empty
```