### PR TITLE
e2e testing framework

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           cat .version >> $GITHUB_ENV
 
-      - name: Set up Go
+      - name: Setup Go
         uses: actions/setup-go@v3
         with:
           go-version: "${{env.GO_VERSION}}"
@@ -35,5 +35,12 @@ jobs:
       - name: Run unit test
         run: make test coverage
 
-      - name: Run integration test
-        run: make integration-test coverage
+      - name: Add Docker Layer Cache
+        uses: satackey/action-docker-layer-caching@v0.0.11
+        continue-on-error: true
+
+      - name: Build Docker image
+        run: make update-devel-image
+
+      - name: Run e2e test
+        run: cd e2e && ./run.sh

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,8 @@
 ---
 run:
   timeout: 5m
+  build-tags:
+    - e2e
   skip-files:
     - httpbin/httpbin.go
     - middleware/delegator.go
@@ -72,6 +74,10 @@ issues:
         - noctx
         - paralleltest
         - testpackage
+
+    - path: e2e/args.go
+      linters:
+        - gochecknoglobals
 
     - path: internal/version/version.go
       linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,6 +50,7 @@ linters-settings:
 issues:
   exclude:
     - "can be `fmt.Stringer`"
+    - "can be `expvar.Var`"
     - "Error return value of `cmd.MarkFlag.+` is not checked"
     - "string `https?` has \\d+ occurrences"
     - "Magic number: 0o"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@
 run:
   timeout: 5m
   skip-files:
