### PR TITLE
proxy: fix initialization

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -153,15 +153,13 @@ func ExampleNew() {
 		Transport: tr,
 	}
 
-	statusCode, body, err := executeRequest(client, targetServerURI.String())
+	body, err := assertRequest(client, targetServerURI.String(), http.StatusOK)
 	if err != nil {
 		panic(err)
 	}
 
-	fmt.Println(statusCode)
 	fmt.Println(body)
 
 	// output:
-	// 200
 	// body
 }

--- a/example_test.go
+++ b/example_test.go
@@ -109,6 +109,7 @@ func ExampleNew() {
 		LocalProxyURI:         localProxyURI,
 		PACURI:                pacServerURI,
 		PACProxiesCredentials: []string{upstreamProxyURI.String()},
+		ProxyLocalhost:        true,
 	}
 	localProxy, err := NewProxy(&c, log)
 	if err != nil {
@@ -124,7 +125,10 @@ func ExampleNew() {
 	// Upstream Proxy.
 	//////
 
-	upstreamProxy, err := NewProxy(&ProxyConfig{LocalProxyURI: upstreamProxyURI}, log)
+	upstreamProxy, err := NewProxy(&ProxyConfig{
+		LocalProxyURI:  upstreamProxyURI,
+		ProxyLocalhost: true,
+	}, log)
 	if err != nil {
 		panic(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/saucelabs/forwarder
 go 1.19
 
 require (
-	github.com/elazarl/goproxy v0.0.0-20220529153421-8ea89ba92021
+	github.com/elazarl/goproxy v0.0.0-20220901064549-fbd10ff4f5a1
 	github.com/elazarl/goproxy/ext v0.0.0-20220529153421-8ea89ba92021
 	github.com/mmatczuk/anyflag v0.0.0-20220924053634-0b67a9ee53bf
 	github.com/saucelabs/pacman v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/dop251/goja_nodejs v0.0.0-20210225215109-d91c329300e7/go.mod h1:hn7BA
 github.com/dop251/goja_nodejs v0.0.0-20211022123610-8dd9abb0616d/go.mod h1:DngW8aVqWbuLRMHItjPUyqdj+HWPvnQe8V8y1nDpIbM=
 github.com/elazarl/goproxy v0.0.0-20220529153421-8ea89ba92021 h1:EbF0UihnxWRcIMOwoVtqnAylsqcjzqpSvMdjF2Ud4rA=
 github.com/elazarl/goproxy v0.0.0-20220529153421-8ea89ba92021/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
+github.com/elazarl/goproxy v0.0.0-20220901064549-fbd10ff4f5a1 h1:ecIiM5NYeEOhy5trm8xel6wpUhYH+QWteUKnwcbCMl4=
+github.com/elazarl/goproxy v0.0.0-20220901064549-fbd10ff4f5a1/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
 github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/elazarl/goproxy/ext v0.0.0-20220529153421-8ea89ba92021 h1:XO62HGrPPZne8dYsNMZJGCCBOHkhcGUWNxyQdggKE3o=
 github.com/elazarl/goproxy/ext v0.0.0-20220529153421-8ea89ba92021/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=

--- a/proxy.go
+++ b/proxy.go
@@ -68,6 +68,8 @@ func NewProxy(cfg *ProxyConfig, log Logger) (*Proxy, error) {
 		proxy:    goproxy.NewProxyHttpServer(),
 		log:      log,
 	}
+	p.setupDNS()
+
 	if p.config.PACURI != nil {
 		pacParser, err := pacman.New(p.config.PACURI.String(), p.config.PACProxiesCredentials...)
 		if err != nil {
@@ -75,7 +77,7 @@ func NewProxy(cfg *ProxyConfig, log Logger) (*Proxy, error) {
 		}
 		p.pacParser = pacParser
 	}
-	p.setupDNS()
+
 	p.setupProxy()
 
 	return p, nil

--- a/proxy.go
+++ b/proxy.go
@@ -100,7 +100,6 @@ func (p *Proxy) setupProxy() {
 	// See: https://github.com/golang/go/issues/28866
 	// See: https://github.com/elazarl/goproxy/issues/306
 	p.proxy.KeepHeader = true
-	p.proxy.Tr = &http.Transport{}
 
 	p.setupBasicAuth()
 	p.setupLocalhostProxy()

--- a/proxy.go
+++ b/proxy.go
@@ -65,7 +65,6 @@ func NewProxy(cfg *ProxyConfig, log Logger) (*Proxy, error) {
 	p := &Proxy{
 		config:   *cfg,
 		userInfo: m,
-		proxy:    goproxy.NewProxyHttpServer(),
 		log:      log,
 	}
 	p.setupDNS()
@@ -91,6 +90,7 @@ func (p *Proxy) setupDNS() {
 }
 
 func (p *Proxy) setupProxy() {
+	p.proxy = goproxy.NewProxyHttpServer()
 	p.proxy.Logger = goproxyLogger{p.log}
 	p.proxy.Verbose = true
 	p.proxy.KeepDestinationHeaders = true

--- a/util.go
+++ b/util.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"encoding/gob"
 	"fmt"
-	"regexp"
 	"strings"
 )
 
@@ -35,15 +34,4 @@ func normalizeURLScheme(uri string) string {
 		scheme = "https"
 	}
 	return fmt.Sprintf("%s://%s", scheme, uri)
-}
-
-var localHostIpv4Regexp = regexp.MustCompile(`127\.0\.0\.\d+`)
-
-// isLocalhost checks whether the destination host is explicitly local host.
-// Note: there can be IPv6 addresses it doesn't catch.
-func isLocalhost(hostName string) bool {
-	return hostName == "localhost" ||
-		hostName == "0:0:0:0:0:0:0:1" ||
-		hostName == "::1" ||
-		localHostIpv4Regexp.MatchString(hostName)
 }

--- a/util.go
+++ b/util.go
@@ -8,6 +8,8 @@ import (
 	"bytes"
 	"encoding/gob"
 	"fmt"
+	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -34,4 +36,18 @@ func normalizeURLScheme(uri string) string {
 		scheme = "https"
 	}
 	return fmt.Sprintf("%s://%s", scheme, uri)
+}
+
+func addProxyBasicAuthHeader(req *http.Request, u *url.Userinfo) {
+	if u == nil || u.Username() == "" {
+		return
+	}
+	req.Header.Set("Proxy-Authorization", "Basic "+userInfoBase64(u))
+}
+
+func addBasicAuthHeader(req *http.Request, u *url.Userinfo) {
+	if u == nil || u.Username() == "" {
+		return
+	}
+	req.Header.Set("Authorization", "Basic "+userInfoBase64(u))
 }

--- a/util_test.go
+++ b/util_test.go
@@ -5,7 +5,6 @@
 package forwarder
 
 import (
-	"net/http"
 	"net/url"
 	"testing"
 )
@@ -57,53 +56,6 @@ func TestNormalizeURLScheme(t *testing.T) {
 			}
 			if u.String() != tc.expected {
 				t.Errorf("expected %s, got %s", tc.expected, u)
-			}
-		})
-	}
-}
-
-func TestIsLocalhost(t *testing.T) {
-	tests := []struct {
-		name     string
-		url      string
-		expected bool
-	}{
-		{
-			name:     "Is localhost",
-			url:      "http://localhost:8080",
-			expected: true,
-		},
-		{
-			name:     "Is localhost IPv6",
-			url:      "http://[::1]:8080",
-			expected: true,
-		},
-		{
-			name:     "Is localhost IPv6 no port",
-			url:      "http://[::1]",
-			expected: true,
-		},
-		{
-			name:     "Is localhost IPv4",
-			url:      "http://127.0.0.2:8080",
-			expected: true,
-		},
-		{
-			name:     "Not localhost",
-			url:      "example.com:8888",
-			expected: false,
-		},
-	}
-
-	for i := range tests {
-		tc := tests[i]
-		t.Run(tc.name, func(t *testing.T) {
-			r, err := http.NewRequest(http.MethodGet, tc.url, http.NoBody)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if isLocalhost(r.URL.Hostname()) != tc.expected {
-				t.Errorf("expected %v, got %v", tc.expected, isLocalhost(r.URL.Hostname()))
 			}
 		})
 	}


### PR DESCRIPTION
This patchset reimplements goproxy setup so that the proxy is not reconfigured in runtime.
In addition to that it fixes missing / wrong configurations. See commit messages for details.
 
Fixes #29
Fixes #31
Fixes #74 
Fixes #76