### PR TITLE
middleware: use prometheus to gather proxy traffic metrics

### DIFF
--- a/http_proxy.go
+++ b/http_proxy.go
@@ -258,6 +258,12 @@ func (hp *HTTPProxy) middlewareStack() martian.RequestResponseModifier {
 	fg.AddRequestModifier(logHTTP)
 	fg.AddResponseModifier(logHTTP)
 
+	if hp.config.HTTPServerConfig.Addr != "" {
+		p := middleware.NewPrometheus(hp.config.PromRegistry, hp.config.PromNamespace)
+		stack.AddRequestModifier(p)
+		stack.AddResponseModifier(p)
+	}
+
 	fg.AddRequestModifier(martian.RequestModifierFunc(hp.setBasicAuth))
 
 	return topg.ToImmutable()


### PR DESCRIPTION
This patch implements `martian.RequestResponseModifier` interface for Prometheus object, so that it can gather proxy traffic metrics. 