### PR TITLE
pac-server and pac-eval subcommands

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,6 +50,7 @@ linters-settings:
 issues:
   exclude:
     - "can be `fmt.Stringer`"
+    - "Error return value of `cmd.MarkFlag.+` is not checked"
     - "string `https?` has \\d+ occurrences"
     - "Magic number: 0o"
     - "`nop.+` is unused"

--- a/bind/flag.go
+++ b/bind/flag.go
@@ -13,21 +13,21 @@ import (
 )
 
 func DNSConfig(fs *pflag.FlagSet, cfg *forwarder.DNSConfig) {
-	fs.VarP(anyflag.NewSliceValue[*url.URL](nil, &cfg.Servers, forwarder.ParseDNSURI),
-		"dns-server", "n", "DNS server, ex. -n udp://1.1.1.1:53 (can be specified multiple times)")
+	fs.VarP(anyflag.NewSliceValue[*url.URL](nil, &cfg.Servers, forwarder.ParseDNSAddress),
+		"dns-server", "n", "DNS server IP or URL ex. 1.1.1.1 or udp://1.1.1.1:53 (can be specified multiple times)")
 	fs.DurationVar(&cfg.Timeout,
 		"dns-timeout", cfg.Timeout, "timeout for DNS queries if DNS server is specified")
 }
 
 func HTTPProxyConfig(fs *pflag.FlagSet, cfg *forwarder.HTTPProxyConfig) {
-	fs.VarP(anyflag.NewValue[*url.URL](cfg.UpstreamProxyURI, &cfg.UpstreamProxyURI, forwarder.ParseProxyURI),
-		"upstream-proxy-uri", "u", "upstream proxy URI")
+	fs.VarP(anyflag.NewValue[*url.URL](cfg.UpstreamProxy, &cfg.UpstreamProxy, forwarder.ParseProxyURL),
+		"upstream-proxy", "u", "upstream proxy URL")
 	fs.VarP(anyflag.NewValue[*url.Userinfo](cfg.UpstreamProxyCredentials, &cfg.UpstreamProxyCredentials, forwarder.ParseUserInfo),
-		"upstream-proxy-credentials", "", "upstream proxy credentials in the form of `username:password`, if not specified, the credentials from the upstream proxy URI are used")
-	fs.VarP(anyflag.NewValue[*url.URL](cfg.PACURI, &cfg.PACURI, url.ParseRequestURI),
-		"pac-uri", "p", "URI to PAC content, or directly, the PAC content")
+		"upstream-proxy-credentials", "", "upstream proxy credentials in the form of `username:password`, it overrides credentials embedded in upstream-proxy URL")
+	fs.VarP(anyflag.NewValue[*url.URL](cfg.PAC, &cfg.PAC, url.ParseRequestURI),
+		"pac", "p", "local file `path or URL` to PAC content")
 	fs.StringSliceVarP(&cfg.PACProxiesCredentials, "pac-proxies-credentials", "d", cfg.PACProxiesCredentials,
-		"PAC proxies credentials using standard URI format")
+		"PAC proxies credentials in URL format ex. http://user:pass@host:port (can be specified multiple times)")
 	fs.StringSliceVar(&cfg.SiteCredentials, "site-credentials", cfg.SiteCredentials,
 		"target site credentials")
 	fs.BoolVarP(&cfg.ProxyLocalhost, "proxy-localhost", "t", cfg.ProxyLocalhost,

--- a/bind/flag.go
+++ b/bind/flag.go
@@ -32,8 +32,6 @@ func HTTPProxyConfig(fs *pflag.FlagSet, cfg *forwarder.HTTPProxyConfig) {
 		"target site credentials")
 	fs.BoolVarP(&cfg.ProxyLocalhost, "proxy-localhost", "t", cfg.ProxyLocalhost,
 		"if set, will proxy localhost requests to an upstream proxy")
-
-	HTTPTransportConfig(fs, cfg.Transport)
 }
 
 func HTTPTransportConfig(fs *pflag.FlagSet, cfg *forwarder.HTTPTransportConfig) {

--- a/bind/flag.go
+++ b/bind/flag.go
@@ -19,6 +19,11 @@ func DNSConfig(fs *pflag.FlagSet, cfg *forwarder.DNSConfig) {
 		"dns-timeout", cfg.Timeout, "timeout for DNS queries if DNS server is specified")
 }
 
+func PAC(fs *pflag.FlagSet, pac **url.URL) {
+	fs.VarP(anyflag.NewValue[*url.URL](*pac, pac, fileurl.ParseFilePathOrURL),
+		"pac", "p", "local file `path or URL` to PAC content, use \"-\" to read from stdin")
+}
+
 func HTTPProxyConfig(fs *pflag.FlagSet, cfg *forwarder.HTTPProxyConfig) {
 	fs.VarP(anyflag.NewValue[*url.URL](cfg.UpstreamProxy, &cfg.UpstreamProxy, forwarder.ParseProxyURL),
 		"upstream-proxy", "u", "upstream proxy URL")

--- a/bind/flag.go
+++ b/bind/flag.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/mmatczuk/anyflag"
 	"github.com/saucelabs/forwarder"
+	"github.com/saucelabs/forwarder/fileurl"
 	"github.com/saucelabs/forwarder/log"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -86,4 +88,20 @@ func LogConfig(fs *pflag.FlagSet, cfg *log.Config) {
 		forwarder.OpenFileParser(os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600, 0o700)),
 		"log-file", "", "log file path (default: stdout)")
 	fs.BoolVar(&cfg.Verbose, "verbose", cfg.Verbose, "enable verbose logging")
