### PR TITLE
Move E2E httpexpect Client to its own module

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -39,7 +39,7 @@ func TestStatusCodes(t *testing.T) {
 		500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511, 599,
 	}
 
-	c := NewClient(t, httpbin)
+	c := newClient(t, httpbin)
 	for i := range validStatusCodes {
 		code := validStatusCodes[i]
 		t.Run(fmt.Sprint(code), func(t *testing.T) {
@@ -50,7 +50,7 @@ func TestStatusCodes(t *testing.T) {
 }
 
 func TestAuth(t *testing.T) {
-	c := NewClient(t, httpbin)
+	c := newClient(t, httpbin)
 	t.Run("ok", func(t *testing.T) {
 		c.GET("/basic-auth/user/passwd", func(r *http.Request) {
 			r.SetBasicAuth("user", "passwd")
@@ -65,7 +65,7 @@ func TestProxyAuth(t *testing.T) {
 	if os.Getenv("FORWARDER_BASIC_AUTH") == "" {
 		t.Skip("FORWARDER_BASIC_AUTH not set")
 	}
-	NewClient(t, httpbin, func(tr *http.Transport) {
+	newClient(t, httpbin, func(tr *http.Transport) {
 		p := tr.Proxy
 		tr.Proxy = func(req *http.Request) (u *url.URL, err error) {
 			u, err = p(req)
@@ -99,7 +99,7 @@ func TestStreamBytes(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			c := NewClient(t, httpbin)
+			c := newClient(t, httpbin)
 			for _, p := range rand.Perm(len(sizes)) {
 				size := sizes[p]
 				c.GET(fmt.Sprintf("/stream-bytes/%d", size)).ExpectStatus(http.StatusOK).ExpectBodySize(size)
@@ -226,9 +226,9 @@ func TestProxyLocalhost(t *testing.T) {
 
 	for _, h := range hosts {
 		if os.Getenv("FORWARDER_PROXY_LOCALHOST") == "allow" {
-			NewClient(t, "http://"+net.JoinHostPort(h, "10000")).GET("/version").ExpectStatus(http.StatusOK)
+			newClient(t, "http://"+net.JoinHostPort(h, "10000")).GET("/version").ExpectStatus(http.StatusOK)
 		} else {
-			NewClient(t, "http://"+net.JoinHostPort(h, "10000")).GET("/version").ExpectStatus(http.StatusBadGateway)
+			newClient(t, "http://"+net.JoinHostPort(h, "10000")).GET("/version").ExpectStatus(http.StatusBadGateway)
 		}
 	}
 }
@@ -241,13 +241,13 @@ func TestBadGateway(t *testing.T) {
 
 	for _, scheme := range []string{"http", "https"} {
 		for _, h := range hosts {
-			NewClient(t, scheme+"://"+h).GET("/status/200").ExpectStatus(http.StatusBadGateway)
+			newClient(t, scheme+"://"+h).GET("/status/200").ExpectStatus(http.StatusBadGateway)
 		}
 	}
 }
 
 func TestGoogleCom(t *testing.T) {
-	NewClient(t, "https://www.google.com").HEAD("/").ExpectStatus(http.StatusOK)
+	newClient(t, "https://www.google.com").HEAD("/").ExpectStatus(http.StatusOK)
 }
 
 func TestSC2450(t *testing.T) {
@@ -255,7 +255,7 @@ func TestSC2450(t *testing.T) {
 		t.Skip("FORWARDER_SC2450 not set")
 	}
 
-	c := NewClient(t, "http://sc-2450:8307")
+	c := newClient(t, "http://sc-2450:8307")
 	c.HEAD("/").ExpectStatus(http.StatusOK)
 	c.GET("/").ExpectStatus(http.StatusOK).ExpectBodyContent(`{"android":{"min_version":"4.0.0"},"ios":{"min_version":"4.0.0"}}`)
 }
@@ -265,7 +265,7 @@ func TestHeaderMods(t *testing.T) {
 		t.Skip("FORWARDER_TEST_HEADERS not set")
 	}
 
-	c := NewClient(t, httpbin)
+	c := newClient(t, httpbin)
 	c.GET("/header/test-add/test-value").ExpectStatus(http.StatusOK)
 	c.GET("/header/test-empty/", func(r *http.Request) {
 		r.Header.Set("test-empty", "not-empty")
@@ -283,7 +283,7 @@ func TestHeaderRespMods(t *testing.T) {
 		t.Skip("FORWARDER_TEST_RESPONSE_HEADERS not set")
 	}
 
-	c := NewClient(t, httpbin)
+	c := newClient(t, httpbin)
 	c.GET("/status/200").ExpectStatus(http.StatusOK).ExpectHeader("test-resp-add", "test-resp-value")
 	c.GET("/header/test-resp-empty/not-empty", func(r *http.Request) {
 		r.Header.Set("test-resp-empty", "not-empty")

--- a/e2e/framework.go
+++ b/e2e/framework.go
@@ -7,15 +7,14 @@
 package e2e
 
 import (
-	"context"
 	"crypto/tls"
-	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/saucelabs/forwarder/utils/httpexpect"
 )
 
 func serviceScheme(envVar string) string {
@@ -65,13 +64,7 @@ func newTransport(tb testing.TB) *http.Transport {
 	return tr
 }
 
-type Client struct {
-	t       *testing.T
-	tr      *http.Transport
-	baseURL string
-}
-
-func NewClient(t *testing.T, baseURL string, opts ...func(tr *http.Transport)) *Client {
+func newClient(t *testing.T, baseURL string, opts ...func(tr *http.Transport)) *httpexpect.Client {
 	t.Helper()
 
 	tr := newTransport(t)
@@ -79,98 +72,5 @@ func NewClient(t *testing.T, baseURL string, opts ...func(tr *http.Transport)) *
 		opt(tr)
 	}
 
-	return &Client{
-		t:       t,
-		tr:      tr,
-		baseURL: baseURL,
-	}
-}
-
-func (c *Client) do(req *http.Request) (*http.Response, error) {
-	resp, err := c.tr.RoundTrip(req)
-
-	// There is a difference between sending HTTP and HTTPS requests.
-	// For HTTPS client issues a CONNECT request to the proxy and then sends the original request.
-	// In case the proxy responds with status code 4XX or 5XX to the CONNECT request, the client interprets it as URL error.
-	//
-	// This is to cover this case.
-	if req.URL.Scheme == "https" && err != nil {
-		for i := 400; i < 600; i++ {
-			if err.Error() == http.StatusText(i) {
-				return &http.Response{
-					StatusCode: i,
-					Status:     http.StatusText(i),
-					ProtoMajor: 1,
-					ProtoMinor: 1,
-					Header:     http.Header{},
-					Body:       http.NoBody,
-					Request:    req,
-				}, nil
-			}
-		}
-	}
-
-	return resp, err
-}
-
-func (c *Client) GET(path string, opts ...func(*http.Request)) *Response {
-	return c.request("GET", path, opts...)
-}
-
-func (c *Client) HEAD(path string, opts ...func(*http.Request)) *Response {
-	return c.request("HEAD", path, opts...)
-}
-
-func (c *Client) request(method, path string, opts ...func(*http.Request)) *Response {
-	req, err := http.NewRequestWithContext(context.Background(), method, fmt.Sprintf("%s%s", c.baseURL, path), http.NoBody)
-	if err != nil {
-		c.t.Fatalf("Failed to create request %s, %s: %v", method, path, err)
-	}
-	for _, opt := range opts {
-		opt(req)
-	}
-	resp, err := c.do(req)
-	if err != nil {
-		c.t.Fatalf("Failed to execute request %s, %s: %v", method, path, err)
-	}
-	defer resp.Body.Close()
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		c.t.Fatalf("Failed to read body from %s, %s: %v", method, path, err)
-	}
-	return &Response{Response: resp, body: b, t: c.t}
-}
-
-type Response struct {
-	*http.Response
-	body []byte
-	t    *testing.T
-}
-
-func (r *Response) ExpectStatus(status int) *Response {
-	if r.StatusCode != status {
-		r.t.Fatalf("%s, %s: expected status %d, got %d", r.Request.Method, r.Request.URL, status, r.StatusCode)
-	}
-	return r
-}
-
-func (r *Response) ExpectHeader(key, value string) *Response {
-	if v := r.Header.Get(key); v != value {
-		r.t.Fatalf("%s, %s: expected header %s to equal '%s', got '%s'", r.Request.Method, r.Request.URL, key, value, v)
-	}
-	return r
-}
-
-func (r *Response) ExpectBodySize(expectedSize int) *Response {
-	if bodySize := len(r.body); bodySize != expectedSize {
-		r.t.Fatalf("%s, %s: expected body size %d, got %d", r.Request.Method, r.Request.URL, expectedSize, bodySize)
-	}
-	return r
-}
-
-func (r *Response) ExpectBodyContent(content string) *Response {
-	if b := string(r.body); b != content {
-		r.t.Fatalf("%s, %s: expected body to equal '%s', got '%s'", r.Request.Method, r.Request.URL, content, b)
-	}
-	return r
+	return httpexpect.NewClient(t, baseURL, tr)
 }

--- a/utils/httpexpect/httpexpect.go
+++ b/utils/httpexpect/httpexpect.go
@@ -1,0 +1,120 @@
+// Copyright 2023 Sauce Labs Inc. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package httpexpect
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+)
+
+type Client struct {
+	t       *testing.T
+	rt      http.RoundTripper
+	baseURL string
+}
+
+func NewClient(t *testing.T, baseURL string, rt http.RoundTripper) *Client {
+	t.Helper()
+
+	return &Client{
+		t:       t,
+		rt:      rt,
+		baseURL: baseURL,
+	}
+}
+
+func (c *Client) do(req *http.Request) (*http.Response, error) {
+	resp, err := c.rt.RoundTrip(req)
+
+	// There is a difference between sending HTTP and HTTPS requests.
+	// For HTTPS client issues a CONNECT request to the proxy and then sends the original request.
+	// In case the proxy responds with status code 4XX or 5XX to the CONNECT request, the client interprets it as URL error.
+	//
+	// This is to cover this case.
+	if req.URL.Scheme == "https" && err != nil {
+		for i := 400; i < 600; i++ {
+			if err.Error() == http.StatusText(i) {
+				return &http.Response{
+					StatusCode: i,
+					Status:     http.StatusText(i),
+					ProtoMajor: 1,
+					ProtoMinor: 1,
+					Header:     http.Header{},
+					Body:       http.NoBody,
+					Request:    req,
+				}, nil
+			}
+		}
+	}
+
+	return resp, err
+}
+
+func (c *Client) GET(path string, opts ...func(*http.Request)) *Response {
+	return c.request("GET", path, opts...)
+}
+
+func (c *Client) HEAD(path string, opts ...func(*http.Request)) *Response {
+	return c.request("HEAD", path, opts...)
+}
+
+func (c *Client) request(method, path string, opts ...func(*http.Request)) *Response {
+	req, err := http.NewRequestWithContext(context.Background(), method, fmt.Sprintf("%s%s", c.baseURL, path), http.NoBody)
+	if err != nil {
+		c.t.Fatalf("Failed to create request %s, %s: %v", method, path, err)
+	}
+	for _, opt := range opts {
+		opt(req)
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		c.t.Fatalf("Failed to execute request %s, %s: %v", method, path, err)
+	}
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		c.t.Fatalf("Failed to read body from %s, %s: %v", method, path, err)
+	}
+	return &Response{Response: resp, body: b, t: c.t}
+}
+
+type Response struct {
+	*http.Response
+	body []byte
+	t    *testing.T
+}
+
+func (r *Response) ExpectStatus(status int) *Response {
+	if r.StatusCode != status {
+		r.t.Fatalf("%s, %s: expected status %d, got %d", r.Request.Method, r.Request.URL, status, r.StatusCode)
+	}
+	return r
+}
+
+func (r *Response) ExpectHeader(key, value string) *Response {
+	if v := r.Header.Get(key); v != value {
+		r.t.Fatalf("%s, %s: expected header %s to equal '%s', got '%s'", r.Request.Method, r.Request.URL, key, value, v)
+	}
+	return r
+}
+
+func (r *Response) ExpectBodySize(expectedSize int) *Response {
+	if bodySize := len(r.body); bodySize != expectedSize {
+		r.t.Fatalf("%s, %s: expected body size %d, got %d", r.Request.Method, r.Request.URL, expectedSize, bodySize)
+	}
+	return r
+}
+
+func (r *Response) ExpectBodyContent(content string) *Response {
+	if b := string(r.body); b != content {
+		r.t.Fatalf("%s, %s: expected body to equal '%s', got '%s'", r.Request.Method, r.Request.URL, content, b)
+	}
+	return r
+}


### PR DESCRIPTION
Extracting generic httpexpect functionality from forwarder tests makes it usable by other projects. The Client will now take http.RoundTripper, which can be fully customized.