### PR TITLE
goreleaser: docker manifests, make image templates use tag or version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -89,5 +89,5 @@ dockers:
 docker_manifests:
     - name_template: "saucelabs/{{ .ProjectName }}:{{ .Version }}"
       image_templates:
-        - "saucelabs/{{ .ProjectName }}:{{ .Tag }}-amd64"
-        - "saucelabs/{{ .ProjectName }}:{{ .Tag }}-arm64v8"
+        - "{{ if .IsSnapshot }}saucelabs/{{ .ProjectName }}:{{ .Tag }}-amd64{{ else }}saucelabs/{{ .ProjectName }}:{{ .Version }}-amd64{{ end }}"
+        - "{{ if .IsSnapshot }}saucelabs/{{ .ProjectName }}:{{ .Tag }}-arm64v8{{ else }}saucelabs/{{ .ProjectName }}:{{ .Version }}-arm64v8{{ end }}"


### PR DESCRIPTION
This patch puts the same `image_templates` values to `docker_manifests` as in `dockers`.

Before this patch goreleaser would make `dockers/image_templates` with {{ .Version }}, but later fail on making `docker_manifests` with **{{ .Tag }}**.