### PR TITLE
http_proxy: use fifo.ImmutableGroup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,4 +49,4 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
-replace github.com/google/martian/v3 => github.com/saucelabs/martian/v3 v3.0.0-20221206110303-9457eff1a5fd
+replace github.com/google/martian/v3 => github.com/saucelabs/martian/v3 v3.0.0-20221216142120-410dcb7c884d

--- a/go.sum
+++ b/go.sum
@@ -244,8 +244,8 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/saucelabs/martian/v3 v3.0.0-20221206110303-9457eff1a5fd h1:AFWtAnfQsfkyldh4YhUzE5yRD/abzbx97mNzcBS2yls=
-github.com/saucelabs/martian/v3 v3.0.0-20221206110303-9457eff1a5fd/go.mod h1:qTXMpLvQ7jzQg40dFPMXJi4+ncyK+DTmPs4KOmsWKOk=
+github.com/saucelabs/martian/v3 v3.0.0-20221216142120-410dcb7c884d h1:kVXD5p+OjiU8RNWQn+zjBFZKxXRb8HA0SFPYUcBhH30=
+github.com/saucelabs/martian/v3 v3.0.0-20221216142120-410dcb7c884d/go.mod h1:qTXMpLvQ7jzQg40dFPMXJi4+ncyK+DTmPs4KOmsWKOk=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -221,7 +221,7 @@ func (hp *HTTPProxy) middlewareStack() martian.RequestResponseModifier {
 	}
 	fg.AddRequestModifier(martian.RequestModifierFunc(hp.setBasicAuth))
 
-	return topg
+	return topg.ToImmutable()
 }
 
 func abortIf(condition func(r *http.Request) bool, response func(*http.Request) *http.Response, returnErr error) martian.RequestModifier {


### PR DESCRIPTION
Proxy will now use fifo.ImmutableGroup introduced in https://github.com/saucelabs/martian/pull/3.

Fixes #134 