### PR TITLE
dockerfile: use distroless base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,6 @@
-FROM ubuntu:22.10
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates curl && \
-    apt-get clean && \
-    apt-get autoremove && \
-    rm -rf /var/lib/apt/lists/*
+FROM gcr.io/distroless/static:nonroot
 
 COPY forwarder /usr/bin/forwarder
 ENTRYPOINT ["/usr/bin/forwarder"]
-CMD ["proxy", "--api-address", ":10000"]
+CMD ["proxy"]
 
-HEALTHCHECK --interval=1s --timeout=250ms --retries=10 CMD ["curl", "-s", "-S", "-f", "http://localhost:10000/readyz"]

--- a/cmd/forwarder/proxy/proxy.go
+++ b/cmd/forwarder/proxy/proxy.go
@@ -179,7 +179,7 @@ func Command() (cmd *cobra.Command) {
 		logConfig:           log.DefaultConfig(),
 	}
 	c.httpProxyConfig.PromRegistry = c.promReg
-	c.apiServerConfig.Addr = ""
+	c.apiServerConfig.Addr = "localhost:10000"
 
 	defer func() {
 		fs := cmd.Flags()

--- a/e2e/docker-compose.yaml
+++ b/e2e/docker-compose.yaml
@@ -3,10 +3,6 @@ version: "3.8"
 services:
   proxy:
     image: saucelabs/forwarder:${FORWARDER_VERSION}
-    healthcheck:
-      interval: 1s
-      timeout: 250ms
-      retries: 10
 
   upstream-proxy:
     extends: proxy


### PR DESCRIPTION
This patch trims down Docker base image to bare minimum, namely [1]:
* ca-certificates
* /tmp directory
* tzdata

In addition to that
- API server is started by default on localhost:10000, default is moved to cmd
- HEALTHCHECK in Dockerfile is removed

[1] https://github.com/GoogleContainerTools/distroless/blob/main/base/README.md