### PR TITLE
config: add support for port '*'

### DIFF
--- a/config.go
+++ b/config.go
@@ -43,10 +43,18 @@ func validatedUserInfo(ui *url.Userinfo) error {
 	return nil
 }
 
+func wildcardPortTo0(val string) string {
+	s := strings.Split(val, ":")
+	if s[len(s)-1] == "*" {
+		s[len(s)-1] = "0"
+	}
+	return strings.Join(s, ":")
+}
+
 // ParseHostPortUser parses a user:password@host:port string into HostUser.
 // User and password cannot be empty.
 func ParseHostPortUser(val string) (*HostPortUser, error) {
-	u, err := url.Parse("http://" + val)
+	u, err := url.Parse("http://" + wildcardPortTo0(val))
 	if err != nil {
 		return nil, err
 	}

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -46,6 +46,12 @@ func TestUserInfoMatcherMatch(t *testing.T) {
 			hostport: "xxx:443",
 			expected: url.UserPassword("baz", "pass"),
 		},
+		{
+			name:     "Matches port '*'",
+			input:    []string{"user:pass@abc:*"},
+			hostport: "abc:80",
+			expected: url.UserPassword("user", "pass"),
+		},
 	}
 
 	for i := range tests {


### PR DESCRIPTION
Parsing user:password@host:port string will check if port is '*' and change it to '0'.

Fixes #57