### PR TITLE
runctx: refactoring

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -113,6 +113,10 @@ issues:
       source: "(nil)"
 
     - linters:
+        - gochecknoglobals
+      source: "Default"
+
+    - linters:
         - gocritic
       source: "// output:"
 

--- a/cmd/forwarder/httpbin/httpbin.go
+++ b/cmd/forwarder/httpbin/httpbin.go
@@ -37,7 +37,7 @@ func (c *command) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return runctx.Funcs{s.Run, a.Run}.Run()
+	return runctx.NewGroup(s.Run, a.Run).Run()
 }
 
 func Command() (cmd *cobra.Command) {

--- a/cmd/forwarder/pac/server/server.go
+++ b/cmd/forwarder/pac/server/server.go
@@ -51,7 +51,7 @@ func (c *command) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return runctx.Run(s.Run)
+	return runctx.NewGroup(s.Run).Run()
 }
 
 func validatePACScript(script string) error {

--- a/cmd/forwarder/run/run.go
+++ b/cmd/forwarder/run/run.go
@@ -105,12 +105,12 @@ func (c *command) RunE(cmd *cobra.Command, args []string) error {
 		c.httpProxyConfig.ResponseModifiers = append(c.httpProxyConfig.ResponseModifiers, header.Headers(c.responseHeaders))
 	}
 
-	var f runctx.Funcs
+	var g runctx.Group
 	p, err := forwarder.NewHTTPProxy(c.httpProxyConfig, pr, cm, rt, logger.Named("proxy"))
 	if err != nil {
 		return err
 	}
-	f = append(f, p.Run)
+	g.Add(p.Run)
 
 	if c.apiServerConfig.Addr != "" {
 		h := forwarder.NewAPIHandler(c.promReg, p.Ready, config, script)
@@ -118,7 +118,7 @@ func (c *command) RunE(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		f = append(f, a.Run)
+		g.Add(a.Run)
 	}
 
 	if c.goleak {
@@ -129,7 +129,7 @@ func (c *command) RunE(cmd *cobra.Command, args []string) error {
 		}()
 	}
 
-	return f.Run()
+	return g.Run()
 }
 
 func Command() (cmd *cobra.Command) {


### PR DESCRIPTION
- NotifySignals is renamed to DefaultNotifySignals
- Hard coded signals are removed
- New struct Group provides better DSL
- Duplicated code is removed