### PR TITLE
chore: add linter to guard copyright header

### DIFF
--- a/.go-header-template.yml
+++ b/.go-header-template.yml
@@ -1,0 +1,3 @@
+Copyright {{YEAR}} The forwarder Authors. All rights reserved.
+Use of this source code is governed by a MPL
+license that can be found in the LICENSE file.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,6 +50,8 @@ linters-settings:
     line-length: 180
   nestif:
     min-complexity: 6
+  goheader:
+    template-path: .go-header-template.yml
 
 issues:
   exclude:

--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-Copyright (c) 2021 Sauce Labs
+Copyright (c) 2022 Sauce Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/api.go
+++ b/api.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package forwarder
 
 import (

--- a/bind/flag.go
+++ b/bind/flag.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package bind
 
 import (

--- a/cert.go
+++ b/cert.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package forwarder
 
 import (

--- a/cert_test.go
+++ b/cert_test.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package forwarder
 
 import (

--- a/cmd/forwarder/decorators.go
+++ b/cmd/forwarder/decorators.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package main
 
 import (

--- a/cmd/forwarder/env.go
+++ b/cmd/forwarder/env.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package main
 
 import (

--- a/cmd/forwarder/ext_e2e.go
+++ b/cmd/forwarder/ext_e2e.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 //go:build e2e
 
 package main

--- a/cmd/forwarder/main.go
+++ b/cmd/forwarder/main.go
@@ -1,5 +1,5 @@
-// Copyright 2021 The forwarder Authors. All rights reserved.
-// Use of this source code is governed by a MIT
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
 // license that can be found in the LICENSE file.
 
 package main

--- a/cmd/forwarder/paceval/paceval.go
+++ b/cmd/forwarder/paceval/paceval.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package paceval
 
 import (

--- a/cmd/forwarder/pacserver/pacserver.go
+++ b/cmd/forwarder/pacserver/pacserver.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package pacserver
 
 import (

--- a/cmd/forwarder/proxy/proxy.go
+++ b/cmd/forwarder/proxy/proxy.go
@@ -1,5 +1,5 @@
-// Copyright 2021 The forwarder Authors. All rights reserved.
-// Use of this source code is governed by a MIT
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
 // license that can be found in the LICENSE file.
 
 package proxy

--- a/cmd/forwarder/root.go
+++ b/cmd/forwarder/root.go
@@ -1,5 +1,5 @@
-// Copyright 2021 The forwarder Authors. All rights reserved.
-// Use of this source code is governed by a MIT
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
 // license that can be found in the LICENSE file.
 
 package main

--- a/cmd/forwarder/version/version.go
+++ b/cmd/forwarder/version/version.go
@@ -1,7 +1,6 @@
-// Copyright 2021 The forwarder Authors. All rights reserved.
-// Use of this source code is governed by a MIT
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
 // license that can be found in the LICENSE file.
-
 package version
 
 import (

--- a/config.go
+++ b/config.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package forwarder
 
 import (

--- a/config_test.go
+++ b/config_test.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package forwarder
 
 import (

--- a/credentials.go
+++ b/credentials.go
@@ -1,7 +1,6 @@
-// Copyright 2021 The forwarder Authors. All rights reserved.
-// Use of this source code is governed by a MIT
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
 // license that can be found in the LICENSE file.
-
 package forwarder
 
 import (

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -1,5 +1,5 @@
-// Copyright 2021 The forwarder Authors. All rights reserved.
-// Use of this source code is governed by a MIT
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
 // license that can be found in the LICENSE file.
 
 package forwarder

--- a/dns.go
+++ b/dns.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package forwarder
 
 import (

--- a/dns_test.go
+++ b/dns_test.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package forwarder
 
 import (

--- a/doc.go
+++ b/doc.go
@@ -1,5 +1,5 @@
-// Copyright 2021 The forwarder Authors. All rights reserved.
-// Use of this source code is governed by a MIT
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
 // license that can be found in the LICENSE file.
 
 // Package forwarder provides a simple forward proxy server.

--- a/fileurl/fileurl.go
+++ b/fileurl/fileurl.go
@@ -1,3 +1,6 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
 package fileurl
 
 import (

--- a/fileurl/fileurl_test.go
+++ b/fileurl/fileurl_test.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package fileurl
 
 import (

--- a/hosts.go
+++ b/hosts.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package forwarder
 
 import (

--- a/hosts_test.go
+++ b/hosts_test.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package forwarder
 
 import "testing"

--- a/http_error.go
+++ b/http_error.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package forwarder
 
 import (

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -1,7 +1,6 @@
-// Copyright 2021 The forwarder Authors. All rights reserved.
-// Use of this source code is governed by a MIT
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
 // license that can be found in the LICENSE file.
-
 package forwarder
 
 import (

--- a/http_server.go
+++ b/http_server.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package forwarder
 
 import (

--- a/http_transport.go
+++ b/http_transport.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package forwarder
 
 import (

--- a/httpbin/sse.go
+++ b/httpbin/sse.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package httpbin
 
 import (

--- a/httpbin/ws.go
+++ b/httpbin/ws.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package httpbin
 
 import (

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package version
 
 var (

--- a/log.go
+++ b/log.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package forwarder
 
 // Logger is the logger used by the forwarder package.

--- a/log/config.go
+++ b/log/config.go
@@ -1,3 +1,6 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
 package log
 
 import (

--- a/log/stdlog/stdlog.go
+++ b/log/stdlog/stdlog.go
@@ -1,3 +1,6 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
 package stdlog
 
 import (

--- a/middleware/basic_auth.go
+++ b/middleware/basic_auth.go
@@ -1,3 +1,8 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+//
+
 package middleware
 
 import (

--- a/middleware/basic_auth_test.go
+++ b/middleware/basic_auth_test.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package middleware
 
 import (

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -1,3 +1,8 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+//
+
 package middleware
 
 import (

--- a/middleware/prometheus.go
+++ b/middleware/prometheus.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package middleware
 
 import (

--- a/middleware/prometheus_test.go
+++ b/middleware/prometheus_test.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package middleware
 
 import (

--- a/pac.go
+++ b/pac.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package forwarder
 
 import "net/url"

--- a/pac/doc.go
+++ b/pac/doc.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 // Package pac provides a PAC file parser and evaluator.
 // Under the hood uses Goja JavaScript VM to run the PAC script.
 // It supports Mozilla FindProxyForURL and the Microsoft IPv6 extension FindProxyForURLEx as well as all the helper functions as described in the PAC specification.

--- a/pac/embed.go
+++ b/pac/embed.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package pac
 
 import _ "embed"

--- a/pac/export_test.go
+++ b/pac/export_test.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package pac
 
 import "github.com/dop251/goja"

--- a/pac/netutil.go
+++ b/pac/netutil.go
@@ -1,3 +1,6 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
 package pac
 
 import "net"

--- a/pac/pac.go
+++ b/pac/pac.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package pac
 
 import (

--- a/pac/pac_ipv4.go
+++ b/pac/pac_ipv4.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package pac
 
 import (

--- a/pac/pac_ipv6.go
+++ b/pac/pac_ipv6.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package pac
 
 import (

--- a/pac/pac_test.go
+++ b/pac/pac_test.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package pac
 
 import (

--- a/pac/pool.go
+++ b/pac/pool.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package pac
 
 import (

--- a/pac/pool_test.go
+++ b/pac/pool_test.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package pac
 
 import (

--- a/pac/proxy.go
+++ b/pac/proxy.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package pac
 
 import (

--- a/pac/proxy_test.go
+++ b/pac/proxy_test.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package pac
 
 import (

--- a/pac/utils.go
+++ b/pac/utils.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package pac
 
 import (

--- a/readurl.go
+++ b/readurl.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package forwarder
 
 import (

--- a/runctx/runctx.go
+++ b/runctx/runctx.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package runctx
 
 import (

--- a/tls.go
+++ b/tls.go
@@ -1,3 +1,7 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package forwarder
 
 type TLSConfig struct {


### PR DESCRIPTION
This patch adds  copyright headers to all `.go` files and a linter to guard them. 