### PR TITLE
install dependencies

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Lint
         run: golangci-lint run -v -c .golangci.yml
 
-      - name: Test
+      - name: Unit test
         run: make test coverage
 
-      - name: Test Integration
-        run: make test-integration coverage
+      - name: Integration test
+        run: make integration-test coverage

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@
 *.dylib
 .direnv
 
+# Development binary
+*.dev
+*.race
+
 # Test binary, build with `go test -c`
 *.test
 

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,3 @@ coverage:
 doc:
 	@echo "Open http://localhost:6060/pkg/github.com/saucelabs/forwarder/ in your browser\n"
 	@godoc -http :6060
-
-ci: lint test coverage
-ci-integration: lint test-integration coverage

--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,6 @@ install-dependencies:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	go install golang.org/x/tools/cmd/godoc@latest
 
-BINDIR := $(CURDIR)/bin
-HAS_AIR := $(shell command -v air;)
-HAS_GODOC := $(shell command -v godoc;)
-HAS_GOLANGCI := $(shell command -v golangci-lint;)
-
 BUILD_BASE_PKG_NAME := github.com/saucelabs/forwarder/internal/
 BUILD_GIT_COMMIT := `git rev-list -1 HEAD`
 BUILD_DATE := `date`
@@ -28,15 +23,9 @@ build:
 	@GOBIN=$(BINDIR) go install -race -ldflags $(BUILD_LDFLAGS) ./... && echo "Build OK"
 
 dev:
-ifndef HAS_AIR
-	$(error You must install github.com/cosmtrek/air)
-endif
 	@air -c .air.toml
 
 lint:
-ifndef HAS_GOLANGCI
-	$(error You must install github.com/golangci/golangci-lint)
-endif
 	@golangci-lint run -v -c .golangci.yml && echo "Lint OK"
 
 test:
@@ -53,9 +42,6 @@ coverage:
 	@go tool cover -func=coverage.out
 
 doc:
-ifndef HAS_GODOC
-	$(error You must install godoc, run "go get golang.org/x/tools/cmd/godoc")
-endif
 	@echo "Open http://localhost:6060/pkg/github.com/saucelabs/forwarder/ in your browser\n"
 	@godoc -http :6060
 

--- a/Makefile
+++ b/Makefile
@@ -14,18 +14,18 @@ install-dependencies:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	go install golang.org/x/tools/cmd/godoc@latest
 
+.PHONY: dev
+dev:
+	@air -c .air.toml
+
 BUILD_BASE_PKG_NAME = github.com/saucelabs/forwarder/internal/
 BUILD_GIT_COMMIT = `git rev-list -1 HEAD`
 BUILD_DATE = `date`
 BUILD_LDFLAGS = "-X '$(BUILD_BASE_PKG_NAME)version.buildCommit=$(BUILD_GIT_COMMIT)' -X '$(BUILD_BASE_PKG_NAME)version.buildVersion=$(BUILD_VERSION)' -X '$(BUILD_BASE_PKG_NAME)version.buildTime=$(BUILD_DATE)' -extldflags '-static'"
 
-.PHONY: build
-build:
-	@GOBIN=$(BINDIR) go install -race -ldflags $(BUILD_LDFLAGS) ./... && echo "Build OK"
-
-.PHONY: dev
-dev:
-	@air -c .air.toml
+.PHONY: dev-build
+dev-build:
+	@go build -o ./forwarder.race -race -ldflags $(BUILD_LDFLAGS) ./.
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 # Use of this source code is governed by a MIT
 # license that can be found in the LICENSE file.
 
+all: dev
+
 BINDIR := $(CURDIR)/bin
 HAS_AIR := $(shell command -v air;)
 HAS_GODOC := $(shell command -v godoc;)
@@ -11,8 +13,6 @@ BUILD_BASE_PKG_NAME := github.com/saucelabs/forwarder/internal/
 BUILD_GIT_COMMIT := `git rev-list -1 HEAD`
 BUILD_DATE := `date`
 BUILD_LDFLAGS := "-X '$(BUILD_BASE_PKG_NAME)version.buildCommit=$(BUILD_GIT_COMMIT)' -X '$(BUILD_BASE_PKG_NAME)version.buildVersion=$(BUILD_VERSION)' -X '$(BUILD_BASE_PKG_NAME)version.buildTime=$(BUILD_DATE)' -extldflags '-static'"
-
-default: dev
 
 build:
 	@GOBIN=$(BINDIR) go install -race -ldflags $(BUILD_LDFLAGS) ./... && echo "Build OK"

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ install-dependencies:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	go install golang.org/x/tools/cmd/godoc@latest
 
