### PR TITLE
http_server: add read and write timeouts

### DIFF
--- a/bind/flag.go
+++ b/bind/flag.go
@@ -83,6 +83,10 @@ func HTTPServerConfig(fs *pflag.FlagSet, cfg *forwarder.HTTPServerConfig, prefix
 		namePrefix+"key-file", cfg.KeyFile, usagePrefix+"HTTP server TLS key file")
 	fs.DurationVar(&cfg.ReadTimeout,
 		namePrefix+"read-timeout", cfg.ReadTimeout, usagePrefix+"HTTP server read timeout")
+	fs.DurationVar(&cfg.ReadHeaderTimeout,
+		namePrefix+"read-header-timeout", cfg.ReadHeaderTimeout, usagePrefix+"HTTP server read header timeout")
+	fs.DurationVar(&cfg.WriteTimeout,
+		namePrefix+"write-timeout", cfg.WriteTimeout, usagePrefix+"HTTP server write timeout")
 	fs.BoolVar(&cfg.LogHTTPRequests,
 		namePrefix+"log-http-requests", cfg.LogHTTPRequests, usagePrefix+"log all HTTP requests, by default only responses with status code >= 500 are logged")
 	fs.VarP(anyflag.NewValue[*url.Userinfo](cfg.BasicAuth, &cfg.BasicAuth, forwarder.ParseUserInfo),

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
+	"time"
 
 	"github.com/google/martian/v3"
 	"github.com/google/martian/v3/fifo"
@@ -36,9 +37,9 @@ type HTTPProxyConfig struct {
 func DefaultHTTPProxyConfig() *HTTPProxyConfig {
 	return &HTTPProxyConfig{
 		HTTPServerConfig: HTTPServerConfig{
-			Protocol:    HTTPScheme,
-			Addr:        ":3128",
-			ReadTimeout: 0, // TODO(mmatczuk): we need a more fine-grained timeouts see #129
+			Protocol:          HTTPScheme,
+			Addr:              ":3128",
+			ReadHeaderTimeout: 1 * time.Minute,
 		},
 	}
 }
@@ -126,7 +127,9 @@ func (hp *HTTPProxy) configureProxy() {
 	hp.proxy.WithoutWarning = true
 	hp.proxy.ErrorResponse = errorResponse
 	hp.proxy.CloseAfterReply = hp.config.CloseAfterReply
-
+	hp.proxy.ReadTimeout = hp.config.ReadTimeout
+	hp.proxy.ReadHeaderTimeout = hp.config.ReadHeaderTimeout
+	hp.proxy.WriteTimeout = hp.config.WriteTimeout
 	// Martian has an intertwined logic for setting http.Transport and the dialer.
 	// The dialer is wrapped, so that additional syscalls are made to the dialed connections.
 	// As a result the dialer needs to be reset.

--- a/http_server.go
+++ b/http_server.go
@@ -66,12 +66,14 @@ func h2TLSConfigTemplate() *tls.Config {
 }
 
 type HTTPServerConfig struct {
-	Protocol        Scheme        `json:"protocol"`
-	Addr            string        `json:"addr"`
-	CertFile        string        `json:"cert_file"`
-	KeyFile         string        `json:"key_file"`
-	ReadTimeout     time.Duration `json:"read_timeout"`
-	LogHTTPRequests bool          `json:"log_http_requests"`
+	Protocol          Scheme        `json:"protocol"`
+	Addr              string        `json:"addr"`
+	CertFile          string        `json:"cert_file"`
+	KeyFile           string        `json:"key_file"`
+	ReadTimeout       time.Duration `json:"read_timeout"`
+	ReadHeaderTimeout time.Duration `json:"read_header_timeout"`
+	WriteTimeout      time.Duration `json:"write_timeout"`
+	LogHTTPRequests   bool          `json:"log_http_requests"`
 
 	PromNamespace string                `json:"prom_namespace"`
 	PromRegistry  prometheus.Registerer `json:"prom_registry"`
@@ -80,9 +82,9 @@ type HTTPServerConfig struct {
 
 func DefaultHTTPServerConfig() *HTTPServerConfig {
 	return &HTTPServerConfig{
-		Protocol:    HTTPScheme,
-		Addr:        ":8080",
-		ReadTimeout: 5 * time.Second,
+		Protocol:          HTTPScheme,
+		Addr:              ":8080",
+		ReadHeaderTimeout: 1 * time.Minute,
 	}
 }
 
@@ -129,9 +131,11 @@ func NewHTTPServer(cfg *HTTPServerConfig, h http.Handler, log Logger) (*HTTPServ
 		config: cfg,
 		log:    log,
 		srv: &http.Server{
-			Addr:        cfg.Addr,
-			Handler:     withMiddleware(cfg, h, log),
-			ReadTimeout: cfg.ReadTimeout,
+			Addr:              cfg.Addr,
+			Handler:           withMiddleware(cfg, h, log),
+			ReadTimeout:       cfg.ReadTimeout,
+			ReadHeaderTimeout: cfg.ReadHeaderTimeout,
+			WriteTimeout:      cfg.WriteTimeout,
 		},
 	}
 


### PR DESCRIPTION
This patch integrates forwarder with timeout changes introduced in https://github.com/saucelabs/martian/pull/1.