+}
+
+func MarkFlagRequired(cmd *cobra.Command, names ...string) {
+	for _, name := range names {
+		if err := cmd.MarkFlagRequired(name); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func MarkFlagFilename(cmd *cobra.Command, names ...string) {
+	for _, name := range names {
+		if err := cmd.MarkFlagFilename(name); err != nil {
+			panic(err)
+		}
+	}
 }

--- a/bind/flag.go
+++ b/bind/flag.go
@@ -36,7 +36,7 @@ func HTTPProxyConfig(fs *pflag.FlagSet, cfg *forwarder.HTTPProxyConfig) {
 	fs.StringSliceVar(&cfg.SiteCredentials, "site-credentials", cfg.SiteCredentials,
 		"target site credentials")
 	fs.BoolVarP(&cfg.ProxyLocalhost, "proxy-localhost", "t", cfg.ProxyLocalhost,
-		"if set, will proxy localhost requests to an upstream proxy")
+		"proxy localhost requests to an upstream proxy")
 }
 
 func HTTPTransportConfig(fs *pflag.FlagSet, cfg *forwarder.HTTPTransportConfig) {
@@ -58,6 +58,8 @@ func HTTPTransportConfig(fs *pflag.FlagSet, cfg *forwarder.HTTPTransportConfig) 
 		"http-response-header-timeout", cfg.ResponseHeaderTimeout, "response header timeout for HTTP connections")
 	fs.DurationVar(&cfg.ExpectContinueTimeout,
 		"http-expect-continue-timeout", cfg.ExpectContinueTimeout, "expect continue timeout for HTTP connections")
+
+	TLSConfig(fs, &cfg.TLSConfig)
 }
 
 func HTTPServerConfig(fs *pflag.FlagSet, cfg *forwarder.HTTPServerConfig, prefix string) {
@@ -84,6 +86,10 @@ func HTTPServerConfig(fs *pflag.FlagSet, cfg *forwarder.HTTPServerConfig, prefix
 		namePrefix+"read-timeout", cfg.ReadTimeout, usagePrefix+"HTTP server read timeout")
 	fs.VarP(anyflag.NewValue[*url.Userinfo](cfg.BasicAuth, &cfg.BasicAuth, forwarder.ParseUserInfo),
 		namePrefix+"basic-auth", "", usagePrefix+"basic-auth in the form of `username:password`")
+}
+
+func TLSConfig(fs *pflag.FlagSet, cfg *forwarder.TLSConfig) {
+	fs.BoolVar(&cfg.InsecureSkipVerify, "insecure-skip-verify", cfg.InsecureSkipVerify, "skip TLS verification")
 }
 
 func LogConfig(fs *pflag.FlagSet, cfg *log.Config) {

--- a/cmd/forwarder/paceval/paceval.go
+++ b/cmd/forwarder/paceval/paceval.go
@@ -1,0 +1,116 @@
+package paceval
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/saucelabs/forwarder"
+	"github.com/saucelabs/forwarder/bind"
+	"github.com/saucelabs/forwarder/pac"
+	"github.com/spf13/cobra"
+)
+
+type command struct {
+	pac                 *url.URL
+	dnsConfig           *forwarder.DNSConfig
+	httpTransportConfig *forwarder.HTTPTransportConfig
+}
+
+func (c *command) RunE(cmd *cobra.Command, args []string) error {
+	var resolver *net.Resolver
+	if len(c.dnsConfig.Servers) > 0 {
+		r, err := forwarder.NewResolver(c.dnsConfig, forwarder.NopLogger)
+		if err != nil {
+			return err
+		}
+		resolver = r
+	}
+	t := forwarder.NewHTTPTransport(c.httpTransportConfig, resolver)
+
+	script, err := forwarder.ReadURL(c.pac, t)
+	if err != nil {
+		return fmt.Errorf("read PAC file: %w", err)
+	}
+	cfg := pac.ProxyResolverConfig{
+		Script:    script,
+		AlertSink: os.Stderr,
+	}
+	pr, err := pac.NewProxyResolver(&cfg, resolver)
+	if err != nil {
+		return err
+	}
+
+	w := cmd.OutOrStdout()
+	for _, arg := range args {
+		u, err := url.Parse(arg)
+		if err != nil {
+			return fmt.Errorf("parse URL: %w", err)
+		}
+		proxy, err := pr.FindProxyForURL(u)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(w, proxy)
+	}
+
+	return nil
+}
+
+func Command() (cmd *cobra.Command) {
+	c := command{
+		pac:                 &url.URL{Scheme: "file", Path: "pac.js"},
+		dnsConfig:           forwarder.DefaultDNSConfig(),
+		httpTransportConfig: forwarder.DefaultHTTPTransportConfig(),
+	}
+
+	defer func() {
+		fs := cmd.Flags()
+
+		bind.PAC(fs, &c.pac)
+		bind.DNSConfig(fs, c.dnsConfig)
+		bind.HTTPTransportConfig(fs, c.httpTransportConfig)
+
+		bind.MarkFlagFilename(cmd, "pac")
+	}()
+	return &cobra.Command{
+		Use:     "pac-eval --pac <file|url> [flags] <url>...",
+		Short:   "Evaluate a PAC file for given URLs",
+		Long:    long,
+		RunE:    c.RunE,
+		Example: example + "\n" + supportedFunctions(),
+	}
+}
+
+const long = `Evaluate a PAC file for given URLs.
+The PAC file can be specified as a file path or URL with scheme "file", "http" or "https".
+The URLs to evaluate are passed as arguments. The output is a list of proxy strings, one per URL.
+The PAC file must contain FindProxyForURL or FindProxyForURLEx and must be valid.
+All PAC util functions are supported (see below).
+Alerts are written to stderr.
+`
+
+const example = `  # Evaluate a PAC file for a URL
+  forwarder pac-eval --pac pac.js https://www.google.com
+
+  # Evaluate a PAC file for multiple URLs
+  forwarder pac-eval --pac pac.js https://www.google.com https://www.facebook.com
+
+  # Evaluate a PAC file for multiple URLs using a PAC file from stdin
+  cat pac.js | forwarder pac-eval --pac - https://www.google.com https://www.facebook.com
+
+  # Evaluate a PAC file for multiple URLs using a PAC file from a URL
+  forwarder pac-eval --pac https://example.com/pac.js https://www.google.com https://www.facebook.com
+`
+
+func supportedFunctions() string {
+	var sb strings.Builder
+	sb.WriteString("Supported PAC util functions:")
+	for _, fn := range pac.SupportedFunctions() {
+		sb.WriteString("\n  ")
+		sb.WriteString(fn)
+	}
+	return sb.String()
+}

--- a/cmd/forwarder/pacserver/pacserver.go
+++ b/cmd/forwarder/pacserver/pacserver.go
@@ -1,0 +1,119 @@
+package pacserver
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/saucelabs/forwarder"
+	"github.com/saucelabs/forwarder/bind"
+	"github.com/saucelabs/forwarder/log"
+	"github.com/saucelabs/forwarder/log/stdlog"
+	"github.com/saucelabs/forwarder/pac"
+	"github.com/spf13/cobra"
+)
+
+type command struct {
+	pac                 *url.URL
+	httpTransportConfig *forwarder.HTTPTransportConfig
+	httpServerConfig    *forwarder.HTTPServerConfig
+	logConfig           *log.Config
+}
+
+func (c *command) RunE(cmd *cobra.Command, args []string) error {
+	t := forwarder.NewHTTPTransport(c.httpTransportConfig, nil)
+
+	script, err := forwarder.ReadURL(c.pac, t)
+	if err != nil {
+		return fmt.Errorf("read PAC file: %w", err)
+	}
+	if _, err := pac.NewProxyResolver(&pac.ProxyResolverConfig{Script: script}, nil); err != nil {
+		return err
+	}
+
+	if f := c.logConfig.File; f != nil {
+		defer f.Close()
+	}
+	logger := stdlog.New(c.logConfig)
+
+	s, err := forwarder.NewHTTPServer(c.httpServerConfig, servePAC(script), logger.Named("server"))
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	ctx, _ = signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	return s.Run(ctx)
+}
+
+func servePAC(script string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ns-proxy-autoconfig")
+		w.Write([]byte(script)) //nolint:errcheck // ignore it
+	})
+}
+
+func Command() (cmd *cobra.Command) {
+	c := command{
+		pac:                 &url.URL{Scheme: "file", Path: "pac.js"},
+		httpTransportConfig: forwarder.DefaultHTTPTransportConfig(),
+		httpServerConfig:    forwarder.DefaultHTTPServerConfig(),
+		logConfig:           log.DefaultConfig(),
+	}
+
+	defer func() {
+		fs := cmd.Flags()
+
+		bind.PAC(fs, &c.pac)
+		bind.HTTPTransportConfig(fs, c.httpTransportConfig)
+		bind.HTTPServerConfig(fs, c.httpServerConfig, "")
+		bind.LogConfig(fs, c.logConfig)
+
+		bind.MarkFlagFilename(cmd, "pac", "cert-file", "key-file", "log-file")
+	}()
+	return &cobra.Command{
+		Use:     "pac-server --pac <file|url> [--protocol <http|https|h2>] [--address <host:port>] [flags]",
+		Short:   "Start HTTP(S) server that serves a PAC file",
+		Long:    long,
+		RunE:    c.RunE,
+		Example: example + "\n" + supportedFunctions(),
+	}
+}
+
+const long = `Start HTTP(S) server that serves a PAC file.
+The PAC file can be specified as a file path or URL with scheme "file", "http" or "https".
+The PAC file must contain FindProxyForURL or FindProxyForURLEx and must be valid.
+All PAC util functions are supported (see below).
+Alerts are ignored.
+
+You can start HTTP, HTTPS or H2 (HTTPS) server.
+The server may be protected by basic authentication.
+If you start an HTTPS server and you don't provide a certificate, the server will generate a self-signed certificate on startup.
+`
+
+const example = `  # Start a HTTP server serving a PAC file
+  pac-server --pac pac.js --protocol http --address localhost:8080
+
+  # Start a HTTPS server serving a PAC file
+  pac-server --pac pac.js --protocol https --address localhost:80443
+
+  # Start a HTTPS server serving a PAC file with custom certificate
+  pac-server --pac pac.js --protocol https --address localhost:80443 --cert-file cert.pem --key-file key.pem
+
+  # Start a HTTPS server serving a PAC file with basic authentication
+  pac-server --pac pac.js --protocol https --address localhost:80443 --basic-auth user:pass
+`
+
+func supportedFunctions() string {
+	var sb strings.Builder
+	sb.WriteString("Supported PAC util functions:")
+	for _, fn := range pac.SupportedFunctions() {
+		sb.WriteString("\n  ")
+		sb.WriteString(fn)
+	}
+	return sb.String()
+}

