### PR TITLE
credentials: support matching empty urls

### DIFF
--- a/credentials.go
+++ b/credentials.go
@@ -88,7 +88,7 @@ func NewCredentialsMatcher(credentials []*HostPortUser, log Logger) (*Credential
 
 // MatchURL adds standard http and https ports if they are missing in URL and calls Match function.
 func (m *CredentialsMatcher) MatchURL(u *url.URL) *url.Userinfo {
-	if m == nil {
+	if m == nil || u == nil {
 		return nil
 	}
 


### PR DESCRIPTION
When pac resolves proxy mode to `DIRECT` the url is nil. This would cause panics in `CredentialsMatcher.MatchUrl(nil)`. CredentialsMatcher will now check if url is nil, to avoid nil pointer dereference.

Fixes #192