-BUILD_BASE_PKG_NAME := github.com/saucelabs/forwarder/internal/
-BUILD_GIT_COMMIT := `git rev-list -1 HEAD`
-BUILD_DATE := `date`
-BUILD_LDFLAGS := "-X '$(BUILD_BASE_PKG_NAME)version.buildCommit=$(BUILD_GIT_COMMIT)' -X '$(BUILD_BASE_PKG_NAME)version.buildVersion=$(BUILD_VERSION)' -X '$(BUILD_BASE_PKG_NAME)version.buildTime=$(BUILD_DATE)' -extldflags '-static'"
+BUILD_BASE_PKG_NAME = github.com/saucelabs/forwarder/internal/
+BUILD_GIT_COMMIT = `git rev-list -1 HEAD`
+BUILD_DATE = `date`
+BUILD_LDFLAGS = "-X '$(BUILD_BASE_PKG_NAME)version.buildCommit=$(BUILD_GIT_COMMIT)' -X '$(BUILD_BASE_PKG_NAME)version.buildVersion=$(BUILD_VERSION)' -X '$(BUILD_BASE_PKG_NAME)version.buildTime=$(BUILD_DATE)' -extldflags '-static'"
 
 .PHONY: build
 build:

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,16 @@
 
 all: dev
 
+export GOBIN := $(PWD)/bin
+export PATH  := $(GOBIN):$(PATH)
+
+.PHONY: install-dependencies
+install-dependencies:
+	@rm -Rf bin
+	go install github.com/cosmtrek/air@latest
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	go install golang.org/x/tools/cmd/godoc@latest
+
 BINDIR := $(CURDIR)/bin
 HAS_AIR := $(shell command -v air;)
 HAS_GODOC := $(shell command -v godoc;)

--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,9 @@ test:
 bench:
 	@go test -bench=. -run=XXX ./pkg/proxy # If you hit too many open files: ulimit -Sn 10000
 
-.PHONY: test-integration
-test-integration:
-	@FORWARDER_TEST_MODE=integration go test -timeout 120s -v -race -cover -coverprofile=coverage.out ./... && echo "Test OK"
+.PHONY: integration-test
+integration-test:
+	@FORWARDER_TEST_MODE=integration go test -timeout 120s -v -race -cover -coverprofile=coverage.out ./...
 
 .PHONY: coverage
 coverage:

--- a/Makefile
+++ b/Makefile
@@ -19,33 +19,38 @@ BUILD_GIT_COMMIT := `git rev-list -1 HEAD`
 BUILD_DATE := `date`
 BUILD_LDFLAGS := "-X '$(BUILD_BASE_PKG_NAME)version.buildCommit=$(BUILD_GIT_COMMIT)' -X '$(BUILD_BASE_PKG_NAME)version.buildVersion=$(BUILD_VERSION)' -X '$(BUILD_BASE_PKG_NAME)version.buildTime=$(BUILD_DATE)' -extldflags '-static'"
 
+.PHONY: build
 build:
 	@GOBIN=$(BINDIR) go install -race -ldflags $(BUILD_LDFLAGS) ./... && echo "Build OK"
 
+.PHONY: dev
 dev:
 	@air -c .air.toml
 
+.PHONY: lint
 lint:
 	@golangci-lint run -v -c .golangci.yml && echo "Lint OK"
 
+.PHONY: test
 test:
 	@go test -timeout 120s -short -v -race -cover -coverprofile=coverage.out ./...
 
-# If you hit too many open files: ulimit -Sn 10000
+.PHONY: bench
 bench:
-	@go test -bench=. -run=XXX ./pkg/proxy
+	@go test -bench=. -run=XXX ./pkg/proxy # If you hit too many open files: ulimit -Sn 10000
 
+.PHONY: test-integration
 test-integration:
 	@FORWARDER_TEST_MODE=integration go test -timeout 120s -v -race -cover -coverprofile=coverage.out ./... && echo "Test OK"
 
+.PHONY: coverage
 coverage:
 	@go tool cover -func=coverage.out
 
+.PHONY: doc
 doc:
 	@echo "Open http://localhost:6060/pkg/github.com/saucelabs/forwarder/ in your browser\n"
 	@godoc -http :6060
 
 ci: lint test coverage
 ci-integration: lint test-integration coverage
-
-.PHONY: lint test coverage ci ci-integration

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # forwarder
 
-`forwarder` provides a simple forward proxy. The proxy can be protected with basic auth.
+The `forwarder` package provides a simple forward proxy.
+The proxy can be protected with basic auth.
 It can also forward connections to a parent proxy, and authorize connections against that.
-Both local, and parent credentials can be set via environment variables.
-For local proxy credential, set `FORWARDER_LOCALPROXY_AUTH`. For remote proxy credential, set `FORWARDER_UPSTREAMPROXY_AUTH`.
+Both local and parent credentials can be set via environment variables.
+For local proxy credential, set `FORWARDER_LOCALPROXY_AUTH`.
+For remote proxy credential, set `FORWARDER_UPSTREAMPROXY_AUTH`.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ Run `$ make doc` or check out [online](https://pkg.go.dev/github.com/saucelabs/f
 
 ## Development
 
-Check out [CONTRIBUTION](CONTRIBUTION.md).
+1. Install required tools by running `make install-dependencies`
+2. Run server in development mode `make dev` 
+
+For more information see [CONTRIBUTION](CONTRIBUTION.md).
 
 ### Release
 


### PR DESCRIPTION
This patch set adds `install-dependencies` makefile target that facilitate installation of required development tools.
I piggybacked improvements to makefile that intend to improve readability and conform to best practices for makefiles.

Fixes #24