### PR TITLE
http proxy: enable connect passthrough

### DIFF
--- a/bind/flag.go
+++ b/bind/flag.go
@@ -43,6 +43,7 @@ func HTTPProxyConfig(fs *pflag.FlagSet, cfg *forwarder.HTTPProxyConfig) {
 		"proxy-localhost", "t", "accept or deny requests to localhost, one of deny, allow, direct; in direct mode localhost requests are not sent to upstream proxy if present")
 
 	fs.StringSliceVar(&cfg.RemoveHeaders, "remove-headers", cfg.RemoveHeaders, "removes request headers if prefixes match (can be specified multiple times)")
+	fs.BoolVar(&cfg.ConnectPassthrough, "connect-passthrough", cfg.ConnectPassthrough, "round trip CONNECT requests")
 }
 
 func HTTPTransportConfig(fs *pflag.FlagSet, cfg *forwarder.HTTPTransportConfig) {

--- a/go.mod
+++ b/go.mod
@@ -48,4 +48,4 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
-replace github.com/google/martian/v3 => github.com/saucelabs/martian/v3 v3.0.0-20221227135800-27a8c8fc6193
+replace github.com/google/martian/v3 => github.com/saucelabs/martian/v3 v3.0.0-20230127123942-1af3e05ac248

--- a/go.sum
+++ b/go.sum
@@ -242,8 +242,8 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/saucelabs/martian/v3 v3.0.0-20221227135800-27a8c8fc6193 h1:/fIeaV4CD5IFU5zbVjSIHytlMAwJGEeqSBfG8sxZWQw=
-github.com/saucelabs/martian/v3 v3.0.0-20221227135800-27a8c8fc6193/go.mod h1:qTXMpLvQ7jzQg40dFPMXJi4+ncyK+DTmPs4KOmsWKOk=
+github.com/saucelabs/martian/v3 v3.0.0-20230127123942-1af3e05ac248 h1:Jul88t5PvQX6Rh/ilSLWkC6ssOTeIoRcSeNID7h21Qo=
+github.com/saucelabs/martian/v3 v3.0.0-20230127123942-1af3e05ac248/go.mod h1:qTXMpLvQ7jzQg40dFPMXJi4+ncyK+DTmPs4KOmsWKOk=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -60,13 +60,14 @@ type ProxyFunc func(*http.Request) (*url.URL, error)
 
 type HTTPProxyConfig struct {
 	HTTPServerConfig
-	ProxyLocalhost    ProxyLocalhostMode         `json:"proxy_localhost"`
-	UpstreamProxy     *url.URL                   `json:"upstream_proxy_uri"`
-	UpstreamProxyFunc ProxyFunc                  `json:"-"`
-	RequestModifiers  []martian.RequestModifier  `json:"-"`
-	ResponseModifiers []martian.ResponseModifier `json:"-"`
-	CloseAfterReply   bool                       `json:"close_after_reply"`
-	RemoveHeaders     []string                   `json:"remove_headers"`
+	ProxyLocalhost     ProxyLocalhostMode         `json:"proxy_localhost"`
+	UpstreamProxy      *url.URL                   `json:"upstream_proxy_uri"`
+	UpstreamProxyFunc  ProxyFunc                  `json:"-"`
+	RequestModifiers   []martian.RequestModifier  `json:"-"`
+	ResponseModifiers  []martian.ResponseModifier `json:"-"`
+	CloseAfterReply    bool                       `json:"close_after_reply"`
+	RemoveHeaders      []string                   `json:"remove_headers"`
+	ConnectPassthrough bool                       `json:"connect_passthrough"`
 }
 
 func DefaultHTTPProxyConfig() *HTTPProxyConfig {
@@ -162,6 +163,11 @@ func (hp *HTTPProxy) configureProxy() {
 	hp.proxy.ReadTimeout = hp.config.ReadTimeout
 	hp.proxy.ReadHeaderTimeout = hp.config.ReadHeaderTimeout
 	hp.proxy.WriteTimeout = hp.config.WriteTimeout
+	hp.proxy.ConnectPassthrough = hp.config.ConnectPassthrough
+	if hp.config.ConnectPassthrough {
+		hp.log.Infof("connect passthrough enabled")
+	}
+
 	// Martian has an intertwined logic for setting http.Transport and the dialer.
 	// The dialer is wrapped, so that additional syscalls are made to the dialed connections.
 	// As a result the dialer needs to be reset.


### PR DESCRIPTION
CONNECT requests will be handled as normal request (i.e. round tripped) when passthrough is enabled.

Fixes #196