### PR TITLE
e2e: make FlagProxyLocalhost test all allow and deny values

### DIFF
--- a/e2e/setups.go
+++ b/e2e/setups.go
@@ -19,8 +19,9 @@ func AllSetups() []setup.Setup {
 	ss = append(ss, DefaultsSetups()...)
 	ss = append(ss, AuthSetups()...)
 	ss = append(ss, PacSetups()...)
+
+	ss = append(ss, FlagProxyLocalhost()...)
 	ss = append(ss,
-		FlagProxyLocalhostAllowSetup(),
 		FlagHeaderSetup(),
 		FlagResponseHeaderSetup(),
 
@@ -146,16 +147,19 @@ func PacSetups() []setup.Setup {
 	}
 }
 
-func FlagProxyLocalhostAllowSetup() setup.Setup {
-	return setup.Setup{
-		Name: "flag-proxy-localhost",
-		Compose: compose.NewBuilder().
-			AddService(
-				forwarder.ProxyService().
-					WithLocalhostMode("allow")).
-			MustBuild(),
-		Run: "^TestFlagProxyLocalhost",
+func FlagProxyLocalhost() (ss []setup.Setup) {
+	for _, mode := range []string{"deny", "allow"} {
+		ss = append(ss, setup.Setup{
+			Name: "flag-proxy-localhost-" + mode,
+			Compose: compose.NewBuilder().
+				AddService(
+					forwarder.ProxyService().
+						WithLocalhostMode(mode)).
+				MustBuild(),
+			Run: "^TestFlagProxyLocalhost/" + mode + "$",
+		})
 	}
+	return
 }
 
 func FlagHeaderSetup() setup.Setup {

--- a/e2e/tests/flag_test.go
+++ b/e2e/tests/flag_test.go
@@ -11,7 +11,6 @@ package tests
 import (
 	"net"
 	"net/http"
-	"os"
 	"testing"
 )
 
@@ -21,19 +20,16 @@ func TestFlagProxyLocalhost(t *testing.T) {
 		"127.0.0.1",
 	}
 
-	if os.Getenv("FORWARDER_PROXY_LOCALHOST") == "allow" {
-		t.Run("allow", func(t *testing.T) {
-			for _, h := range hosts {
-				newClient(t, "http://"+net.JoinHostPort(h, "10000")).GET("/version").ExpectStatus(http.StatusOK)
-			}
-		})
-	} else {
-		t.Run("deny", func(t *testing.T) {
-			for _, h := range hosts {
-				newClient(t, "http://"+net.JoinHostPort(h, "10000")).GET("/version").ExpectStatus(http.StatusBadGateway)
-			}
-		})
-	}
+	t.Run("allow", func(t *testing.T) {
+		for _, h := range hosts {
+			newClient(t, "http://"+net.JoinHostPort(h, "10000")).GET("/version").ExpectStatus(http.StatusOK)
+		}
+	})
+	t.Run("deny", func(t *testing.T) {
+		for _, h := range hosts {
+			newClient(t, "http://"+net.JoinHostPort(h, "10000")).GET("/version").ExpectStatus(http.StatusBadGateway)
+		}
+	})
 }
 
 func TestFlagHeader(t *testing.T) {


### PR DESCRIPTION
It would be interesting to add direct mode test.
We are missing the possibility to assert that the request had a certain route to be added in #317.