### PR TITLE
httpbin: do not use rand

### DIFF
--- a/httpbin/httpbin.go
+++ b/httpbin/httpbin.go
@@ -1,9 +1,12 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
 package httpbin
 
 import (
 	"fmt"
 	"io"
-	"math/rand"
 	"net/http"
 	"strconv"
 	"strings"
@@ -84,8 +87,6 @@ func statusHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-var rnd = rand.NewSource(time.Now().Unix())
-
 // streamBytesHandler implements the /stream-bytes/{bytes} endpoint.
 // See https://httpbin.org/#/Dynamic_data/get_stream_bytes__n_
 func streamBytesHandler(w http.ResponseWriter, r *http.Request) {
@@ -107,7 +108,11 @@ func streamBytesHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.WriteHeader(http.StatusOK)
-	io.CopyBuffer(w, io.LimitReader(rand.New(rnd), int64(n)), make([]byte, chunkSize))
+
+	io.CopyBuffer(w, &patternReader{
+		Pattern: []byte("SauceLabs"),
+		N:       int64(n),
+	}, make([]byte, chunkSize))
 }
 
 func atoi(w http.ResponseWriter, s string) (int, bool) {

--- a/httpbin/io.go
+++ b/httpbin/io.go
@@ -1,0 +1,36 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
+package httpbin
+
+import (
+	"io"
+)
+
+type patternReader struct {
+	Pattern []byte
+	N       int64
+}
+
+func (l *patternReader) Read(p []byte) (int, error) {
+	if l.N <= 0 {
+		return 0, io.EOF
+	}
+
+	if int64(len(p)) > l.N {
+		p = p[:l.N]
+	}
+	var n int
+	for {
+		n0 := copy(p, l.Pattern)
+		n += n0
+		if n0 < len(l.Pattern) {
+			break
+		}
+		p = p[n0:]
+	}
+
+	l.N -= int64(n)
+	return n, nil
+}

--- a/httpbin/io_test.go
+++ b/httpbin/io_test.go
@@ -1,0 +1,27 @@
+// Copyright 2022 The forwarder Authors. All rights reserved.
+// Use of this source code is governed by a MPL
+// license that can be found in the LICENSE file.
+
+package httpbin
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func TestPatternReader(t *testing.T) {
+	r := &patternReader{
+		Pattern: []byte("0123456789"),
+		N:       int64(75),
+	}
+	var buf bytes.Buffer
+	n, err := io.Copy(&buf, r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 75 {
+		t.Fatalf("n=%d, want 75", n)
+	}
+	t.Log(buf.String())
+}


### PR DESCRIPTION
As random computations are expensive this is a green alternative. It replaces random bloat with and endless "SauceLabs" tapestry.

Fixes #228