### PR TITLE
makefile: export shell with overwritten path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 
 export GOBIN ?= $(PWD)/bin
 export PATH  := $(GOBIN):$(PATH)
+export SHELL := env PATH=$(PATH) $(SHELL)
 
 include .version
 


### PR DESCRIPTION
By default Makefile executes lines in a separate shell invocations. Changing PATH variable in one line does not affect next invocations.

Before this patch Makefile would not use executables from '/bin' directory as assigning to PATH wasn't persistent. 
```bash
make build
make: goreleaser: No such file or directory
make: *** [build] Error 1
```

This patch fixes it, by exporting SHELL that uses up-to-date PATH.