### PR TITLE
log: ingest Logger interface

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -68,6 +68,7 @@ issues:
     - "can be `fmt.Stringer`"
     - "returns interface \\(github.com/dop251/goja\\.Value\\)"
     - "returns interface \\(github.com/google/martian/v3\\.(Request|Response)+Modifier\\)"
+    - "shadow of imported from 'github.com/saucelabs/forwarder/log' package 'log'"
     - "string `https?` has \\d+ occurrences"
 
   exclude-rules:

--- a/cmd/forwarder/paceval/paceval.go
+++ b/cmd/forwarder/paceval/paceval.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/saucelabs/forwarder"
 	"github.com/saucelabs/forwarder/bind"
+	"github.com/saucelabs/forwarder/log"
 	"github.com/saucelabs/forwarder/pac"
 	"github.com/spf13/cobra"
 )
@@ -25,7 +26,7 @@ type command struct {
 func (c *command) RunE(cmd *cobra.Command, args []string) error {
 	var resolver *net.Resolver
 	if len(c.dnsConfig.Servers) > 0 {
-		r, err := forwarder.NewResolver(c.dnsConfig, forwarder.NopLogger)
+		r, err := forwarder.NewResolver(c.dnsConfig, log.NopLogger)
 		if err != nil {
 			return err
 		}

--- a/credentials.go
+++ b/credentials.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+
+	"github.com/saucelabs/forwarder/log"
 )
 
 type HostPortUser struct {
@@ -34,10 +36,10 @@ type CredentialsMatcher struct {
 	host     map[string]*url.Userinfo
 	port     map[string]*url.Userinfo
 	global   *url.Userinfo
-	log      Logger
+	log      log.Logger
 }
 
-func NewCredentialsMatcher(credentials []*HostPortUser, log Logger) (*CredentialsMatcher, error) {
+func NewCredentialsMatcher(credentials []*HostPortUser, log log.Logger) (*CredentialsMatcher, error) {
 	if len(credentials) == 0 {
 		return nil, nil //nolint:nilnil // nil is a valid value
 	}

--- a/dns.go
+++ b/dns.go
@@ -10,6 +10,8 @@ import (
 	"net"
 	"net/url"
 	"time"
+
+	"github.com/saucelabs/forwarder/log"
 )
 
 type DNSConfig struct {
@@ -45,10 +47,10 @@ type resolver struct {
 	resolver net.Resolver
 	dialer   net.Dialer
 	servers  []*url.URL
-	log      Logger
+	log      log.Logger
 }
 
-func NewResolver(cfg *DNSConfig, log Logger) (*net.Resolver, error) {
+func NewResolver(cfg *DNSConfig, log log.Logger) (*net.Resolver, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/martian/v3/fifo"
 	"github.com/google/martian/v3/httpspec"
 	"github.com/saucelabs/forwarder/httplog"
+	"github.com/saucelabs/forwarder/log"
 	"github.com/saucelabs/forwarder/middleware"
 	"github.com/saucelabs/forwarder/pac"
 )
@@ -103,14 +104,14 @@ type HTTPProxy struct {
 	pac       PACResolver
 	creds     *CredentialsMatcher
 	transport http.RoundTripper
-	log       Logger
+	log       log.Logger
 	proxy     *martian.Proxy
 	addr      atomic.Pointer[string]
 
 	TLSConfig *tls.Config
 }
 
-func NewHTTPProxy(cfg *HTTPProxyConfig, pr PACResolver, cm *CredentialsMatcher, rt http.RoundTripper, log Logger) (*HTTPProxy, error) {
+func NewHTTPProxy(cfg *HTTPProxyConfig, pr PACResolver, cm *CredentialsMatcher, rt http.RoundTripper, log log.Logger) (*HTTPProxy, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}

--- a/http_server.go
+++ b/http_server.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/saucelabs/forwarder/httplog"
+	"github.com/saucelabs/forwarder/log"
 	"github.com/saucelabs/forwarder/middleware"
 )
 
@@ -124,12 +125,12 @@ func (c *HTTPServerConfig) loadCertificate(tlsCfg *tls.Config) error {
 
 type HTTPServer struct {
 	config HTTPServerConfig
-	log    Logger
+	log    log.Logger
 	srv    *http.Server
 	addr   atomic.Pointer[string]
 }
 
-func NewHTTPServer(cfg *HTTPServerConfig, h http.Handler, log Logger) (*HTTPServer, error) {
+func NewHTTPServer(cfg *HTTPServerConfig, h http.Handler, log log.Logger) (*HTTPServer, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
@@ -162,7 +163,7 @@ func NewHTTPServer(cfg *HTTPServerConfig, h http.Handler, log Logger) (*HTTPServ
 	return hs, nil
 }
 
-func withMiddleware(cfg *HTTPServerConfig, log Logger, h http.Handler) http.Handler {
+func withMiddleware(cfg *HTTPServerConfig, log log.Logger, h http.Handler) http.Handler {
 	// Note that the order of execution is reversed.
 	if cfg.BasicAuth != nil {
 		p, _ := cfg.BasicAuth.Password()

--- a/log/log.go
+++ b/log/log.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MPL
 // license that can be found in the LICENSE file.
 
-package forwarder
+package log
 
 // Logger is the logger used by the forwarder package.
 type Logger interface {

--- a/pac.go
+++ b/pac.go
@@ -4,7 +4,11 @@
 
 package forwarder
 
-import "net/url"
+import (
+	"net/url"
+
+	"github.com/saucelabs/forwarder/log"
+)
 
 type PACResolver interface {
 	// FindProxyForURL calls FindProxyForURL or FindProxyForURLEx function in the PAC script.
@@ -14,7 +18,7 @@ type PACResolver interface {
 
 type LoggingPACResolver struct {
 	Resolver PACResolver
-	Logger   Logger
+	Logger   log.Logger
 }
 
 func (r *LoggingPACResolver) FindProxyForURL(u *url.URL, hostname string) (string, error) {


### PR DESCRIPTION
This patch moves forwarder.Logger into log.Logger. It enables using logger in subpackages without a need to redefine it every time.