### PR TITLE
cmd/forwarder: group flags in help view

### DIFF
--- a/cmd/forwarder/paceval/paceval.go
+++ b/cmd/forwarder/paceval/paceval.go
@@ -73,6 +73,8 @@ func Command() (cmd *cobra.Command) {
 		bind.HTTPTransportConfig(fs, c.httpTransportConfig)
 
 		bind.MarkFlagFilename(cmd, "pac")
+
+		fs.SortFlags = false
 	}()
 	return &cobra.Command{
 		Use:     "pac-eval --pac <file|url> [flags] <url>...",

--- a/cmd/forwarder/pacserver/pacserver.go
+++ b/cmd/forwarder/pacserver/pacserver.go
@@ -64,11 +64,13 @@ func Command() (cmd *cobra.Command) {
 		fs := cmd.Flags()
 
 		bind.PAC(fs, &c.pac)
-		bind.HTTPTransportConfig(fs, c.httpTransportConfig)
 		bind.HTTPServerConfig(fs, c.httpServerConfig, "", true)
+		bind.HTTPTransportConfig(fs, c.httpTransportConfig)
 		bind.LogConfig(fs, c.logConfig)
 
 		bind.MarkFlagFilename(cmd, "pac", "cert-file", "key-file", "log-file")
+
+		fs.SortFlags = false
 	}()
 	return &cobra.Command{
 		Use:     "pac-server --pac <file|url> [--protocol <http|https|h2>] [--address <host:port>] [flags]",


### PR DESCRIPTION
The flags are groupped:
- core
- api
- http
- log

Fixes #136 