### PR TITLE
SC-3812 Add basic auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ endif
 test:
 	@go test -timeout 120s -short -v -race -cover -coverprofile=coverage.out ./...
 
+bench:
+	@go test -bench=. -run=XXX ./pkg/proxy
+
 test-integration:
 	@FORWARDER_TEST_MODE=integration go test -timeout 120s -v -race -cover -coverprofile=coverage.out ./... && echo "Test OK"
 

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ endif
 test:
 	@go test -timeout 120s -short -v -race -cover -coverprofile=coverage.out ./...
 
+# If you hit too many open files: ulimit -Sn 10000
 bench:
 	@go test -bench=. -run=XXX ./pkg/proxy
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -16,6 +16,8 @@ var (
 	localProxyURI    string
 	upstreamProxyURI string
 
+	siteCredentials []string
+
 	pacProxiesCredentials []string
 	pacURI                string
 
@@ -46,10 +48,10 @@ Note: Can't setup upstream, and PAC at the same time.
 
   Start a proxy listening to http://0.0.0.0:8085:
   $ forwarder run -l "http://0.0.0.0:8085"
-  
+
   Start a protected proxy:
   $ forwarder run -l "http://user:pwd@localhost:8085"
-  
+
   Start a protected proxy, forwarding connection to an upstream proxy running at
   http://localhost:8089:
   $ forwarder run \
@@ -61,19 +63,19 @@ Note: Can't setup upstream, and PAC at the same time.
   $ forwarder run \
     -l "http://user:pwd@localhost:8085" \
     -u "http://user1:pwd1@localhost:8089"
-	
+
   Start a protected proxy, forwarding connection to an upstream proxy, setup via
   PAC - server running at http://localhost:8090:
   $ forwarder run \
     -l "http://user:pwd@localhost:8085" \
     -p "http://localhost:8090"
-	
+
   Start a protected proxy, forwarding connection to an upstream proxy, setup via
   PAC - protected server running at http://user2:pwd2@localhost:8090:
   $ forwarder run \
     -l "http://user:pwd@localhost:8085" \
     -p "http://user2:pwd2@localhost:8090"
-	
+
   Start a protected proxy, forwarding connection to an upstream proxy, setup via
   PAC - protected server running at http://user2:pwd2@localhost:8090, specifying
   credential for protected proxies specified in PAC:
@@ -93,7 +95,7 @@ Note: Can't setup upstream, and PAC at the same time.
 	  -d "http://user3:pwd4@localhost:8091,http://user4:pwd5@localhost:8092"
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
-		p, err := proxy.New(localProxyURI, upstreamProxyURI, pacURI, pacProxiesCredentials, &proxy.Options{
+		p, err := proxy.New(localProxyURI, upstreamProxyURI, pacURI, pacProxiesCredentials, siteCredentials, &proxy.Options{
 			LoggingOptions: &proxy.LoggingOptions{
 				Level:     logLevel,
 				FileLevel: fileLevel,
@@ -120,6 +122,7 @@ func init() {
 	runCmd.Flags().StringSliceVarP(&dnsURIs, "dns-uri", "n", nil, "sets dns URI")
 	runCmd.Flags().StringVarP(&pacURI, "pac-uri", "p", "", "sets URI to PAC content, or directly, the PAC content")
 	runCmd.Flags().StringSliceVarP(&pacProxiesCredentials, "pac-proxies-credentials", "d", nil, "sets PAC proxies credentials using standard URI format")
+	runCmd.Flags().StringSliceVarP(&siteCredentials, "site-credentials", "d", nil, "sets site based credentials")
 	runCmd.Flags().BoolVarP(&proxyLocalhost, "proxy-localhost", "t", false, "if set, will proxy localhost requests to an upstream proxy - if any")
 	runCmd.Flags().BoolVarP(&automaticallyRetryPort, "find-port", "r", true, "if set, and the specified local proxy port is in-use, it will find, and use an available one")
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -117,12 +117,12 @@ Note: Can't setup upstream, and PAC at the same time.
 func init() {
 	rootCmd.AddCommand(runCmd)
 
-	runCmd.Flags().StringVarP(&localProxyURI, "local-proxy-uri", "l", "http://localhost:8080", "Sets local proxy URI")
+	runCmd.Flags().StringVarP(&localProxyURI, "local-proxy-uri", "l", "http://localhost:8080", "sets local proxy URI")
 	runCmd.Flags().StringVarP(&upstreamProxyURI, "upstream-proxy-uri", "u", "", "sets upstream proxy URI")
 	runCmd.Flags().StringSliceVarP(&dnsURIs, "dns-uri", "n", nil, "sets dns URI")
 	runCmd.Flags().StringVarP(&pacURI, "pac-uri", "p", "", "sets URI to PAC content, or directly, the PAC content")
 	runCmd.Flags().StringSliceVarP(&pacProxiesCredentials, "pac-proxies-credentials", "d", nil, "sets PAC proxies credentials using standard URI format")
-	runCmd.Flags().StringSliceVarP(&siteCredentials, "site-credentials", "d", nil, "sets site based credentials")
+	runCmd.Flags().StringSliceVar(&siteCredentials, "site-credentials", nil, "sets site based credentials")
 	runCmd.Flags().BoolVarP(&proxyLocalhost, "proxy-localhost", "t", false, "if set, will proxy localhost requests to an upstream proxy - if any")
 	runCmd.Flags().BoolVarP(&automaticallyRetryPort, "find-port", "r", true, "if set, and the specified local proxy port is in-use, it will find, and use an available one")
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/elazarl/goproxy v0.0.0-20220529153421-8ea89ba92021
 	github.com/elazarl/goproxy/ext v0.0.0-20220529153421-8ea89ba92021
 	github.com/go-playground/validator/v10 v10.11.0
+	github.com/google/go-cmp v0.5.6
 	github.com/saucelabs/customerror v1.0.3
 	github.com/saucelabs/pacman v0.1.1
 	github.com/saucelabs/randomness v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,7 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=

--- a/pkg/proxy/example_test.go
+++ b/pkg/proxy/example_test.go
@@ -134,6 +134,8 @@ func ExampleNew() {
 		// PAC proxies credentials in standard URI format.
 		[]string{upstreamProxyURI.String()},
 
+		nil,
+
 		// Logging settings.
 		&Options{
 			LoggingOptions: loggingOptions,
@@ -163,6 +165,8 @@ func ExampleNew() {
 		"",
 
 		// PAC proxies credentials in standard URI format.
+		nil,
+
 		nil,
 
 		// Logging settings.
@@ -228,7 +232,7 @@ func ExampleNew_automaticallyRetryPort() {
 
 	errored := false
 
-	proxy1, err := New(fmt.Sprintf("http://0.0.0.0:%d", randomPort), "", "", nil, &Options{
+	proxy1, err := New(fmt.Sprintf("http://0.0.0.0:%d", randomPort), "", "", nil, nil, &Options{
 		LoggingOptions: &LoggingOptions{
 			Level:     "none",
 			FileLevel: "none",
@@ -242,7 +246,7 @@ func ExampleNew_automaticallyRetryPort() {
 
 	time.Sleep(1 * time.Second)
 
-	proxy2, err := New(fmt.Sprintf("http://0.0.0.0:%d", randomPort), "", "", nil, &Options{
+	proxy2, err := New(fmt.Sprintf("http://0.0.0.0:%d", randomPort), "", "", nil, nil, &Options{
 		AutomaticallyRetryPort: true,
 
 		LoggingOptions: &LoggingOptions{
@@ -285,7 +289,7 @@ func ExampleNew_sypplyingLogger() {
 
 	errored := false
 
-	proxy1, err := New(fmt.Sprintf("http://0.0.0.0:%d", randomPort), "", "", nil, &Options{
+	proxy1, err := New(fmt.Sprintf("http://0.0.0.0:%d", randomPort), "", "", nil, nil, &Options{
 		LoggingOptions: &LoggingOptions{
 			Logger:    customLogger,
 			Level:     level.Trace.String(),

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -700,7 +700,10 @@ func BenchmarkNew(b *testing.B) {
 
 	localProxyURI := URIBuilder(defaultProxyHostname, r.MustGenerate(), "", "")
 
-	proxy, err := New(localProxyURI.String(), "", "", nil, nil, nil)
+	proxy, err := New(localProxyURI.String(), "", "", nil, nil,
+		&Options{
+			LoggingOptions: loggingOptions,
+		})
 	if err != nil {
 		log.Fatalln("Failed to create proxy.", err)
 	}


### PR DESCRIPTION
Add `siteCredentials` to the forwarder.

This will allow the forwarder to pass credentials to the requested site without the original requester needing any credentials.