+    - httpbin/httpbin.go
     - middleware/delegator.go
   silent: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.10
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates && \
+    apt-get install -y --no-install-recommends ca-certificates curl && \
     apt-get clean && \
     apt-get autoremove && \
     rm -rf /var/lib/apt/lists/*
@@ -9,3 +9,5 @@ RUN apt-get update && \
 COPY forwarder /usr/bin/forwarder
 ENTRYPOINT ["/usr/bin/forwarder"]
 CMD ["proxy", "--api-address", ":10000"]
+
+HEALTHCHECK --interval=1s --timeout=250ms --retries=10 CMD ["curl", "-s", "-S", "-f", "http://localhost:10000/readyz"]

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ lint:
 
 .PHONY: test
 test:
-	@go test -timeout 120s -short -v -race -cover -coverprofile=coverage.out ./...
+	@go test -timeout 120s -short -race -cover -coverprofile=coverage.out ./...
 
 .PHONY: bench
 bench:

--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,18 @@ coverage:
 
 ### Release
 
+.PHONY: update-devel-image
+update-devel-image: TAG=devel
+update-devel-image: TMPDIR:=$(shell mktemp -d)
+update-devel-image:
+	@CGO_ENABLED=0 GOOS=linux go build -o $(TMPDIR)/forwarder ./cmd/forwarder
+	@ln ./Dockerfile $(TMPDIR)
+	@docker buildx build -t saucelabs/forwarder:$(TAG) $(TMPDIR)
+	@rm -rf $(TMPDIR)
+
 .PHONY: dist
 dist:
-	@GORELEASER_CURRENT_TAG=1.0.0-devel goreleaser --snapshot --rm-dist
+	@GORELEASER_CURRENT_TAG=1.0.0-rc goreleaser --snapshot --rm-dist
 
 .PHONY: doc
 doc:

--- a/cert.go
+++ b/cert.go
@@ -29,6 +29,7 @@ type SelfSignedCert struct {
 
 func RSASelfSignedCert() *SelfSignedCert {
 	return &SelfSignedCert{
+		Hosts:        []string{"localhost"},
 		Organization: []string{"Sauce Labs Inc."},
 		ValidFrom:    time.Now(),
 		ValidFor:     365 * 24 * time.Hour,

--- a/cmd/forwarder/httpbin/httpbin.go
+++ b/cmd/forwarder/httpbin/httpbin.go
@@ -1,0 +1,55 @@
+package httpbin
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+
+	"github.com/saucelabs/forwarder"
+	"github.com/saucelabs/forwarder/bind"
+	"github.com/saucelabs/forwarder/httpbin"
+	"github.com/saucelabs/forwarder/log"
+	"github.com/saucelabs/forwarder/log/stdlog"
+	"github.com/spf13/cobra"
+)
+
+type command struct {
+	httpServerConfig *forwarder.HTTPServerConfig
+	logConfig        *log.Config
+}
+
+func (c *command) RunE(cmd *cobra.Command, args []string) error {
+	if f := c.logConfig.File; f != nil {
+		defer f.Close()
+	}
+	logger := stdlog.New(c.logConfig)
+
+	s, err := forwarder.NewHTTPServer(c.httpServerConfig, httpbin.Handler(), logger.Named("server"))
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	ctx, _ = signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	return s.Run(ctx)
+}
+
+func Command() (cmd *cobra.Command) {
+	c := command{
+		httpServerConfig: forwarder.DefaultHTTPServerConfig(),
+		logConfig:        log.DefaultConfig(),
+	}
+
+	defer func() {
+		fs := cmd.Flags()
+		bind.HTTPServerConfig(fs, c.httpServerConfig, "")
+		bind.LogConfig(fs, c.logConfig)
+		bind.MarkFlagFilename(cmd, "cert-file", "key-file", "log-file")
+	}()
+	return &cobra.Command{
+		Use:    "httpbin [--protocol <http|https|h2>] [--address <host:port>] [flags]",
+		Short:  "Start HTTP(S) server that serves httpbin.org API",
+		RunE:   c.RunE,
+		Hidden: true,
+	}
+}

--- a/cmd/forwarder/root.go
+++ b/cmd/forwarder/root.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"github.com/saucelabs/forwarder/cmd/forwarder/httpbin"
 	"github.com/saucelabs/forwarder/cmd/forwarder/paceval"
 	"github.com/saucelabs/forwarder/cmd/forwarder/pacserver"
 	"github.com/saucelabs/forwarder/cmd/forwarder/proxy"
@@ -27,6 +28,7 @@ func rootCommand() *cobra.Command {
 	}
 
 	rootCmd.AddCommand(
+		httpbin.Command(),
 		withPACSupportedFunctions(paceval.Command()),
 		withPACSupportedFunctions(pacserver.Command()),
 		withPACSupportedFunctions(proxy.Command()),

--- a/dns_test.go
+++ b/dns_test.go
@@ -3,6 +3,7 @@ package forwarder
 import (
 	"context"
 	"net/url"
+	"os"
 	"testing"
 	"time"
 
@@ -10,6 +11,10 @@ import (
 )
 
 func TestResolverLookupHost(t *testing.T) {
+	if _, ok := os.LookupEnv("CI"); ok {
+		t.Skip("skipping test in CI environment")
+	}
+
 	c := &DNSConfig{
 		Servers: []*url.URL{{Scheme: "udp", Host: "1.1.1.1:53"}},
 		Timeout: 5 * time.Second,

--- a/e2e/.env
+++ b/e2e/.env
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME=forwarder-e2e

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -1,8 +1,8 @@
 # Ignore CPU pinning in CI.
 ifdef CI
-CPUSET := ""
+COMPOSE := docker compose -f docker-compose.yaml $(foreach f,$(CONF),-f $(f))
 else
-CPUSET := -f override/cpuset.yaml
+COMPOSE := docker compose -f docker-compose.yaml -f override/cpuset.yaml $(foreach f,$(CONF),-f $(f))
 endif
 
 # Docker tag to be tested.
@@ -10,12 +10,10 @@ ifndef FORWARDER_VERSION
 export FORWARDER_VERSION := devel
 endif
 
-COMPOSE := docker compose -f docker-compose.yaml
-
 .PHONY: up
 up:
-	@$(COMPOSE) $(CPUSET) $(foreach f,$(CONF),-f $(f) ) \
-	up -d --wait --force-recreate --remove-orphans
+	@echo "$(COMPOSE)"
+	@$(COMPOSE) up -d --wait --force-recreate --remove-orphans
 
 .PHONY: down
 down:

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -1,0 +1,34 @@
+# Ignore CPU pinning in CI.
+ifdef CI
+CPUSET := ""
+else
+CPUSET := -f override/cpuset.yaml
+endif
+
+# Docker tag to be tested.
+ifndef FORWARDER_VERSION
+export FORWARDER_VERSION := devel
+endif
+
+.PHONY: up
+up:
+	@docker-compose -f docker-compose.yaml $(CPUSET) $(foreach f,$(CONF),-f $(f) ) \
+	up -d --wait --force-recreate --remove-orphans
+
+.PHONY: down
+down:
+	@docker-compose down -v --remove-orphans
+
+.PHONY: dump-logs
+dump-logs:
+	@docker-compose logs $(SRV)
+
+.PHONY: test
+test: RUN=.
+test: e2e.test
+	@docker run --name "test-runner" --network "forwarder-e2e_default" --cpuset-cpus 0 \
+	-v "$(PWD)/e2e.test:/usr/bin/e2e.test" -i --read-only --rm ubuntu \
+	e2e.test -test.run $(RUN) $(ARGS)
+
+e2e.test: *.go
+	@CGO_ENABLED=0 GOOS=linux go test -tags e2e -c -o e2e.test .

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -10,18 +10,20 @@ ifndef FORWARDER_VERSION
 export FORWARDER_VERSION := devel
 endif
 
+COMPOSE := docker compose -f docker-compose.yaml
+
 .PHONY: up
 up:
-	@docker-compose -f docker-compose.yaml $(CPUSET) $(foreach f,$(CONF),-f $(f) ) \
+	@$(COMPOSE) $(CPUSET) $(foreach f,$(CONF),-f $(f) ) \
 	up -d --wait --force-recreate --remove-orphans
 
 .PHONY: down
 down:
-	@docker-compose down -v --remove-orphans
+	@$(COMPOSE) down -v --remove-orphans
 
 .PHONY: dump-logs
 dump-logs:
-	@docker-compose logs $(SRV)
+	@$(COMPOSE) logs $(SRV)
 
 .PHONY: test
 test: RUN=.

--- a/e2e/args.go
+++ b/e2e/args.go
@@ -1,0 +1,9 @@
+package e2e
+
+import "flag"
+
+var (
+	proxy              = flag.String("proxy", "", "URL of the proxy to test against")
+	httpbin            = flag.String("httpbin", "", "URL of the httpbin server to test against")
+	insecureSkipVerify = flag.Bool("insecure-skip-verify", false, "Skip TLS certificate verification")
+)

--- a/e2e/client.go
+++ b/e2e/client.go
@@ -1,0 +1,40 @@
+package e2e
+
+import (
+	"flag"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/saucelabs/forwarder"
+)
+
+func newHTTPClient(t *testing.T) *http.Client {
+	t.Helper()
+
+	if !flag.Parsed() {
+		flag.Parse()
+	}
+
+	if *proxy == "" {
+		t.Fatal("proxy URL not set")
+	}
+
+	cfg := forwarder.DefaultHTTPTransportConfig()
+	cfg.InsecureSkipVerify = *insecureSkipVerify
+
+	rt := forwarder.NewHTTPTransport(cfg, nil)
+	if *proxy == "" {
+		t.Log("proxy not set, running without proxy")
+	} else {
+		proxyURL, err := url.Parse(*proxy)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rt.Proxy = http.ProxyURL(proxyURL)
+	}
+
+	return &http.Client{
+		Transport: rt,
+	}
+}

--- a/e2e/docker-compose.yaml
+++ b/e2e/docker-compose.yaml
@@ -1,0 +1,15 @@
+version: "3.8"
+
+services:
+  proxy:
+    image: saucelabs/forwarder:${FORWARDER_VERSION}
+    environment:
+      FORWARDER_VERBOSE: "true"
+    healthcheck:
+      interval: 1s
+      timeout: 250ms
+      retries: 10
+
+  upstream-proxy:
+    extends: proxy
+

--- a/e2e/docker-compose.yaml
+++ b/e2e/docker-compose.yaml
@@ -13,3 +13,5 @@ services:
   upstream-proxy:
     extends: proxy
 
+  httpbin:
+    extends: proxy

--- a/e2e/httpbin-http.yaml
+++ b/e2e/httpbin-http.yaml
@@ -2,9 +2,6 @@ version: "3.8"
 
 services:
   httpbin:
-    extends:
-      file: docker-compose.yaml
-      service: proxy
     command: httpbin --address :80
     healthcheck:
       test: ["CMD", "curl", "-s", "-S", "-f", "http://localhost/status/200"]

--- a/e2e/httpbin-http.yaml
+++ b/e2e/httpbin-http.yaml
@@ -1,0 +1,10 @@
+version: "3.8"
+
+services:
+  httpbin:
+    extends:
+      file: docker-compose.yaml
+      service: proxy
+    command: httpbin --address :80
+    healthcheck:
+      test: ["CMD", "curl", "-s", "-S", "-f", "http://localhost/status/200"]

--- a/e2e/httpbin-https.yaml
+++ b/e2e/httpbin-https.yaml
@@ -1,0 +1,10 @@
+version: "3.8"
+
+services:
+  httpbin:
+    extends:
+      file: docker-compose.yaml
+      service: proxy
+    command: httpbin --protocol HTTPS --address :443
+    healthcheck:
+      test: ["CMD", "curl", "-s", "-S", "-f", "-k", "https://localhost/status/200"]

--- a/e2e/httpbin-https.yaml
+++ b/e2e/httpbin-https.yaml
@@ -2,9 +2,6 @@ version: "3.8"
 
 services:
   httpbin:
-    extends:
-      file: docker-compose.yaml
-      service: proxy
     command: httpbin --protocol HTTPS --address :443
     healthcheck:
       test: ["CMD", "curl", "-s", "-S", "-f", "-k", "https://localhost/status/200"]

--- a/e2e/override/cpuset.yaml
+++ b/e2e/override/cpuset.yaml
@@ -1,0 +1,9 @@
+version: "3.8"
+
+services:
+  proxy:
+    cpuset: "1"
+  upstream-proxy:
+    cpuset: "2"
+  httpbin:
+    cpuset: "3"

--- a/e2e/override/proxy-http.yaml
+++ b/e2e/override/proxy-http.yaml
@@ -1,0 +1,6 @@
+version: "3.8"
+
+services:
+  proxy:
+    environment:
+      FORWARDER_PROTOCOL: "HTTP"

--- a/e2e/override/proxy-https.yaml
+++ b/e2e/override/proxy-https.yaml
@@ -1,0 +1,6 @@
+version: "3.8"
+
+services:
+  proxy:
+    environment:
+      FORWARDER_PROTOCOL: "HTTPS"

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+on_error() {
+  make dump-logs
+}
+
+run_direct_test() {
+  trap 'on_error' ERR
+
+  PROXY_SCHEME=$1
+  HTTPBIN_SCHEME=$1
+
+  echo ">>> DIRECT proxy=${PROXY_SCHEME} httpbin=${HTTPBIN_SCHEME}"
+  make up CONF="override/proxy-${PROXY_SCHEME}.yaml httpbin-${HTTPBIN_SCHEME}.yaml"
+  make test ARGS="-proxy ${PROXY_SCHEME}://proxy:3128 -httpbin ${HTTPBIN_SCHEME}://httpbin -insecure-skip-verify"
+}
+
+run_direct_test http http
+run_direct_test https http
+run_direct_test https https
+run_direct_test http https

--- a/e2e/status_test.go
+++ b/e2e/status_test.go
@@ -1,0 +1,51 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestStatusCodes(t *testing.T) {
+	if *httpbin == "" {
+		t.Fatal("httpbin URL not set")
+	}
+
+	// List of all valid status codes plus some non-standard ones.
+	// See https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+	validStatusCodes := []int{
+		// FIXME: proxy wrongly supports 1xx, see #113
+		// 100, 101, 102, 103, 122,
+		200, 201, 202, 203, 204, 205, 206, 207, 208, 226,
+		300, 301, 302, 303, 304, 305, 306, 307, 308,
+		400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 421, 422, 423, 424, 425, 426, 428, 429, 431, 451,
+		500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511, 599,
+	}
+
+	var (
+		ctx    = context.Background()
+		client = newHTTPClient(t)
+	)
+
+	for i := range validStatusCodes {
+		code := validStatusCodes[i]
+		t.Run(fmt.Sprint(code), func(t *testing.T) {
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/status/%d", *httpbin, code), http.NoBody)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != code {
+				t.Fatalf("expected status code %d, got %d", code, resp.StatusCode)
+			}
+		})
+	}
+}

--- a/httpbin/httpbin.go
+++ b/httpbin/httpbin.go
@@ -1,0 +1,110 @@
+package httpbin
+
+import (
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/saucelabs/forwarder/middleware"
+)
+
+// Handler returns http.Handler that implements elements of httpbin.org API.
+// The implemented endpoints are:
+// `/basic-auth/{user}/{passwd}`, `/delay/{seconds}`, `/status/{code}`, `/stream-bytes/{bytes}`.
+func Handler() http.Handler {
+	m := http.NewServeMux()
+	m.HandleFunc("/basic-auth/", basicAuthHandler)
+	m.HandleFunc("/delay/", delayHandler)
+	m.HandleFunc("/status/", statusHandler)
+	m.HandleFunc("/stream-bytes/", streamBytesHandler)
+	return m
+}
+
+// basicAuthHandler implements the /basic-auth/{user}/{passwd} endpoint.
+// See https://httpbin.org/#/Auth/get_basic_auth__user___passwd_
+func basicAuthHandler(w http.ResponseWriter, r *http.Request) {
+	p := r.URL.Path[len("/basic-auth/"):]
+
+	user, pass, ok := strings.Cut(p, "/")
+	if !ok {
+		msg := fmt.Sprintf("Invalid path %q, expected ≤user>/<password>", p)
+		http.Error(w, msg, http.StatusBadRequest)
+		return
+	}
+
+	mw := middleware.NewBasicAuth(middleware.AuthorizationHeader)
+	if !mw.AuthenticatedRequest(r, user, pass) {
+		w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// delayHandler implements the /delay/{seconds} endpoint.
+func delayHandler(w http.ResponseWriter, r *http.Request) {
+	p := r.URL.Path[len("/delay/"):]
+
+	s, ok := atoi(w, p)
+	if !ok {
+		return
+	}
+	if s > 10 {
+		s = 10
+	}
+
+	time.Sleep(time.Duration(s) * time.Second)
+	w.WriteHeader(http.StatusOK)
+}
+
+// statusHandler implements the /status/{code} endpoint.
+// See https://httpbin.org/#/Status_codes
+func statusHandler(w http.ResponseWriter, r *http.Request) {
+	p := r.URL.Path[len("/status/"):]
+
+	c, ok := atoi(w, p)
+	if !ok {
+		return
+	}
+	w.WriteHeader(c)
+}
+
+var rnd = rand.NewSource(time.Now().Unix())
+
+// streamBytesHandler implements the /stream-bytes/{bytes} endpoint.
+// See https://httpbin.org/#/Dynamic_data/get_stream_bytes__n_
+func streamBytesHandler(w http.ResponseWriter, r *http.Request) {
+	p := r.URL.Path[len("/stream-bytes/"):]
+
+	n, ok := atoi(w, p)
+	if !ok {
+		return
+	}
+
+	q := r.URL.Query()
+	chunkSize := 10 * 1024
+	if cs := q.Get("chunk_size"); cs != "" {
+		chunkSize, ok = atoi(w, cs)
+		if !ok {
+			return
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.WriteHeader(http.StatusOK)
+	io.CopyBuffer(w, io.LimitReader(rand.New(rnd), int64(n)), make([]byte, chunkSize))
+}
+
+func atoi(w http.ResponseWriter, s string) (int, bool) {
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		msg := fmt.Sprintf("Invalid argument %q: %s", s, err)
+		http.Error(w, msg, http.StatusBadRequest)
+	}
+	return v, err == nil
+}

--- a/log.go
+++ b/log.go
@@ -1,5 +1,7 @@
 package forwarder
 
+import "strings"
+
 // Logger is the logger used by the forwarder package.
 type Logger interface {
 	Errorf(format string, args ...interface{})
@@ -27,5 +29,10 @@ type goproxyLogger struct {
 }
 
 func (l goproxyLogger) Printf(format string, v ...interface{}) {
-	l.Debugf(format, v...)
+	if strings.HasPrefix(format, "[%03d] WARN: ") {
+		l.Logger.Infof(format[13:], v...)
+		return
+	}
+
+	l.Logger.Debugf(strings.Replace(format, "INFO: ", "", 1), v...)
 }


### PR DESCRIPTION
The e2e tests are implemented using docker-compose, go test, makefile and bash.

There are 4 containers:
- Proxy
- Upstream Proxy
- Test backend (httpbin)
- Test runner

Container configuration is changed by adding environment variables from the override files (see override directory).
This enables to mix and match the files, this could be called a "mixin" model, to enable different features.

All but last container are managed by docker-compose.
On start we wait until all services ready using the readiness check in the api.
The last container is injected to the docker-compose network to run the compiled go test program.

Makefile implements helpers for working with docker and building the test binary.
All the concrete test invocations are done from the run.sh shell script.

The status check test is ran against all combinations of http/https proxy and backend, example output.

```
>>> DIRECT proxy=http httpbin=http
[+] Running 3/3
 ⠿ Container forwarder-e2e-upstream-proxy-1  Healthy                                                                                                                                                                                                        1.8s
 ⠿ Container forwarder-e2e-httpbin-1         Healthy                                                                                                                                                                                                        1.8s
 ⠿ Container forwarder-e2e-proxy-1           Healthy                                                                                                                                                                                                        2.3s
PASS
>>> DIRECT proxy=https httpbin=https
[+] Running 3/3
 ⠿ Container forwarder-e2e-upstream-proxy-1  Healthy                                                                                                                                                                                                        1.7s
 ⠿ Container forwarder-e2e-httpbin-1         Healthy                                                                                                                                                                                                        2.3s
 ⠿ Container forwarder-e2e-proxy-1           Healthy                                                                                                                                                                                                        2.3s
PASS
>>> DIRECT proxy=https httpbin=https
[+] Running 3/3
 ⠿ Container forwarder-e2e-upstream-proxy-1  Healthy                                                                                                                                                                                                        2.1s
 ⠿ Container forwarder-e2e-httpbin-1         Healthy                                                                                                                                                                                                        2.1s
 ⠿ Container forwarder-e2e-proxy-1           Healthy                                                                                                                                                                                                        2.1s
PASS
>>> DIRECT proxy=http httpbin=http
[+] Running 3/3
 ⠿ Container forwarder-e2e-upstream-proxy-1  Healthy                                                                                                                                                                                                        2.1s
 ⠿ Container forwarder-e2e-proxy-1           Healthy                                                                                                                                                                                                        2.1s
 ⠿ Container forwarder-e2e-httpbin-1         Healthy                                                                                                                                                                                                        2.1s
PASS
```

The test found a bug in 1XX response handling in proxy, reported in https://github.com/saucelabs/forwarder/issues/113.