### PR TITLE
cmd/forwarder/proxy: group flags by prefix in help view

### DIFF
--- a/cmd/forwarder/proxy/proxy.go
+++ b/cmd/forwarder/proxy/proxy.go
@@ -183,15 +183,15 @@ func Command() (cmd *cobra.Command) {
 
 	defer func() {
 		fs := cmd.Flags()
-		bind.DNSConfig(fs, c.dnsConfig)
-		bind.HTTPTransportConfig(fs, c.httpTransportConfig)
-		bind.PAC(fs, &c.pac)
+		bind.HTTPProxyConfig(fs, c.httpProxyConfig)
 		fs.VarP(anyflag.NewSliceValue[*forwarder.HostPortUser](c.credentials, &c.credentials, forwarder.ParseHostPortUser),
 			"credentials", "c",
 			"site or upstream proxy basic authentication credentials in the form of `username:password@host:port`, "+
 				"host and port can be set to \"*\" to match all (can be specified multiple times)")
-		bind.HTTPProxyConfig(fs, c.httpProxyConfig)
+		bind.PAC(fs, &c.pac)
+		bind.DNSConfig(fs, c.dnsConfig)
 		bind.HTTPServerConfig(fs, c.apiServerConfig, "api", true)
+		bind.HTTPTransportConfig(fs, c.httpTransportConfig)
 		bind.LogConfig(fs, c.logConfig)
 
 		bind.MarkFlagFilename(cmd, "cert-file", "key-file", "pac")
@@ -199,6 +199,8 @@ func Command() (cmd *cobra.Command) {
 
 		fs.BoolVar(&c.goleak, "goleak", false, "enable goleak")
 		bind.MarkFlagHidden(cmd, "goleak")
+
+		fs.SortFlags = false
 	}()
 	return &cobra.Command{
 		Use:     "proxy [--protocol <http|https|h2>] [--address <host:port>] [--upstream-proxy <url>] [--pac <file|url>] [--credentials <username:password@host:port>]... [flags]",


### PR DESCRIPTION
The flags are groupped:
- core
- api
- http
- log

```
Flags:
      --protocol                                  HTTP server protocol, one of http, https (env FORWARDER_PROTOCOL) (default http)
      --address host:port                         HTTP server listen address in the form of host:port (env FORWARDER_ADDRESS) (default ":3128")
      --cert-file string                          HTTP server TLS certificate file (env FORWARDER_CERT_FILE)
      --key-file string                           HTTP server TLS key file (env FORWARDER_KEY_FILE)
      --read-timeout duration                     HTTP server read timeout (env FORWARDER_READ_TIMEOUT)
      --log-http-requests                         log all HTTP requests, by default only responses with status code >= 500 are logged (env FORWARDER_LOG_HTTP_REQUESTS)
      --basic-auth username:password              HTTP server basic-auth in the form of username:password (env FORWARDER_BASIC_AUTH)
  -u, --upstream-proxy                            upstream proxy URL (env FORWARDER_UPSTREAM_PROXY)
  -t, --proxy-localhost                           proxy localhost requests to an upstream proxy (env FORWARDER_PROXY_LOCALHOST)
  -c, --credentials username:password@host:port   site or upstream proxy basic authentication credentials in the form of username:password@host:port, host and port can be set to "*" to match all (can be specified multiple times) (env FORWARDER_CREDENTIALS) (default [])
  -p, --pac path or URL                           local file path or URL to PAC content, use "-" to read from stdin (env FORWARDER_PAC)
  -n, --dns-server                                DNS server IP or URL ex. 1.1.1.1 or udp://1.1.1.1:53 (can be specified multiple times) (env FORWARDER_DNS_SERVER) (default [])
      --dns-timeout duration                      timeout for DNS queries if DNS server is specified (env FORWARDER_DNS_TIMEOUT) (default 5s)
      --api-protocol                              api HTTP server protocol, one of http, https, h2 (env FORWARDER_API_PROTOCOL) (default http)
      --api-address host:port                     api HTTP server listen address in the form of host:port (env FORWARDER_API_ADDRESS)
      --api-cert-file string                      api HTTP server TLS certificate file (env FORWARDER_API_CERT_FILE)
      --api-key-file string                       api HTTP server TLS key file (env FORWARDER_API_KEY_FILE)
      --api-read-timeout duration                 api HTTP server read timeout (env FORWARDER_API_READ_TIMEOUT) (default 5s)
      --api-log-http-requests                     api log all HTTP requests, by default only responses with status code >= 500 are logged (env FORWARDER_API_LOG_HTTP_REQUESTS)
      --api-basic-auth username:password          api HTTP server basic-auth in the form of username:password (env FORWARDER_API_BASIC_AUTH)
      --http-dial-timeout duration                dial timeout for HTTP connections (env FORWARDER_HTTP_DIAL_TIMEOUT) (default 30s)
      --http-keep-alive duration                  keep alive interval for HTTP connections (env FORWARDER_HTTP_KEEP_ALIVE) (default 30s)
      --http-tls-handshake-timeout duration       TLS handshake timeout for HTTP connections (env FORWARDER_HTTP_TLS_HANDSHAKE_TIMEOUT) (default 10s)
      --http-max-idle-conns int                   maximum number of idle connections for HTTP connections (env FORWARDER_HTTP_MAX_IDLE_CONNS) (default 100)
      --http-max-idle-conns-per-host int          maximum number of idle connections per host for HTTP connections (env FORWARDER_HTTP_MAX_IDLE_CONNS_PER_HOST) (default 11)
      --http-max-conns-per-host int               maximum number of connections per host for HTTP connections (env FORWARDER_HTTP_MAX_CONNS_PER_HOST)
      --http-idle-conn-timeout duration           idle connection timeout for HTTP connections (env FORWARDER_HTTP_IDLE_CONN_TIMEOUT) (default 1m30s)
      --http-response-header-timeout duration     response header timeout for HTTP connections (env FORWARDER_HTTP_RESPONSE_HEADER_TIMEOUT)
      --http-expect-continue-timeout duration     expect continue timeout for HTTP connections (env FORWARDER_HTTP_EXPECT_CONTINUE_TIMEOUT) (default 1s)
      --insecure-skip-verify                      skip TLS verification (env FORWARDER_INSECURE_SKIP_VERIFY)
      --log-file                                  log file path (default: stdout) (env FORWARDER_LOG_FILE)
      --verbose                                   enable verbose logging (env FORWARDER_VERBOSE)
  -h, --help                                      help for proxy
```