### PR TITLE
http_proxy: add ProxyLocalhost=direct mode

### DIFF
--- a/bind/flag.go
+++ b/bind/flag.go
@@ -32,8 +32,14 @@ func HTTPProxyConfig(fs *pflag.FlagSet, cfg *forwarder.HTTPProxyConfig) {
 	HTTPServerConfig(fs, &cfg.HTTPServerConfig, "", false)
 	fs.VarP(anyflag.NewValue[*url.URL](cfg.UpstreamProxy, &cfg.UpstreamProxy, forwarder.ParseProxyURL),
 		"upstream-proxy", "u", "upstream proxy URL")
-	fs.BoolVarP(&cfg.ProxyLocalhost, "proxy-localhost", "t", cfg.ProxyLocalhost,
-		"proxy localhost requests to an upstream proxy")
+
+	proxyLocalhostValues := []forwarder.ProxyLocalhostMode{
+		forwarder.DenyProxyLocalhost,
+		forwarder.AllowProxyLocalhost,
+		forwarder.DirectProxyLocalhost,
+	}
+	fs.VarP(anyflag.NewValue[forwarder.ProxyLocalhostMode](cfg.ProxyLocalhost, &cfg.ProxyLocalhost, anyflag.EnumParser[forwarder.ProxyLocalhostMode](proxyLocalhostValues...)),
+		"proxy-localhost", "t", "accept or deny requests to localhost, one of deny, allow, direct; in direct mode localhost requests are not sent to upstream proxy if present")
 }
 
 func HTTPTransportConfig(fs *pflag.FlagSet, cfg *forwarder.HTTPTransportConfig) {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -164,7 +164,7 @@ func TestProxyLocalhost(t *testing.T) {
 	}
 
 	for _, h := range hosts {
-		if os.Getenv("FORWARDER_PROXY_LOCALHOST") == "true" {
+		if os.Getenv("FORWARDER_PROXY_LOCALHOST") == "allow" {
 			Expect(t, "http://"+net.JoinHostPort(h, "10000")).GET("/version").Expect().Status(http.StatusOK)
 		} else {
 			Expect(t, "http://"+net.JoinHostPort(h, "10000")).GET("/version").Expect().Status(http.StatusBadGateway)

--- a/e2e/override/proxy-localhost.yaml
+++ b/e2e/override/proxy-localhost.yaml
@@ -3,4 +3,4 @@ version: "3.8"
 services:
   proxy:
     environment:
-      FORWARDER_PROXY_LOCALHOST: "true"
+      FORWARDER_PROXY_LOCALHOST: "allow"

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/martian/v3 v3.1.0
 	github.com/gorilla/websocket v1.5.0
-	github.com/kevinburke/hostsfile v0.0.0-20220522040509-e5e984885321
 	github.com/mmatczuk/anyflag v0.0.0-20221011091730-9f8baeb6fd9c
 	github.com/prometheus/client_golang v1.13.0
 	github.com/prometheus/common v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,6 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
-github.com/kevinburke/hostsfile v0.0.0-20220522040509-e5e984885321 h1:zfI6ImDFFLxvWztL5C7pigHTGyjfI3EtS/UDaDKk7dg=
-github.com/kevinburke/hostsfile v0.0.0-20220522040509-e5e984885321/go.mod h1:jxc0FMWcuW3a+dQiKqEesZGT5abRU8gFVbdJaykah/g=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=


### PR DESCRIPTION
ProxyLocalhost is changed to enum, available values are:
- deny (former false)
- allow (former true)
- direct

In the direct mode requests to localhost are allowed but are not sent to upstream proxy.

Fixes #176