--- a/cmd/forwarder/proxy/proxy.go
+++ b/cmd/forwarder/proxy/proxy.go
@@ -23,6 +23,7 @@ import (
 type command struct {
 	promReg               *prometheus.Registry
 	dnsConfig             *forwarder.DNSConfig
+	httpTransportConfig   *forwarder.HTTPTransportConfig
 	httpProxyConfig       *forwarder.HTTPProxyConfig
 	httpProxyServerConfig *forwarder.HTTPServerConfig
 	apiServerConfig       *forwarder.HTTPServerConfig
@@ -43,8 +44,9 @@ func (c *command) RunE(cmd *cobra.Command, args []string) error {
 		}
 		resolver = r
 	}
+	t := forwarder.NewHTTPTransport(c.httpTransportConfig, resolver)
 
-	p, err := forwarder.NewHTTPProxy(c.httpProxyConfig, resolver, logger.Named("proxy"))
+	p, err := forwarder.NewHTTPProxy(c.httpProxyConfig, t, logger.Named("proxy"))
 	if err != nil {
 		return err
 	}
@@ -99,6 +101,7 @@ func Command() (cmd *cobra.Command) {
 	c := command{
 		promReg:               prometheus.NewRegistry(),
 		dnsConfig:             forwarder.DefaultDNSConfig(),
+		httpTransportConfig:   forwarder.DefaultHTTPTransportConfig(),
 		httpProxyConfig:       forwarder.DefaultHTTPProxyConfig(),
 		httpProxyServerConfig: forwarder.DefaultHTTPServerConfig(),
 		apiServerConfig:       forwarder.DefaultHTTPServerConfig(),
@@ -111,6 +114,7 @@ func Command() (cmd *cobra.Command) {
 	defer func() {
 		fs := cmd.Flags()
 		bind.DNSConfig(fs, c.dnsConfig)
+		bind.HTTPTransportConfig(fs, c.httpTransportConfig)
 		bind.HTTPProxyConfig(fs, c.httpProxyConfig)
 		bind.HTTPServerConfig(fs, c.httpProxyServerConfig, "")
 		bind.HTTPServerConfig(fs, c.apiServerConfig, "api")

--- a/cmd/forwarder/proxy/proxy.go
+++ b/cmd/forwarder/proxy/proxy.go
@@ -80,16 +80,16 @@ const example = `Start HTTP proxy listening to localhost:8080:
   $ forwarder proxy --address localhost:8080 --basic-auth user:pass
 
   Forward connections to an upstream proxy:
-  $ forwarder proxy --address localhost:8080 --upstream-proxy-uri http://localhost:8089
+  $ forwarder proxy --address localhost:8080 --upstream-proxy http://localhost:8089
 
   Forward connections to an upstream proxy protected with basic auth:
-  $ forwarder proxy --address localhost:8080 --upstream-proxy-uri http://localhost:8089 --upstream-proxy-basic-auth user:pass
+  $ forwarder proxy --address localhost:8080 --upstream-proxy http://localhost:8089 --upstream-proxy-basic-auth user:pass
 
   Forward connections to an upstream proxy setup via PAC: 
-  $ forwarder proxy --address localhost:8080 --pac-uri http://localhost:8090/pac
+  $ forwarder proxy --address localhost:8080 --pac http://localhost:8090/pac
 
   Forward connections to an upstream proxy, setup via PAC protected with basic auth:
-  $ forwarder proxy --address localhost:8080 --pac-uri http://user:pass@localhost:8090/pac -d http://user3:pwd4@localhost:8091 -d http://user2:pwd2@localhost:8092 
+  $ forwarder proxy --address localhost:8080 --pac http://user:pass@localhost:8090/pac -d http://user3:pwd4@localhost:8091 -d http://user2:pwd2@localhost:8092 
 
   Add basic auth header to requests to foo.bar:* and qux.baz:80.
   $ forwarder proxy --address localhost:8080 --site-credentials "foo.bar:0,qux.baz:80"
@@ -116,7 +116,7 @@ func Command() (cmd *cobra.Command) {
 		bind.HTTPServerConfig(fs, c.apiServerConfig, "api")
 		bind.LogConfig(fs, c.logConfig)
 
-		cmd.MarkFlagsMutuallyExclusive("upstream-proxy-uri", "pac-uri")
+		cmd.MarkFlagsMutuallyExclusive("upstream-proxy", "pac")
 	}()
 	return &cobra.Command{
 		Use:     "proxy",

--- a/cmd/forwarder/root.go
+++ b/cmd/forwarder/root.go
@@ -12,7 +12,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const envPrefix = "FORWARDER"
+const (
+	envPrefix = "FORWARDER"
+	maxCols   = 80
+)
 
 func rootCommand() *cobra.Command {
 	rootCmd := &cobra.Command{
@@ -31,6 +34,7 @@ func rootCommand() *cobra.Command {
 	)
 	for _, cmd := range rootCmd.Commands() {
 		appendEnvToUsage(cmd, envPrefix)
+		wrapLongAt(cmd, maxCols)
 	}
 
 	return rootCmd

--- a/cmd/forwarder/root.go
+++ b/cmd/forwarder/root.go
@@ -5,6 +5,8 @@
 package main
 
 import (
+	"github.com/saucelabs/forwarder/cmd/forwarder/paceval"
+	"github.com/saucelabs/forwarder/cmd/forwarder/pacserver"
 	"github.com/saucelabs/forwarder/cmd/forwarder/proxy"
 	"github.com/saucelabs/forwarder/cmd/forwarder/version"
 	"github.com/spf13/cobra"
@@ -14,7 +16,7 @@ const envPrefix = "FORWARDER"
 
 func rootCommand() *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use:   "proxy",
+		Use:   "forwarder",
 		Short: "A simple flexible forward proxy",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return bindFlagsToEnv(cmd, envPrefix)
@@ -22,6 +24,8 @@ func rootCommand() *cobra.Command {
 	}
 
 	rootCmd.AddCommand(
+		paceval.Command(),
+		pacserver.Command(),
 		proxy.Command(),
 		version.Command(),
 	)

--- a/cmd/forwarder/wrap.go
+++ b/cmd/forwarder/wrap.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func wrapLongAt(cmd *cobra.Command, width int) {
+	cmd.Long = wrapTextAt(cmd.Long, width)
+}
+
+func wrapTextAt(s string, width int) string {
+	s = regexp.MustCompile(`\n{2,}`).ReplaceAllString(s, "\n<separator>\n")
+
+	var (
+		sb strings.Builder
+		lw = 0
+	)
+	for _, w := range regexp.MustCompile(`\s+`).Split(s, -1) {
+		if w == "<separator>" {
+			sb.WriteString("\n\n")
+			lw = 0
+			continue
+		}
+
+		if lw+len(w) > width {
+			sb.Write([]byte{'\n'})
+			lw = 0
+		}
+		sb.WriteString(w)
+		sb.Write([]byte{' '})
+		lw += len(w) + 1
+	}
+
+	return "\n" + sb.String()
+}

--- a/config.go
+++ b/config.go
@@ -43,19 +43,19 @@ func validatedUserInfo(ui *url.Userinfo) error {
 	return nil
 }
 
-// ParseProxyURI parser a Proxy URI as URL
+// ParseProxyURL parser a Proxy URL
 //
 // Requirements:
 // - Protocol: http, https, socks5, socks, quic.
 // - Hostname min 4 chars.
 // - Port in a valid range: 1 - 65535.
 // - (Optional) username and password.
-func ParseProxyURI(val string) (*url.URL, error) {
+func ParseProxyURL(val string) (*url.URL, error) {
 	u, err := url.Parse(val)
 	if err != nil {
 		return nil, err
 	}
-	if err := validateProxyURI(u); err != nil {
+	if err := validateProxyURL(u); err != nil {
 		return nil, err
 	}
 
@@ -64,7 +64,7 @@ func ParseProxyURI(val string) (*url.URL, error) {
 
 const minHostLength = 4
 
-func validateProxyURI(u *url.URL) error {
+func validateProxyURL(u *url.URL) error {
 	if u == nil {
 		return nil
 	}
@@ -87,7 +87,7 @@ func validateProxyURI(u *url.URL) error {
 	return nil
 }
 
-// ParseDNSURI parses a DNS URI as URL.
+// ParseDNSAddress parses a DNS URL or IP address.
 // It supports IP only or full URL.
 // Hostname is not allowed.
 // Examples: `udp://1.1.1.1:53`, `1.1.1.1`.
@@ -98,7 +98,7 @@ func validateProxyURI(u *url.URL) error {
 // - (Optional) port in a valid range: 1 - 65535 (default 53).
 // - No username and password.
 // - No path, query, and fragment.
-func ParseDNSURI(val string) (*url.URL, error) {
+func ParseDNSAddress(val string) (*url.URL, error) {
 	u, err := url.Parse(val)
 	if err != nil {
 		return nil, err
@@ -112,14 +112,14 @@ func ParseDNSURI(val string) (*url.URL, error) {
 	if u.Port() == "" {
 		u.Host += ":53"
 	}
-	if err := validateDNSURI(u); err != nil {
+	if err := validateDNSURL(u); err != nil {
 		return nil, err
 	}
 
 	return u, nil
 }
 
-func validateDNSURI(u *url.URL) error {
+func validateDNSURL(u *url.URL) error {
 	if u.Scheme != "udp" && u.Scheme != "tcp" {
 		return fmt.Errorf("invalid protocol: %s, supported protocols are udp and tcp", u.Scheme)
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -58,7 +58,7 @@ func TestParseUserInfo(t *testing.T) {
 	}
 }
 
-func TestParseProxyURI(t *testing.T) {
+func TestParseProxyURL(t *testing.T) {
 	tests := []struct {
 		name  string
 		input string
@@ -93,7 +93,7 @@ func TestParseProxyURI(t *testing.T) {
 	for i := range tests {
 		tc := &tests[i]
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := ParseProxyURI(tc.input)
+			_, err := ParseProxyURL(tc.input)
 			if err != nil {
 				if tc.err == "" {
 					t.Fatalf("expected success, got %q", err)
@@ -107,8 +107,8 @@ func TestParseProxyURI(t *testing.T) {
 	}
 }
 
-func TestParseDNSURIDefaults(t *testing.T) {
-	u, err := ParseDNSURI("1.1.1.1")
+func TestParseDNSAddressDefaults(t *testing.T) {
+	u, err := ParseDNSAddress("1.1.1.1")
 	if err != nil {
 		t.Fatalf("expected success, got %q", err)
 	}
@@ -117,7 +117,7 @@ func TestParseDNSURIDefaults(t *testing.T) {
 	}
 }
 
-func TestParseDNSURI(t *testing.T) {
+func TestParseDNSAddress(t *testing.T) {
 	tests := []struct {
 		name  string
 		input string
@@ -169,7 +169,7 @@ func TestParseDNSURI(t *testing.T) {
 	for i := range tests {
 		tc := &tests[i]
 		t.Run(tc.name, func(t *testing.T) {
-			u, err := ParseDNSURI(tc.input)
+			u, err := ParseDNSAddress(tc.input)
 			if err != nil {
 				if tc.err == "" {
 					t.Fatalf("expected success, got %q", err)

--- a/dns.go
+++ b/dns.go
@@ -30,7 +30,7 @@ func (c *DNSConfig) Validate() error {
 		return fmt.Errorf("no DNS server configured")
 	}
 	for i, u := range c.Servers {
-		if err := validateDNSURI(u); err != nil {
+		if err := validateDNSURL(u); err != nil {
 			return fmt.Errorf("servers[%d]: %w", i, err)
 		}
 	}

--- a/fileurl/fileurl.go
+++ b/fileurl/fileurl.go
@@ -14,8 +14,14 @@ var (
 // ParseFilePathOrURL extends url.Parse with the ability to parse file paths
 // and adds extended support for URL file scheme as described in RFC 8089.
 // If there is no scheme, it will be set to "file".
+// If value equals "-", it will be set to "file://-" meaning stdin.
 // See: https://datatracker.ietf.org/doc/html/rfc8089
 func ParseFilePathOrURL(val string) (*url.URL, error) {
+	// Handle stdin.
+	if val == "-" {
+		return &url.URL{Scheme: "file", Path: "-"}, nil
+	}
+
 	val = strings.ReplaceAll(val, "\\", "/")
 
 	// Handle UNC paths.

--- a/fileurl/fileurl_test.go
+++ b/fileurl/fileurl_test.go
@@ -16,6 +16,10 @@ func TestParseFilePathOrURL(t *testing.T) {
 		want  url.URL
 	}{
 		{
+			input: "-",
+			want:  url.URL{Scheme: "file", Path: "-"},
+		},
+		{
 			input: "path/to/file",
 			want:  url.URL{Scheme: "file", Path: "path/to/file"},
 		},

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -10,86 +10,11 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"runtime"
-	"time"
 
 	"github.com/elazarl/goproxy"
 	"github.com/saucelabs/forwarder/middleware"
 	"github.com/saucelabs/pacman"
 )
-
-type HTTPTransportConfig struct {
-	// DialTimeout is the maximum amount of time a dial will wait for
-	// a connect to complete.
-	//
-	// With or without a timeout, the operating system may impose
-	// its own earlier timeout. For instance, TCP timeouts are
-	// often around 3 minutes.
-	DialTimeout time.Duration `json:"dial_timeout"`
-
-	// KeepAlive specifies the interval between keep-alive
-	// probes for an active network connection.
-	// If zero, keep-alive probes are sent with a default value
-	// (currently 15 seconds), if supported by the protocol and operating
-	// system. Network protocols or operating systems that do
-	// not support keep-alives ignore this field.
-	// If negative, keep-alive probes are disabled.
-	KeepAlive time.Duration `json:"keep_alive"`
-
-	// TLSHandshakeTimeout specifies the maximum amount of time waiting to
-	// wait for a TLS handshake. Zero means no timeout.
-	TLSHandshakeTimeout time.Duration `json:"tls_handshake_timeout"`
-
-	// MaxIdleConns controls the maximum number of idle (keep-alive)
-	// connections across all hosts. Zero means no limit.
-	MaxIdleConns int `json:"max_idle_conns"`
-
-	// MaxIdleConnsPerHost, if non-zero, controls the maximum idle
-	// (keep-alive) connections to keep per-host. If zero,
-	// DefaultMaxIdleConnsPerHost is used.
-	MaxIdleConnsPerHost int `json:"max_idle_conns_per_host"`
-
-	// MaxConnsPerHost optionally limits the total number of
-	// connections per host, including connections in the dialing,
-	// active, and idle states. On limit violation, dials will block.
-	//
-	// Zero means no limit.
-	MaxConnsPerHost int `json:"max_conns_per_host"`
-
-	// IdleConnTimeout is the maximum amount of time an idle
-	// (keep-alive) connection will remain idle before closing
-	// itself.
-	// Zero means no limit.
-	IdleConnTimeout time.Duration `json:"idle_conn_timeout"`
-
-	// ResponseHeaderTimeout, if non-zero, specifies the amount of
-	// time to wait for a server's response headers after fully
-	// writing the request (including its body, if any). This
-	// time does not include the time to read the response body.
-	ResponseHeaderTimeout time.Duration `json:"response_header_timeout"`
-
-	// ExpectContinueTimeout, if non-zero, specifies the amount of
-	// time to wait for a server's first response headers after fully
-	// writing the request headers if the request has an
-	// "Expect: 100-continue" header. Zero means no timeout and
-	// causes the body to be sent immediately, without
-	// waiting for the server to approve.
-	// This time does not include the time to send the request header.
-	ExpectContinueTimeout time.Duration `json:"expect_continue_timeout"`
-}
-
-func DefaultHTTPTransportConfig() *HTTPTransportConfig {
-	// The default values are taken from [hashicorp/go-cleanhttp](https://github.com/hashicorp/go-cleanhttp/blob/a0807dd79fc1680a7b1f2d5a2081d92567aab97d/cleanhttp.go#L19.
-	return &HTTPTransportConfig{
-		DialTimeout:           30 * time.Second,
-		KeepAlive:             30 * time.Second,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-		MaxIdleConnsPerHost:   runtime.GOMAXPROCS(0) + 1,
-	}
-}
 
 type HTTPProxyConfig struct {
 	// UpstreamProxy is the upstream proxy , ex. http://user:password@127.0.0.1:8080.
@@ -120,16 +45,10 @@ type HTTPProxyConfig struct {
 	// - usr3:pwd3@bar.foo:8080
 	// HTTPProxy will add basic auth headers for requests to these URLs.
 	SiteCredentials []string `json:"site_credentials"`
-
-	// Transport specifies http.Transport configuration used when making Transport requests.
-	// If nil, DefaultHTTPTransportConfig will be used.
-	Transport *HTTPTransportConfig `json:"http"`
 }
 
 func DefaultHTTPProxyConfig() *HTTPProxyConfig {
-	return &HTTPProxyConfig{
-		Transport: DefaultHTTPTransportConfig(),
-	}
+	return &HTTPProxyConfig{}
 }
 
 func (c *HTTPProxyConfig) Validate() error {
@@ -161,13 +80,15 @@ type HTTPProxy struct {
 	log       Logger
 }
 
-func NewHTTPProxy(cfg *HTTPProxyConfig, r *net.Resolver, log Logger) (*HTTPProxy, error) {
-	if cfg.Transport == nil {
-		cfg.Transport = DefaultHTTPTransportConfig()
-	}
-
+func NewHTTPProxy(cfg *HTTPProxyConfig, t *http.Transport, log Logger) (*HTTPProxy, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, err
+	}
+
+	// If not set, use http.DefaultTransport.
+	if t == nil {
+		log.Infof("HTTP transport not configured, using standard library default")
+		t = http.DefaultTransport.(*http.Transport).Clone() //nolint:forcetypeassert // we know it's a *http.Transport
 	}
 
 	// Parse site credential list into map of host:port -> base64 encoded input.
@@ -178,11 +99,11 @@ func NewHTTPProxy(cfg *HTTPProxyConfig, r *net.Resolver, log Logger) (*HTTPProxy
 
 	p := &HTTPProxy{
 		config:    *cfg,
+		transport: t,
 		userInfo:  m,
 		basicAuth: middleware.NewProxyBasicAuth(),
 		log:       log,
 	}
-	p.configureTransport(r)
 
 	if p.config.PAC != nil {
 		pacParser, err := pacman.New(p.config.PAC.String(), p.config.PACProxiesCredentials...)
@@ -195,28 +116,6 @@ func NewHTTPProxy(cfg *HTTPProxyConfig, r *net.Resolver, log Logger) (*HTTPProxy
 	p.configureProxy()
 
 	return p, nil
-}
-
-func (hp *HTTPProxy) configureTransport(r *net.Resolver) {
-	hp.log.Infof("Using HTTP transport config: %+v", *hp.config.Transport)
-
-	c := hp.config.Transport
-	hp.transport = &http.Transport{
-		Proxy: nil,
-		DialContext: defaultTransportDialContext(&net.Dialer{
-			Timeout:   c.DialTimeout,
-			KeepAlive: c.KeepAlive,
-			Resolver:  r,
-		}),
-		MaxIdleConns:          c.MaxIdleConns,
-		IdleConnTimeout:       c.IdleConnTimeout,
-		TLSHandshakeTimeout:   c.TLSHandshakeTimeout,
-		ExpectContinueTimeout: c.ExpectContinueTimeout,
-		ForceAttemptHTTP2:     true,
-		MaxIdleConnsPerHost:   c.MaxIdleConnsPerHost,
-	}
-
-	hp.transport.Proxy = nil
 }
 
 func defaultTransportDialContext(dialer *net.Dialer) func(context.Context, string, string) (net.Conn, error) {

--- a/http_proxy_test.go
+++ b/http_proxy_test.go
@@ -37,22 +37,22 @@ func TestHTTPProxyConfigValidate(t *testing.T) {
 		{
 			name: "both upstream and PAC are set",
 			config: HTTPProxyConfig{
-				UpstreamProxyURI: newProxyURL(80, upstreamProxyCredentialUsername, upstreamProxyCredentialPassword),
-				PACURI:           newProxyURL(80, "", ""),
+				UpstreamProxy: newProxyURL(80, upstreamProxyCredentialUsername, upstreamProxyCredentialPassword),
+				PAC:           newProxyURL(80, "", ""),
 			},
 			err: "only one of upstream_proxy_uri or pac_uri can be set",
 		},
 		{
-			name: "invalid upstream proxy URI",
+			name: "invalid upstream proxy ",
 			config: HTTPProxyConfig{
-				UpstreamProxyURI: &url.URL{},
+				UpstreamProxy: &url.URL{},
 			},
 			err: "upstream_proxy_uri: invalid scheme",
 		},
 		{
-			name: "invalid PAC server URI",
+			name: "invalid PAC server ",
 			config: HTTPProxyConfig{
-				PACURI: &url.URL{},
+				PAC: &url.URL{},
 			},
 			err: "pac_uri: invalid scheme",
 		},
@@ -97,8 +97,8 @@ func TestHTTPProxySmoke(t *testing.T) { //nolint // FIXME cognitive complexity 8
 		{
 			name: "Protected upstream proxy",
 			config: HTTPProxyConfig{
-				UpstreamProxyURI: newProxyURL(0, upstreamProxyCredentialUsername, upstreamProxyCredentialPassword),
-				ProxyLocalhost:   true,
+				UpstreamProxy:  newProxyURL(0, upstreamProxyCredentialUsername, upstreamProxyCredentialPassword),
+				ProxyLocalhost: true,
 			},
 		},
 	}
@@ -134,15 +134,15 @@ func TestHTTPProxySmoke(t *testing.T) { //nolint // FIXME cognitive complexity 8
 			}
 
 			// Upstream HTTPProxy.
-			if tc.config.UpstreamProxyURI != nil {
+			if tc.config.UpstreamProxy != nil {
 				upstreamProxy, err := NewHTTPProxy(&HTTPProxyConfig{ProxyLocalhost: true}, nil, stdlog.Default().Named("upstream"))
 				if err != nil {
 					t.Fatalf("NewHTTPProxy() error=%v", err)
 				}
 				var h http.Handler = upstreamProxy
-				if tc.config.UpstreamProxyURI.User != nil {
-					p, _ := tc.config.UpstreamProxyURI.User.Password()
-					h = middleware.NewProxyBasicAuth().Wrap(upstreamProxy, tc.config.UpstreamProxyURI.User.Username(), p)
+				if tc.config.UpstreamProxy.User != nil {
+					p, _ := tc.config.UpstreamProxy.User.Password()
+					h = middleware.NewProxyBasicAuth().Wrap(upstreamProxy, tc.config.UpstreamProxy.User.Username(), p)
 				}
 
 				usrv := httptest.NewServer(h)
@@ -151,8 +151,8 @@ func TestHTTPProxySmoke(t *testing.T) { //nolint // FIXME cognitive complexity 8
 				}
 				defer usrv.Close()
 
-				// Update the upstream proxy URI with host and port.
-				tc.config.UpstreamProxyURI.Host = usrv.Listener.Addr().String()
+				// Update the upstream proxy  with host and port.
+				tc.config.UpstreamProxy.Host = usrv.Listener.Addr().String()
 			}
 
 			// Local proxy.
@@ -287,7 +287,7 @@ func assertRequest(t *testing.T, client *http.Client, uri string, statusCode int
 
 	u, err := url.ParseRequestURI(uri)
 	if err != nil {
-		t.Fatalf("Failed to parse URI: %s", err)
+		t.Fatalf("Failed to parse : %s", err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/http_transport.go
+++ b/http_transport.go
@@ -1,6 +1,7 @@
 package forwarder
 
 import (
+	"crypto/tls"
 	"net"
 	"net/http"
 	"runtime"
@@ -65,6 +66,8 @@ type HTTPTransportConfig struct {
 	// waiting for the server to approve.
 	// This time does not include the time to send the request header.
 	ExpectContinueTimeout time.Duration `json:"expect_continue_timeout"`
+
+	TLSConfig
 }
 
 func DefaultHTTPTransportConfig() *HTTPTransportConfig {
@@ -94,5 +97,8 @@ func NewHTTPTransport(cfg *HTTPTransportConfig, r *net.Resolver) *http.Transport
 		ExpectContinueTimeout: cfg.ExpectContinueTimeout,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConnsPerHost:   cfg.MaxIdleConnsPerHost,
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: cfg.InsecureSkipVerify, //nolint:gosec // for self-signed certificates
+		},
 	}
 }

--- a/http_transport.go
+++ b/http_transport.go
@@ -1,0 +1,98 @@
+package forwarder
+
+import (
+	"net"
+	"net/http"
+	"runtime"
+	"time"
+)
+
+type HTTPTransportConfig struct {
+	// DialTimeout is the maximum amount of time a dial will wait for
+	// a connect to complete.
+	//
+	// With or without a timeout, the operating system may impose
+	// its own earlier timeout. For instance, TCP timeouts are
+	// often around 3 minutes.
+	DialTimeout time.Duration `json:"dial_timeout"`
+
+	// KeepAlive specifies the interval between keep-alive
+	// probes for an active network connection.
+	// If zero, keep-alive probes are sent with a default value
+	// (currently 15 seconds), if supported by the protocol and operating
+	// system. Network protocols or operating systems that do
+	// not support keep-alives ignore this field.
+	// If negative, keep-alive probes are disabled.
+	KeepAlive time.Duration `json:"keep_alive"`
+
+	// TLSHandshakeTimeout specifies the maximum amount of time waiting to
+	// wait for a TLS handshake. Zero means no timeout.
+	TLSHandshakeTimeout time.Duration `json:"tls_handshake_timeout"`
+
+	// MaxIdleConns controls the maximum number of idle (keep-alive)
+	// connections across all hosts. Zero means no limit.
+	MaxIdleConns int `json:"max_idle_conns"`
+
+	// MaxIdleConnsPerHost, if non-zero, controls the maximum idle
+	// (keep-alive) connections to keep per-host. If zero,
+	// DefaultMaxIdleConnsPerHost is used.
+	MaxIdleConnsPerHost int `json:"max_idle_conns_per_host"`
+
+	// MaxConnsPerHost optionally limits the total number of
+	// connections per host, including connections in the dialing,
+	// active, and idle states. On limit violation, dials will block.
+	//
+	// Zero means no limit.
+	MaxConnsPerHost int `json:"max_conns_per_host"`
+
+	// IdleConnTimeout is the maximum amount of time an idle
+	// (keep-alive) connection will remain idle before closing
+	// itself.
+	// Zero means no limit.
+	IdleConnTimeout time.Duration `json:"idle_conn_timeout"`
+
+	// ResponseHeaderTimeout, if non-zero, specifies the amount of
+	// time to wait for a server's response headers after fully
+	// writing the request (including its body, if any). This
+	// time does not include the time to read the response body.
+	ResponseHeaderTimeout time.Duration `json:"response_header_timeout"`
+
+	// ExpectContinueTimeout, if non-zero, specifies the amount of
+	// time to wait for a server's first response headers after fully
+	// writing the request headers if the request has an
+	// "Expect: 100-continue" header. Zero means no timeout and
+	// causes the body to be sent immediately, without
+	// waiting for the server to approve.
+	// This time does not include the time to send the request header.
+	ExpectContinueTimeout time.Duration `json:"expect_continue_timeout"`
+}
+
+func DefaultHTTPTransportConfig() *HTTPTransportConfig {
+	// The default values are taken from [hashicorp/go-cleanhttp](https://github.com/hashicorp/go-cleanhttp/blob/a0807dd79fc1680a7b1f2d5a2081d92567aab97d/cleanhttp.go#L19.
+	return &HTTPTransportConfig{
+		DialTimeout:           30 * time.Second,
+		KeepAlive:             30 * time.Second,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		MaxIdleConnsPerHost:   runtime.GOMAXPROCS(0) + 1,
+	}
+}
+
+func NewHTTPTransport(cfg *HTTPTransportConfig, r *net.Resolver) *http.Transport {
+	return &http.Transport{
+		Proxy: nil,
+		DialContext: defaultTransportDialContext(&net.Dialer{
+			Timeout:   cfg.DialTimeout,
+			KeepAlive: cfg.KeepAlive,
+			Resolver:  r,
+		}),
+		MaxIdleConns:          cfg.MaxIdleConns,
+		IdleConnTimeout:       cfg.IdleConnTimeout,
+		TLSHandshakeTimeout:   cfg.TLSHandshakeTimeout,
+		ExpectContinueTimeout: cfg.ExpectContinueTimeout,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConnsPerHost:   cfg.MaxIdleConnsPerHost,
+	}
+}

--- a/log.go
+++ b/log.go
@@ -7,7 +7,9 @@ type Logger interface {
 	Debugf(format string, args ...interface{})
 }
 
-// nopLogger is a logger that does nothing.
+// NopLogger is a logger that does nothing.
+var NopLogger = nopLogger{} //nolint:gochecknoglobals // nop implementation
+
 type nopLogger struct{}
 
 func (l nopLogger) Errorf(format string, args ...interface{}) {

--- a/log/stdlog/stdlog.go
+++ b/log/stdlog/stdlog.go
@@ -22,7 +22,7 @@ func New(cfg *flog.Config) StdLogger {
 	}
 	return StdLogger{
 		log:     log.New(w, "", log.Ldate|log.Ltime|log.LUTC),
-		verbose: true,
+		verbose: cfg.Verbose,
 	}
 }
 

--- a/pac/doc.go
+++ b/pac/doc.go
@@ -2,3 +2,37 @@
 // Under the hood uses Goja JavaScript VM to run the PAC script.
 // It supports Mozilla FindProxyForURL and the Microsoft IPv6 extension FindProxyForURLEx as well as all the helper functions as described in the PAC specification.
 package pac
+
+import (
+	"regexp"
+	"sort"
+)
+
+var jsFunctionRegex = regexp.MustCompile(`function\s+([a-zA-Z0-9_]+)\s*\(`)
+
+// SupportedFunctions returns a list of supported javascript functions from the PAC specification.
+func SupportedFunctions() []string {
+	var all []string //nolint:prealloc // not worth it
+	for _, m := range jsFunctionRegex.FindAllStringSubmatch(asciiPacUtilsScript, -1) {
+		all = append(all, m[1])
+	}
+
+	// Add built-in functions.
+	all = append(all,
+		"dnsResolve",
+		"myIpAddress",
+		// IPv6
+		"isResolvableEx",
+		"isInNetEx",
+		"dnsResolveEx",
+		"myIpAddressEx",
+		"sortIpAddressList",
+		"getClientVersion",
+		// Alert
+		"alert",
+	)
+
+	sort.Strings(all)
+
+	return all
+}

--- a/pac/pac_test.go
+++ b/pac/pac_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestProxyResolverChromium(t *testing.T) {
+func TestProxyResolverChromium(t *testing.T) { //nolint:maintidx // long table
 	defaultQueryURL, err := url.ParseRequestURI("https://www.google.com/")
 	if err != nil {
 		t.Fatal(err)
@@ -29,6 +29,10 @@ func TestProxyResolverChromium(t *testing.T) {
 		err       string
 		evalErr   string
 	}{
+		{
+			fileName: "ambiguous_entry_point.js",
+			err:      "ambiguous entry point",
+		},
 		{
 			fileName: "b_132073833.js",
 			want:     []Proxy{{Mode: DIRECT}},

--- a/pac/testdata/chromium-libpac/ambiguous_entry_point.js
+++ b/pac/testdata/chromium-libpac/ambiguous_entry_point.js
@@ -1,0 +1,7 @@
+function FindProxyForURL(url, host) {
+    return "DIRECT";
+}
+
+function FindProxyForURLEx(url, host) {
+    return "DIRECT";
+}

--- a/readurl.go
+++ b/readurl.go
@@ -1,0 +1,84 @@
+package forwarder
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+)
+
+// ReadURL can read a local file, http or https URL or stdin.
+func ReadURL(u *url.URL, rt http.RoundTripper) (string, error) {
+	switch u.Scheme {
+	case "file":
+		return readFile(u)
+	case "http", "https":
+		return readHTTP(u, rt)
+	default:
+		return "", fmt.Errorf("unsupported scheme %q, supported schemes are file, http and https", u.Scheme)
+	}
+}
+
+func readFile(u *url.URL) (string, error) {
+	if u.Host != "" {
+		return "", fmt.Errorf("invalid file URL %q, host is not allowed", u.String())
+	}
+	if u.User != nil {
+		return "", fmt.Errorf("invalid file URL %q, user is not allowed", u.String())
+	}
+	if u.RawQuery != "" {
+		return "", fmt.Errorf("invalid file URL %q, query is not allowed", u.String())
+	}
+	if u.Fragment != "" {
+		return "", fmt.Errorf("invalid file URL %q, fragment is not allowed", u.String())
+	}
+	if u.Path == "" {
+		return "", fmt.Errorf("invalid file URL %q, path is empty", u.String())
+	}
+
+	if u.Path == "-" {
+		return readAndClose(os.Stdin)
+	}
+
+	f, err := os.Open(u.Path)
+	if err != nil {
+		return "", err
+	}
+	return readAndClose(f)
+}
+
+func readAndClose(r io.ReadCloser) (string, error) {
+	defer r.Close()
+	b, err := io.ReadAll(r)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func readHTTP(u *url.URL, rt http.RoundTripper) (string, error) {
+	c := http.Client{
+		Transport: rt,
+	}
+	req, err := http.NewRequest(http.MethodGet, u.String(), http.NoBody) //nolint:noctx // timeout is set in the transport
+	if err != nil {
+		return "", err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code %d", resp.StatusCode)
+	}
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(b), nil
+}

--- a/tls.go
+++ b/tls.go
@@ -1,0 +1,11 @@
+package forwarder
+
+type TLSConfig struct {
+	// InsecureSkipVerify controls whether a client verifies the server's
+	// certificate chain and host name. If InsecureSkipVerify is true, crypto/tls
+	// accepts any certificate presented by the server and any host name in that
+	// certificate. In this mode, TLS is susceptible to machine-in-the-middle
+	// attacks unless custom verification is used. This should be used only for
+	// testing or in combination with VerifyConnection or VerifyPeerCertificate.
+	InsecureSkipVerify bool `json:"insecure_skip_verify"`
+}


### PR DESCRIPTION
# pac-server  Start HTTP(S) server that serves a PAC file

```
$ forwarder pac-server -h

Start HTTP(S) server that serves a PAC file. The PAC file can be specified as a 
file path or URL with scheme "file", "http" or "https". The PAC file must 
contain FindProxyForURL or FindProxyForURLEx and must be valid. All PAC util 
functions are supported (see below). Alerts are ignored. 

You can start HTTP, HTTPS or H2 (HTTPS) server. The server may be protected by 
basic authentication. If you start an HTTPS server and you don't provide a 
certificate, the server will generate a self-signed certificate on startup.

Usage:
  forwarder pac-server --pac <file|url> [--protocol <http|https|h2>] [--address <host:port>] [flags]

Examples:
  # Start a HTTP server serving a PAC file
  pac-server --pac pac.js --protocol http --address localhost:8080

  # Start a HTTPS server serving a PAC file
  pac-server --pac pac.js --protocol https --address localhost:80443

  # Start a HTTPS server serving a PAC file with custom certificate
  pac-server --pac pac.js --protocol https --address localhost:80443 --cert-file cert.pem --key-file key.pem

  # Start a HTTPS server serving a PAC file with basic authentication
  pac-server --pac pac.js --protocol https --address localhost:80443 --basic-auth user:pass

Supported PAC util functions:
  alert
  convert_addr
  dateRange
  dnsDomainIs
  dnsDomainLevels
  dnsResolve
  dnsResolveEx
  getClientVersion
  getDay
  getMonth
  isInNet
  isInNetEx
  isPlainHostName
  isResolvable
  isResolvableEx
  isValidIpAddress
  localHostOrDomainIs
  myIpAddress
  myIpAddressEx
  shExpMatch
  sortIpAddressList
  timeRange
  weekdayRange

Flags:
      --address host:port                       HTTP server listen address in the form of host:port (env FORWARDER_ADDRESS) (default ":8080")
      --basic-auth username:password            basic-auth in the form of username:password (env FORWARDER_BASIC_AUTH)
      --cert-file string                        HTTP server TLS certificate file (env FORWARDER_CERT_FILE)
  -h, --help                                    help for pac-server
      --http-dial-timeout duration              dial timeout for HTTP connections (env FORWARDER_HTTP_DIAL_TIMEOUT) (default 30s)
      --http-expect-continue-timeout duration   expect continue timeout for HTTP connections (env FORWARDER_HTTP_EXPECT_CONTINUE_TIMEOUT) (default 1s)
      --http-idle-conn-timeout duration         idle connection timeout for HTTP connections (env FORWARDER_HTTP_IDLE_CONN_TIMEOUT) (default 1m30s)
      --http-keep-alive duration                keep alive interval for HTTP connections (env FORWARDER_HTTP_KEEP_ALIVE) (default 30s)
      --http-max-conns-per-host int             maximum number of connections per host for HTTP connections (env FORWARDER_HTTP_MAX_CONNS_PER_HOST)
      --http-max-idle-conns int                 maximum number of idle connections for HTTP connections (env FORWARDER_HTTP_MAX_IDLE_CONNS) (default 100)
      --http-max-idle-conns-per-host int        maximum number of idle connections per host for HTTP connections (env FORWARDER_HTTP_MAX_IDLE_CONNS_PER_HOST) (default 9)
      --http-response-header-timeout duration   response header timeout for HTTP connections (env FORWARDER_HTTP_RESPONSE_HEADER_TIMEOUT)
      --http-tls-handshake-timeout duration     TLS handshake timeout for HTTP connections (env FORWARDER_HTTP_TLS_HANDSHAKE_TIMEOUT) (default 10s)
      --key-file string                         HTTP server TLS key file (env FORWARDER_KEY_FILE)
      --log-file                                log file path (default: stdout) (env FORWARDER_LOG_FILE)
  -p, --pac path or URL                         local file path or URL to PAC content, use "-" to read from stdin (env FORWARDER_PAC) (default file://pac.js)
      --protocol                                HTTP server protocol, one of http, https, h2 (env FORWARDER_PROTOCOL) (default http)
      --read-timeout duration                   HTTP server read timeout (env FORWARDER_READ_TIMEOUT) (default 5s)
      --verbose                                 enable verbose logging (env FORWARDER_VERBOSE)
```

# pac-eval  Evaluate a PAC file for given URLs

```
$ forwarder pac-eval -h

Evaluate a PAC file for given URLs. The PAC file can be specified as a file path 
or URL with scheme "file", "http" or "https". The URLs to evaluate are passed as 
arguments. The output is a list of proxy strings, one per URL. The PAC file must 
contain FindProxyForURL or FindProxyForURLEx and must be valid. All PAC util 
functions are supported (see below). Alerts are written to stderr.

Usage:
  forwarder pac-eval --pac <file|url> [flags] <url>...

Examples:
  # Evaluate a PAC file for a URL
  forwarder pac-eval --pac pac.js https://www.google.com

  # Evaluate a PAC file for multiple URLs
  forwarder pac-eval --pac pac.js https://www.google.com https://www.facebook.com

  # Evaluate a PAC file for multiple URLs using a PAC file from stdin
  cat pac.js | forwarder pac-eval --pac - https://www.google.com https://www.facebook.com

  # Evaluate a PAC file for multiple URLs using a PAC file from a URL
  forwarder pac-eval --pac https://example.com/pac.js https://www.google.com https://www.facebook.com

Supported PAC util functions:
  alert
  convert_addr
  dateRange
  dnsDomainIs
  dnsDomainLevels
  dnsResolve
  dnsResolveEx
  getClientVersion
  getDay
  getMonth
  isInNet
  isInNetEx
  isPlainHostName
  isResolvable
  isResolvableEx
  isValidIpAddress
  localHostOrDomainIs
  myIpAddress
  myIpAddressEx
  shExpMatch
  sortIpAddressList
  timeRange
  weekdayRange

Flags:
  -n, --dns-server                              DNS server IP or URL ex. 1.1.1.1 or udp://1.1.1.1:53 (can be specified multiple times) (env FORWARDER_DNS_SERVER) (default [])
      --dns-timeout duration                    timeout for DNS queries if DNS server is specified (env FORWARDER_DNS_TIMEOUT) (default 5s)
  -h, --help                                    help for pac-eval
      --http-dial-timeout duration              dial timeout for HTTP connections (env FORWARDER_HTTP_DIAL_TIMEOUT) (default 30s)
      --http-expect-continue-timeout duration   expect continue timeout for HTTP connections (env FORWARDER_HTTP_EXPECT_CONTINUE_TIMEOUT) (default 1s)
      --http-idle-conn-timeout duration         idle connection timeout for HTTP connections (env FORWARDER_HTTP_IDLE_CONN_TIMEOUT) (default 1m30s)
      --http-keep-alive duration                keep alive interval for HTTP connections (env FORWARDER_HTTP_KEEP_ALIVE) (default 30s)
      --http-max-conns-per-host int             maximum number of connections per host for HTTP connections (env FORWARDER_HTTP_MAX_CONNS_PER_HOST)
      --http-max-idle-conns int                 maximum number of idle connections for HTTP connections (env FORWARDER_HTTP_MAX_IDLE_CONNS) (default 100)
      --http-max-idle-conns-per-host int        maximum number of idle connections per host for HTTP connections (env FORWARDER_HTTP_MAX_IDLE_CONNS_PER_HOST) (default 9)
      --http-response-header-timeout duration   response header timeout for HTTP connections (env FORWARDER_HTTP_RESPONSE_HEADER_TIMEOUT)
      --http-tls-handshake-timeout duration     TLS handshake timeout for HTTP connections (env FORWARDER_HTTP_TLS_HANDSHAKE_TIMEOUT) (default 10s)
  -p, --pac path or URL                         local file path or URL to PAC content, use "-" to read from stdin (env FORWARDER_PAC) (default file://pac.js)
```