### PR TITLE
Renaming *_CREDENTIAL to *_AUTH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Load config from Config file, and from env vars. Use viper for that
 - Automatically alocates a random port, if the specified one is in-use
 
+## [0.2.0] - 2022-05-30
+## Changed
+- Upgraded goproxy library to the latest master
+- Upgraded pacman
+- Renamed FORWARDER_*_CREDENTIAL to FORWARDER_*_AUTH env vars
+
 ## [0.1.20] - 2022-04-21
 ## Changed
 - Upgrade goproxy library to the latest master

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -34,10 +34,10 @@ Also, credentials for proxies specified in PAC can be set.
 
 All credentials can be set via env vars:
 
-- Local proxy: FORWARDER_LOCALPROXY_CREDENTIAL
-- Upstream proxy: FORWARDER_UPSTREAMPROXY_CREDENTIAL
-- PAC URI: PACMAN_CREDENTIAL
-- PAC proxies: PACMAN_PROXIES_CREDENTIAL
+- Local proxy: FORWARDER_LOCALPROXY_AUTH
+- Upstream proxy: FORWARDER_UPSTREAMPROXY_AUTH
+- PAC URI: PACMAN_AUTH
+- PAC proxies: PACMAN_PROXIES_AUTH
 
 Note: Can't setup upstream, and PAC at the same time.
 `,

--- a/go.mod
+++ b/go.mod
@@ -6,18 +6,18 @@ require (
 	github.com/eapache/go-resiliency v1.2.0
 	github.com/elazarl/goproxy v0.0.0-20220529153421-8ea89ba92021
 	github.com/elazarl/goproxy/ext v0.0.0-20220529153421-8ea89ba92021
-	github.com/go-playground/validator/v10 v10.10.0
+	github.com/go-playground/validator/v10 v10.11.0
 	github.com/saucelabs/customerror v1.0.3
-	github.com/saucelabs/pacman v0.0.13
+	github.com/saucelabs/pacman v0.1.1
 	github.com/saucelabs/randomness v0.0.5
-	github.com/saucelabs/sypl v1.5.10
+	github.com/saucelabs/sypl v1.5.12
 	github.com/spf13/cobra v1.3.0
 )
 
 require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91 // indirect
-	github.com/dop251/goja v0.0.0-20211006122547-7efcb634c641 // indirect
+	github.com/dop251/goja v0.0.0-20220516123900-4418d4575a41 // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/go-playground/locales v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -99,7 +99,11 @@ github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91 h1:Izz0+t1Z5nI16
 github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dop251/goja v0.0.0-20211006122547-7efcb634c641 h1:FeL9DrCQOmJ0Xw5V3hNa3MVDYAvNaa/fVGJkYUgfgLY=
 github.com/dop251/goja v0.0.0-20211006122547-7efcb634c641/go.mod h1:R9ET47fwRVRPZnOGvHxxhuZcbrMCuiqOz3Rlrh4KSnk=
+github.com/dop251/goja v0.0.0-20211022113120-dc8c55024d06/go.mod h1:R9ET47fwRVRPZnOGvHxxhuZcbrMCuiqOz3Rlrh4KSnk=
+github.com/dop251/goja v0.0.0-20220516123900-4418d4575a41 h1:yRPjAkkuR/E/tsVG7QmhzEeEtD3P2yllxsT1/ftURb0=
+github.com/dop251/goja v0.0.0-20220516123900-4418d4575a41/go.mod h1:TQJQ+ZNyFVvUtUEtCZxBhfWiH7RJqR3EivNmvD6Waik=
 github.com/dop251/goja_nodejs v0.0.0-20210225215109-d91c329300e7/go.mod h1:hn7BA7c8pLvoGndExHudxTDKZ84Pyvv+90pbBjbTz0Y=
+github.com/dop251/goja_nodejs v0.0.0-20211022123610-8dd9abb0616d/go.mod h1:DngW8aVqWbuLRMHItjPUyqdj+HWPvnQe8V8y1nDpIbM=
 github.com/eapache/go-resiliency v1.2.0 h1:v7g92e/KSN71Rq7vSThKaWIq68fL4YHvWyiUKorFR1Q=
 github.com/eapache/go-resiliency v1.2.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/elazarl/goproxy v0.0.0-20220115173737-adb46da277ac h1:XDAn206aIqKPdF5YczuuJXSQPx+WOen0Pxbxp5Fq8Pg=
@@ -148,6 +152,8 @@ github.com/go-playground/universal-translator v0.18.0 h1:82dyy6p4OuJq4/CByFNOn/j
 github.com/go-playground/universal-translator v0.18.0/go.mod h1:UvRDBj+xPUEGrFYl+lu/H90nyDXpg0fqeB/AQUGNTVA=
 github.com/go-playground/validator/v10 v10.10.0 h1:I7mrTYv78z8k8VXa/qJlOlEXn/nBh+BF8dHX5nt/dr0=
 github.com/go-playground/validator/v10 v10.10.0/go.mod h1:74x4gJWsvQexRdW8Pn3dXSGrTK4nAUsbPlLADvpJkos=
+github.com/go-playground/validator/v10 v10.11.0 h1:0W+xRM511GY47Yy3bZUbJVitCNg2BOGlCyvTqsp/xIw=
+github.com/go-playground/validator/v10 v10.11.0/go.mod h1:i+3WkQ1FvaUjjxh1kSvIA4dMGDBiPU55YFDl0WbKdWU=
 github.com/go-sourcemap/sourcemap v2.1.3+incompatible h1:W1iEw64niKVGogNgBN3ePyLFfuisuzeidWPMPWmECqU=
 github.com/go-sourcemap/sourcemap v2.1.3+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -357,11 +363,17 @@ github.com/saucelabs/lumberjack/v3 v3.0.2 h1:d2xl3L4gtuwhFOnBEWTcTRxZ64wQWyFfUK8
 github.com/saucelabs/lumberjack/v3 v3.0.2/go.mod h1:YWvEpPjHrjk7jKET9K4Vphyk6RFlXFD1e/rP60Fr+JA=
 github.com/saucelabs/pacman v0.0.13 h1:kdHLdZCminN/TGbKgXncZvXATNT7NTbXtVAfJQpVAlQ=
 github.com/saucelabs/pacman v0.0.13/go.mod h1:CiqtUweQyceGUDccdu65+LK+UxUzfERJFILMwoyQ5us=
+github.com/saucelabs/pacman v0.1.0 h1:2LpWMsGaISW79ziXTdtzgpqMLaGJsMemVo8Y8TGwtnw=
+github.com/saucelabs/pacman v0.1.0/go.mod h1:sjyZ/L3RVWB0/s5aGasliVlOJgyCnq7EvYsnZPfASJQ=
+github.com/saucelabs/pacman v0.1.1 h1:QtL6rGSRS5HuXQlo1d5mnD8ElXMdMDnVD3VEatOrFOU=
+github.com/saucelabs/pacman v0.1.1/go.mod h1:sjyZ/L3RVWB0/s5aGasliVlOJgyCnq7EvYsnZPfASJQ=
 github.com/saucelabs/randomness v0.0.5 h1:IBgMdKOWb4zCKUbQ03tTjIUXZcxG1rT/cH1iggYjCJE=
 github.com/saucelabs/randomness v0.0.5/go.mod h1:jleEVfS8aVUKZ6Js4NTnqqM62SyvAaiRs23WEgckP+g=
 github.com/saucelabs/sypl v1.5.8/go.mod h1:ubSLpo9I9awtabutiS6Npjof7s/km+HJ/9aOOPClMW0=
 github.com/saucelabs/sypl v1.5.10 h1:EptSBygwDminwfyg9SJP81ZwNcazX+1x1P4HWi18nkI=
 github.com/saucelabs/sypl v1.5.10/go.mod h1:ubSLpo9I9awtabutiS6Npjof7s/km+HJ/9aOOPClMW0=
+github.com/saucelabs/sypl v1.5.12 h1:48Qtq/A7JtWdXcTFngJzzHI5731ccReedrkZimkslfA=
+github.com/saucelabs/sypl v1.5.12/go.mod h1:r/KHXrhgQ0XFnmXAazNmRXi1AtmVs/K4VJ1OoNWkRBk=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
@@ -385,6 +397,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -418,6 +431,7 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292 h1:f+lwQ+GtmgoY+A2YaQxlSOnDjXcQ7ZRLWOHbC6HtRqE=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -634,7 +634,7 @@ func New(
 		return nil, customerror.Wrap(ErrInvalidLocalProxyURI, err)
 	}
 
-	err = loadCredentialFromEnvVar("FORWARDER_LOCALPROXY_CREDENTIAL", parsedLocalProxyURI)
+	err = loadCredentialFromEnvVar("FORWARDER_LOCALPROXY_AUTH", parsedLocalProxyURI)
 	if err != nil {
 		return nil, err
 	}
@@ -650,7 +650,7 @@ func New(
 			return nil, customerror.Wrap(ErrInvalidUpstreamProxyURI, err)
 		}
 
-		err = loadCredentialFromEnvVar("FORWARDER_UPSTREAMPROXY_CREDENTIAL", parsedUpstreamProxyURI)
+		err = loadCredentialFromEnvVar("FORWARDER_UPSTREAMPROXY_AUTH", parsedUpstreamProxyURI)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -267,31 +267,31 @@ func TestNew(t *testing.T) {
 			},
 			preFunc: func() {
 				// Local proxy.
-				os.Setenv("FORWARDER_LOCALPROXY_CREDENTIAL", url.UserPassword(
+				os.Setenv("FORWARDER_LOCALPROXY_AUTH", url.UserPassword(
 					localProxyCredentialUsername,
 					localProxyCredentialPassword,
 				).String())
 
 				// Upstream proxy.
-				os.Setenv("FORWARDER_UPSTREAMPROXY_CREDENTIAL", url.UserPassword(
+				os.Setenv("FORWARDER_UPSTREAMPROXY_AUTH", url.UserPassword(
 					upstreamProxyCredentialUsername,
 					upstreamProxyCredentialPassword,
 				).String())
 			},
 			postFunc: func() {
-				os.Unsetenv("FORWARDER_LOCALPROXY_CREDENTIAL")
+				os.Unsetenv("FORWARDER_LOCALPROXY_AUTH")
 
-				os.Unsetenv("FORWARDER_UPSTREAMPROXY_CREDENTIAL")
+				os.Unsetenv("FORWARDER_UPSTREAMPROXY_AUTH")
 			},
 			preUpstreamFunc: func() {
 				// Local proxy.
-				os.Setenv("FORWARDER_LOCALPROXY_CREDENTIAL", url.UserPassword(
+				os.Setenv("FORWARDER_LOCALPROXY_AUTH", url.UserPassword(
 					upstreamProxyCredentialUsername,
 					upstreamProxyCredentialPassword,
 				).String())
 			},
 			postUpstreamFunc: func() {
-				os.Unsetenv("FORWARDER_LOCALPROXY_CREDENTIAL")
+				os.Unsetenv("FORWARDER_LOCALPROXY_AUTH")
 			},
 			wantErr: false,
 		},
@@ -446,7 +446,7 @@ func TestNew(t *testing.T) {
 			}
 
 			// Both local `localProxy.LocalProxyURI` and `localProxy.UpstreamProxyURI`
-			// changed, if `FORWARDER_LOCALPROXY_CREDENTIAL` or `FORWARDER_UPSTREAMPROXY_CREDENTIAL`
+			// changed, if `FORWARDER_LOCALPROXY_AUTH` or `FORWARDER_UPSTREAMPROXY_AUTH`
 			// were set. This updates test vars.
 			if localProxyURI != localProxy.LocalProxyURI {
 				localProxyURI = localProxy.LocalProxyURI


### PR DESCRIPTION
Renaming *_CREDENTIAL to *_AUTH env vars to maintain the same naming convention everywhere