### PR TITLE
Improved format of configuration description

### DIFF
--- a/bind/flag.go
+++ b/bind/flag.go
@@ -201,7 +201,7 @@ func DescribeFlags(flags *pflag.FlagSet) string {
 		if flag.Hidden || flag.Name == "help" {
 			return
 		}
-		b.WriteString(fmt.Sprintf("%s: %q\n", flag.Name, flag.Value))
+		b.WriteString(fmt.Sprintf("%s=%s\n", flag.Name, strings.Trim(flag.Value.String(), "[]")))
 	})
 	return b.String()
 }


### PR DESCRIPTION
New format: 
```
./fwd run --verbose --dns-server=1.2.3.4:53,5.6.7.8:53

2023/03/23 10:34:59 DEBUG: configuration
address=:3128
api-address=localhost:10000
api-basic-auth=
api-cert-file=
api-key-file=
api-log-http=errors
api-protocol=http
api-read-header-timeout=1m0s
api-read-timeout=0s
api-write-timeout=0s
basic-auth=
cert-file=
config-file=
credentials=
dns-server=1.2.3.4:53,5.6.7.8:53
dns-timeout=5s
http-dial-timeout=30s
http-expect-continue-timeout=1s
http-idle-conn-timeout=1m30s
http-keep-alive=30s
http-max-conns-per-host=0
http-max-idle-conns=100
http-max-idle-conns-per-host=11
http-response-header-timeout=0s
http-tls-handshake-timeout=10s
insecure-skip-verify=false
key-file=
log-file=
log-http=errors
pac=
protocol=http
proxy-localhost=deny
read-header-timeout=1m0s
read-timeout=0s
remove-headers=
upstream-proxy=
verbose=true
write-timeout=0s
```

I like it. I find this to be more straightforward. 