### PR TITLE
http_server: move TLS{Cert,Key}File to TLSConfig

### DIFF
--- a/bind/flag.go
+++ b/bind/flag.go
@@ -167,12 +167,12 @@ func HTTPServerConfig(fs *pflag.FlagSet, cfg *forwarder.HTTPServerConfig, prefix
 				"For https and h2 protocols, if TLS certificate is not specified, "+
 				"the server will use a self-signed certificate. ")
 
-		fs.StringVar(&cfg.TLSCertFile,
-			namePrefix+"tls-cert-file", cfg.TLSCertFile, "<path>"+
+		fs.StringVar(&cfg.CertFile,
+			namePrefix+"tls-cert-file", cfg.CertFile, "<path>"+
 				"TLS certificate to use if the server protocol is https or h2. ")
 
-		fs.StringVar(&cfg.TLSKeyFile,
-			namePrefix+"tls-key-file", cfg.TLSKeyFile, "<path>"+
+		fs.StringVar(&cfg.KeyFile,
+			namePrefix+"tls-key-file", cfg.KeyFile, "<path>"+
 				"TLS private key to use if the server protocol is https or h2. ")
 	}
 

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -154,11 +154,11 @@ func NewHTTPProxy(cfg *HTTPProxyConfig, pr PACResolver, cm *CredentialsMatcher, 
 }
 
 func (hp *HTTPProxy) configureHTTPS() error {
-	if hp.config.TLSCertFile == "" && hp.config.TLSKeyFile == "" {
+	if hp.config.CertFile == "" && hp.config.KeyFile == "" {
 		hp.log.Infof("no TLS certificate provided, using self-signed certificate")
 	}
 	tlsCfg := httpsTLSConfigTemplate()
-	err := hp.config.loadCertificate(tlsCfg)
+	err := LoadCertificateFromTLSConfig(tlsCfg, &hp.config.TLSConfig)
 	hp.TLSConfig = tlsCfg
 	return err
 }

--- a/tls.go
+++ b/tls.go
@@ -6,6 +6,12 @@
 
 package forwarder
 
+import (
+	"crypto/tls"
+
+	"github.com/saucelabs/forwarder/utils/certutil"
+)
+
 type TLSConfig struct {
 	// InsecureSkipVerify controls whether a client verifies the server's
 	// certificate chain and host name. If InsecureSkipVerify is true, crypto/tls
@@ -14,4 +20,28 @@ type TLSConfig struct {
 	// attacks unless custom verification is used. This should be used only for
 	// testing or in combination with VerifyConnection or VerifyPeerCertificate.
 	InsecureSkipVerify bool
+
+	// CertFile is the path to the TLS certificate.
+	CertFile string
+
+	// KeyFile is the path to the TLS private key of the certificate.
+	KeyFile string
+}
+
+func LoadCertificateFromTLSConfig(dst *tls.Config, src *TLSConfig) error {
+	var (
+		cert tls.Certificate
+		err  error
+	)
+
+	if src.CertFile == "" && src.KeyFile == "" {
+		cert, err = certutil.RSASelfSignedCert().Gen()
+	} else {
+		cert, err = tls.LoadX509KeyPair(src.CertFile, src.KeyFile)
+	}
+
+	if err == nil {
+		dst.Certificates = append(dst.Certificates, cert)
+	}
+	return err
 }


### PR DESCRIPTION
This moves TLS cert and file configuration for easier reuse.