### PR TITLE
fix (readme): remove shorthand for insecure flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ HTTP client options:
     --http-tls-handshake-timeout <duration> (default 10s) (env FORWARDER_HTTP_TLS_HANDSHAKE_TIMEOUT)
         The maximum amount of time waiting to wait for a TLS handshake. Zero means no limit.
 
-    -k, --insecure <value> (default false) (env FORWARDER_INSECURE)
+    --insecure <value> (default false) (env FORWARDER_INSECURE)
         Don't verify the server's certificate chain and host name. Enable to work with self-signed certificates. 
 
 Logging options:


### PR DESCRIPTION
Shorthand support for insecure flag has been disabled in be8f5f7.