### PR TITLE
replace verbosity with log levels

### DIFF
--- a/bind/flag.go
+++ b/bind/flag.go
@@ -160,7 +160,13 @@ func LogConfig(fs *pflag.FlagSet, cfg *log.Config) {
 	fs.VarP(anyflag.NewValue[*os.File](nil, &cfg.File,
 		forwarder.OpenFileParser(os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600, 0o700)),
 		"log-file", "", "log file path (default: stdout)")
-	fs.BoolVar(&cfg.Verbose, "verbose", cfg.Verbose, "enable verbose logging")
+
+	logLevel := []log.Level{
+		log.ErrorLevel,
+		log.InfoLevel,
+		log.DebugLevel,
+	}
+	fs.Var(anyflag.NewValue[log.Level](cfg.Level, &cfg.Level, anyflag.EnumParser[log.Level](logLevel...)), "log-level", "one of: error, info, debug")
 }
 
 func MarkFlagHidden(cmd *cobra.Command, names ...string) {

--- a/e2e/override/debug.yaml
+++ b/e2e/override/debug.yaml
@@ -4,9 +4,9 @@ services:
   proxy:
     environment:
       FORWARDER_LOG_HTTP: "headers"
-      FORWARDER_VERBOSE: "true"
+      FORWARDER_LOG_LEVEL: "debug"
 
   upstream-proxy:
     environment:
       FORWARDER_LOG_HTTP: "headers"
-      FORWARDER_VERBOSE: "true"
+      FORWARDER_LOG_LEVEL: "debug"

--- a/log/level.go
+++ b/log/level.go
@@ -6,19 +6,14 @@
 
 package log
 
-import (
-	"os"
+type Level int32
+
+const (
+	ErrorLevel Level = iota
+	InfoLevel
+	DebugLevel
 )
 
-// Config is a configuration for the loggers.
-type Config struct {
-	File  *os.File
-	Level Level
-}
-
-func DefaultConfig() *Config {
-	return &Config{
-		File:  nil,
-		Level: InfoLevel,
-	}
+func (l Level) String() string {
+	return [3]string{"error", "info", "debug"}[l]
 }

--- a/log/stdlog/stdlog.go
+++ b/log/stdlog/stdlog.go
@@ -16,8 +16,8 @@ import (
 
 func Default() StdLogger {
 	return StdLogger{
-		log:     log.Default(),
-		verbose: true,
+		log:   log.Default(),
+		level: flog.InfoLevel,
 	}
 }
 
@@ -27,16 +27,16 @@ func New(cfg *flog.Config) StdLogger {
 		w = cfg.File
 	}
 	return StdLogger{
-		log:     log.New(w, "", log.Ldate|log.Ltime|log.LUTC),
-		verbose: cfg.Verbose,
+		log:   log.New(w, "", log.Ldate|log.Ltime|log.LUTC),
+		level: cfg.Level,
 	}
 }
 
 // StdLogger implements the forwarder.Logger interface using the standard log package.
 type StdLogger struct {
-	log     *log.Logger
-	name    string
-	verbose bool
+	log   *log.Logger
+	name  string
+	level flog.Level
 
 	// Decorate allows to modify the log message before it is written.
 	Decorate func(string) string
@@ -51,6 +51,9 @@ func (sl StdLogger) Named(name string) StdLogger {
 }
 
 func (sl StdLogger) Errorf(format string, args ...interface{}) {
+	if sl.level < flog.ErrorLevel {
+		return
+	}
 	if sl.Decorate != nil {
 		format = sl.Decorate(format)
 	}
@@ -58,6 +61,9 @@ func (sl StdLogger) Errorf(format string, args ...interface{}) {
 }
 
 func (sl StdLogger) Infof(format string, args ...interface{}) {
+	if sl.level < flog.InfoLevel {
+		return
+	}
 	if sl.Decorate != nil {
 		format = sl.Decorate(format)
 	}
@@ -65,7 +71,7 @@ func (sl StdLogger) Infof(format string, args ...interface{}) {
 }
 
 func (sl StdLogger) Debugf(format string, args ...interface{}) {
-	if !sl.verbose {
+	if sl.level < flog.DebugLevel {
 		return
 	}
 	if sl.Decorate != nil {


### PR DESCRIPTION
This pr replaces verbosity with log levels. Available levels: `error`, `info`, `debug`. Default log level is `info`. 

