### PR TITLE
cmd,bind: group logging flags together

### DIFF
--- a/bind/flag.go
+++ b/bind/flag.go
@@ -29,8 +29,9 @@ func PAC(fs *pflag.FlagSet, pac **url.URL) {
 		"pac", "p", "local file `path or URL` to PAC content, use \"-\" to read from stdin")
 }
 
-func HTTPProxyConfig(fs *pflag.FlagSet, cfg *forwarder.HTTPProxyConfig) {
+func HTTPProxyConfig(fs *pflag.FlagSet, cfg *forwarder.HTTPProxyConfig, lcfg *log.Config) {
 	HTTPServerConfig(fs, &cfg.HTTPServerConfig, "", false)
+	LogConfig(fs, lcfg)
 	fs.VarP(anyflag.NewValue[*url.URL](cfg.UpstreamProxy, &cfg.UpstreamProxy, forwarder.ParseProxyURL),
 		"upstream-proxy", "u", "upstream proxy URL")
 
@@ -100,10 +101,10 @@ func HTTPServerConfig(fs *pflag.FlagSet, cfg *forwarder.HTTPServerConfig, prefix
 		namePrefix+"read-header-timeout", cfg.ReadHeaderTimeout, usagePrefix+"HTTP server read header timeout")
 	fs.DurationVar(&cfg.WriteTimeout,
 		namePrefix+"write-timeout", cfg.WriteTimeout, usagePrefix+"HTTP server write timeout")
-	fs.Var(anyflag.NewValue[httplog.LoggerMode](cfg.LogHTTPMode, &cfg.LogHTTPMode, httplog.ParseMode),
-		namePrefix+"log-http-requests", usagePrefix+"log http request, one of url, headers, body, error; error mode is default and logs requests with status code >= 500")
 	fs.VarP(anyflag.NewValue[*url.Userinfo](cfg.BasicAuth, &cfg.BasicAuth, forwarder.ParseUserInfo),
 		namePrefix+"basic-auth", "", usagePrefix+"HTTP server basic-auth in the form of `username:password`")
+	fs.Var(anyflag.NewValue[httplog.LoggerMode](cfg.LogHTTPMode, &cfg.LogHTTPMode, httplog.ParseMode),
+		namePrefix+"log-http-requests", usagePrefix+"log http request, one of url, headers, body, error; error mode is default and logs requests with status code >= 500")
 }
 
 func TLSConfig(fs *pflag.FlagSet, cfg *forwarder.TLSConfig) {

--- a/cmd/forwarder/pacserver/pacserver.go
+++ b/cmd/forwarder/pacserver/pacserver.go
@@ -69,8 +69,8 @@ func Command() (cmd *cobra.Command) {
 
 		bind.PAC(fs, &c.pac)
 		bind.HTTPServerConfig(fs, c.httpServerConfig, "", true)
-		bind.HTTPTransportConfig(fs, c.httpTransportConfig)
 		bind.LogConfig(fs, c.logConfig)
+		bind.HTTPTransportConfig(fs, c.httpTransportConfig)
 
 		bind.MarkFlagFilename(cmd, "pac", "cert-file", "key-file", "log-file")
 

--- a/cmd/forwarder/proxy/proxy.go
+++ b/cmd/forwarder/proxy/proxy.go
@@ -183,7 +183,7 @@ func Command() (cmd *cobra.Command) {
 
 	defer func() {
 		fs := cmd.Flags()
-		bind.HTTPProxyConfig(fs, c.httpProxyConfig)
+		bind.HTTPProxyConfig(fs, c.httpProxyConfig, c.logConfig)
 		fs.VarP(anyflag.NewSliceValue[*forwarder.HostPortUser](c.credentials, &c.credentials, forwarder.ParseHostPortUser),
 			"credentials", "c",
 			"site or upstream proxy basic authentication credentials in the form of `username:password@host:port`, "+
@@ -192,7 +192,6 @@ func Command() (cmd *cobra.Command) {
 		bind.DNSConfig(fs, c.dnsConfig)
 		bind.HTTPServerConfig(fs, c.apiServerConfig, "api", true)
 		bind.HTTPTransportConfig(fs, c.httpTransportConfig)
-		bind.LogConfig(fs, c.logConfig)
 
 		bind.MarkFlagFilename(cmd, "cert-file", "key-file", "pac")
 		cmd.MarkFlagsMutuallyExclusive("upstream-proxy", "pac")


### PR DESCRIPTION
`forwarder help proxy`:
```
Flags:
      --protocol                                  HTTP server protocol, one of http, https (env FORWARDER_PROTOCOL) (default http)
      --address host:port                         HTTP server listen address in the form of host:port (env FORWARDER_ADDRESS) (default ":3128")
      --cert-file string                          HTTP server TLS certificate file (env FORWARDER_CERT_FILE)
      --key-file string                           HTTP server TLS key file (env FORWARDER_KEY_FILE)
      --read-timeout duration                     HTTP server read timeout (env FORWARDER_READ_TIMEOUT)
      --read-header-timeout duration              HTTP server read header timeout (env FORWARDER_READ_HEADER_TIMEOUT) (default 1m0s)
      --write-timeout duration                    HTTP server write timeout (env FORWARDER_WRITE_TIMEOUT)
      --basic-auth username:password              HTTP server basic-auth in the form of username:password (env FORWARDER_BASIC_AUTH)
      --log-http-requests                         log http request, one of url, headers, body, error; error mode is default and logs requests with status code >= 500 (env FORWARDER_LOG_HTTP_REQUESTS) (default error)
      --log-file                                  log file path (default: stdout) (env FORWARDER_LOG_FILE)
      --verbose                                   enable verbose logging (env FORWARDER_VERBOSE)
  -u, --upstream-proxy                            upstream proxy URL (env FORWARDER_UPSTREAM_PROXY)
  -t, --proxy-localhost                           accept or deny requests to localhost, one of deny, allow, direct; in direct mode localhost requests are not sent to upstream proxy if present (env FORWARDER_PROXY_LOCALHOST) (default deny)
      --remove-headers strings                    removes request headers if prefixes match (can be specified multiple times) (env FORWARDER_REMOVE_HEADERS)
  -c, --credentials username:password@host:port   site or upstream proxy basic authentication credentials in the form of username:password@host:port, host and port can be set to "*" to match all (can be specified multiple times) (env FORWARDER_CREDENTIALS) (default [])
  -p, --pac path or URL                           local file path or URL to PAC content, use "-" to read from stdin (env FORWARDER_PAC)
  -n, --dns-server                                DNS server IP or URL ex. 1.1.1.1 or udp://1.1.1.1:53 (can be specified multiple times) (env FORWARDER_DNS_SERVER) (default [])
      --dns-timeout duration                      timeout for DNS queries if DNS server is specified (env FORWARDER_DNS_TIMEOUT) (default 5s)
      --api-protocol                              api HTTP server protocol, one of http, https, h2 (env FORWARDER_API_PROTOCOL) (default http)
      --api-address host:port                     api HTTP server listen address in the form of host:port (env FORWARDER_API_ADDRESS) (default "localhost:10000")
      --api-cert-file string                      api HTTP server TLS certificate file (env FORWARDER_API_CERT_FILE)
      --api-key-file string                       api HTTP server TLS key file (env FORWARDER_API_KEY_FILE)
      --api-read-timeout duration                 api HTTP server read timeout (env FORWARDER_API_READ_TIMEOUT)
      --api-read-header-timeout duration          api HTTP server read header timeout (env FORWARDER_API_READ_HEADER_TIMEOUT) (default 1m0s)
      --api-write-timeout duration                api HTTP server write timeout (env FORWARDER_API_WRITE_TIMEOUT)
      --api-basic-auth username:password          api HTTP server basic-auth in the form of username:password (env FORWARDER_API_BASIC_AUTH)
      --api-log-http-requests                     api log http request, one of url, headers, body, error; error mode is default and logs requests with status code >= 500 (env FORWARDER_API_LOG_HTTP_REQUESTS) (default error)
      --http-dial-timeout duration                dial timeout for HTTP connections (env FORWARDER_HTTP_DIAL_TIMEOUT) (default 30s)
      --http-keep-alive duration                  keep alive interval for HTTP connections (env FORWARDER_HTTP_KEEP_ALIVE) (default 30s)
      --http-tls-handshake-timeout duration       TLS handshake timeout for HTTP connections (env FORWARDER_HTTP_TLS_HANDSHAKE_TIMEOUT) (default 10s)
      --http-max-idle-conns int                   maximum number of idle connections for HTTP connections (env FORWARDER_HTTP_MAX_IDLE_CONNS) (default 100)
      --http-max-idle-conns-per-host int          maximum number of idle connections per host for HTTP connections (env FORWARDER_HTTP_MAX_IDLE_CONNS_PER_HOST) (default 11)
      --http-max-conns-per-host int               maximum number of connections per host for HTTP connections (env FORWARDER_HTTP_MAX_CONNS_PER_HOST)
      --http-idle-conn-timeout duration           idle connection timeout for HTTP connections (env FORWARDER_HTTP_IDLE_CONN_TIMEOUT) (default 1m30s)
      --http-response-header-timeout duration     response header timeout for HTTP connections (env FORWARDER_HTTP_RESPONSE_HEADER_TIMEOUT)
      --http-expect-continue-timeout duration     expect continue timeout for HTTP connections (env FORWARDER_HTTP_EXPECT_CONTINUE_TIMEOUT) (default 1s)
      --insecure-skip-verify                      skip TLS verification (env FORWARDER_INSECURE_SKIP_VERIFY)
  -h, --help                                      help for proxy
```

Fixes #200