### PR TITLE
add DNS e2e tests

### DIFF
--- a/e2e/dns/db.rpz
+++ b/e2e/dns/db.rpz
@@ -1,0 +1,10 @@
+$TTL 60
+@            IN    SOA  localhost. root.localhost.  (
+                          2015112501   ; serial
+                          1h           ; refresh
+                          30m          ; retry
+                          1w           ; expiry
+                          30m)         ; minimum
+                   IN     NS    localhost.
+
+httpbin.local  A        192.168.100.10

--- a/e2e/dns/named.conf.local
+++ b/e2e/dns/named.conf.local
@@ -1,0 +1,4 @@
+zone "rpz" {
+  type master;
+  file "/etc/bind/db.rpz";
+};

--- a/e2e/dns/named.conf.options
+++ b/e2e/dns/named.conf.options
@@ -1,0 +1,26 @@
+options {
+	directory "/var/cache/bind";
+
+	// If there is a firewall between you and nameservers you want
+	// to talk to, you may need to fix the firewall to allow multiple
+	// ports to talk.  See http://www.kb.cert.org/vuls/id/800113
+
+	// If your ISP provided one or more IP addresses for stable
+	// nameservers, you probably want to use them as forwarders.
+	// Uncomment the following block, and insert the addresses replacing
+	// the all-0's placeholder.
+
+	// forwarders {
+	// 	0.0.0.0;
+	// };
+
+	//========================================================================
+	// If BIND logs error messages about the root key being expired,
+	// you will need to update your keys.  See https://www.isc.org/bind-keys
+	//========================================================================
+	dnssec-validation auto;
+
+	listen-on-v6 { any; };
+
+	response-policy { zone "rpz"; };
+};

--- a/e2e/dns/service.go
+++ b/e2e/dns/service.go
@@ -1,0 +1,43 @@
+// Copyright 2023 Sauce Labs Inc. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package dns
+
+import (
+	"github.com/saucelabs/forwarder/utils/compose"
+)
+
+type service compose.Service
+
+const (
+	Image = "ubuntu/bind9:latest"
+
+	ServiceName = "dns"
+)
+
+func Service() *service { //nolint:revive,golint // Unexported by design.
+	return &service{
+		Name:        ServiceName,
+		Image:       Image,
+		Environment: map[string]string{},
+		Volumes: []string{
+			"./dns/db.rpz:/etc/bind/db.rpz",
+			"./dns/named.conf.local:/etc/bind/named.conf.local",
+			"./dns/named.conf.options:/etc/bind/named.conf.options",
+		},
+	}
+}
+
+func (s *service) WithIP(network, ipv4 string) *service {
+	s.Network = map[string]compose.ServiceNetwork{
+		network: {IPv4: ipv4},
+	}
+	return s
+}
+
+func (s *service) Service() *compose.Service {
+	return (*compose.Service)(s)
+}

--- a/e2e/forwarder/service.go
+++ b/e2e/forwarder/service.go
@@ -131,6 +131,13 @@ func (s *Service) WithEnv(key, val string) *Service {
 	return s
 }
 
+func (s *Service) WithIP(network, ipv4 string) *Service {
+	s.Network = map[string]compose.ServiceNetwork{
+		network: {IPv4: ipv4},
+	}
+	return s
+}
+
 func (s *Service) Service() *compose.Service {
 	return (*compose.Service)(s)
 }

--- a/e2e/forwarder/service.go
+++ b/e2e/forwarder/service.go
@@ -7,6 +7,7 @@
 package forwarder
 
 import (
+	"strings"
 	"time"
 
 	"github.com/saucelabs/forwarder/utils/compose"
@@ -135,6 +136,11 @@ func (s *Service) WithIP(network, ipv4 string) *Service {
 	s.Network = map[string]compose.ServiceNetwork{
 		network: {IPv4: ipv4},
 	}
+	return s
+}
+
+func (s *Service) WithDNSServer(servers ...string) *Service {
+	s.Environment["FORWARDER_DNS_SERVER"] = strings.Join(servers, ",")
 	return s
 }
 

--- a/e2e/tests/flag_test.go
+++ b/e2e/tests/flag_test.go
@@ -70,3 +70,15 @@ func setHeader(key, value string) func(r *http.Request) {
 		r.Header.Set(key, value)
 	}
 }
+
+var httpbinDNS = serviceScheme("HTTPBIN_PROTOCOL") + "://httpbin.local:8080"
+
+func TestFlagDNSServer(t *testing.T) {
+	t.Run("default httpbin address", func(t *testing.T) {
+		newClient(t, httpbin).GET("/status/200").ExpectStatus(http.StatusBadGateway)
+	})
+
+	t.Run("custom httpbin address", func(t *testing.T) {
+		newClient(t, httpbinDNS).GET("/status/200").ExpectStatus(http.StatusOK)
+	})
+}

--- a/utils/compose/builder.go
+++ b/utils/compose/builder.go
@@ -32,6 +32,13 @@ func (b *Builder) AddService(s ServiceBuilder) *Builder {
 	return b
 }
 
+func (b *Builder) AddNetwork(n *Network) *Builder {
+	if b.error == nil {
+		b.error = b.c.addNetwork(n)
+	}
+	return b
+}
+
 func (b *Builder) Build() (*Compose, error) {
 	if b.error != nil {
 		return nil, b.error

--- a/utils/compose/compose.go
+++ b/utils/compose/compose.go
@@ -19,6 +19,7 @@ type Compose struct {
 	Path     string              `yaml:"-"`
 	Version  string              `yaml:"version"`
 	Services map[string]*Service `yaml:"services,omitempty"`
+	Networks map[string]*Network `yaml:"networks,omitempty"`
 }
 
 func newCompose() *Compose {
@@ -26,6 +27,7 @@ func newCompose() *Compose {
 		Path:     "docker-compose.yaml",
 		Version:  "3.8",
 		Services: make(map[string]*Service),
+		Networks: make(map[string]*Network),
 	}
 }
 
@@ -38,6 +40,19 @@ func (c *Compose) addService(s *Service) error {
 	}
 
 	c.Services[s.Name] = s
+
+	return nil
+}
+
+func (c *Compose) addNetwork(n *Network) error {
+	if err := n.Validate(); err != nil {
+		return err
+	}
+	if c.Networks[n.Name] != nil {
+		return fmt.Errorf("network %s already exists", n.Name)
+	}
+
+	c.Networks[n.Name] = n
 
 	return nil
 }

--- a/utils/compose/network.go
+++ b/utils/compose/network.go
@@ -1,0 +1,98 @@
+// Copyright 2023 Sauce Labs Inc. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package compose
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+)
+
+type IPAMConfig struct {
+	Subnet  string `yaml:"subnet"`
+	Gateway string `yaml:"gateway"`
+	IPRange string `yaml:"ip_range"`
+}
+
+func (c *IPAMConfig) Validate() error {
+	if err := validateIPWithMask(c.Subnet); err != nil {
+		return fmt.Errorf("network subnet is invalid: %w", err)
+	}
+	if err := validateIP(c.Gateway); err != nil {
+		return fmt.Errorf("network gateway is invalid %w", err)
+	}
+	if err := validateIPWithMask(c.IPRange); err != nil {
+		return fmt.Errorf("network IP range is invalid %w", err)
+	}
+	return nil
+}
+
+type IPAM struct {
+	Config []IPAMConfig `yaml:"config"`
+}
+
+func (i *IPAM) Validate() error {
+	for j := range i.Config {
+		if err := i.Config[j].Validate(); err != nil {
+			return fmt.Errorf("network IPAM Config[%d] is invalid: %w", j, err)
+		}
+	}
+	return nil
+}
+
+type Network struct {
+	Name   string `yaml:"name"`
+	Driver string `yaml:"driver"`
+	IPAM   IPAM   `yaml:"ipam"`
+}
+
+func (n *Network) Validate() error {
+	if n.Name == "" {
+		return fmt.Errorf("network name is required")
+	}
+	if n.Driver == "" {
+		return fmt.Errorf("network driver is required")
+	}
+	return n.IPAM.Validate()
+}
+
+func validateIP(input string) error {
+	if ip := net.ParseIP(input); ip == nil {
+		return fmt.Errorf("could not parse IP address: %s", input)
+	}
+
+	return nil
+}
+
+func validateMask(input string) error {
+	mask, err := strconv.Atoi(input)
+	if err != nil {
+		return fmt.Errorf("could not parse mask: %s", input)
+	}
+
+	if mask < 0 || mask > 32 {
+		return fmt.Errorf("must be between 0 and 32, mask: %d", mask)
+	}
+
+	return nil
+}
+
+func validateIPWithMask(input string) error {
+	ip, mask, ok := strings.Cut(input, "/")
+	if !ok {
+		return fmt.Errorf("must be in the format of IP/MASK, input: %s", input)
+	}
+	if err := validateIP(ip); err != nil {
+		return err
+	}
+	if err := validateMask(mask); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/utils/compose/service.go
+++ b/utils/compose/service.go
@@ -11,14 +11,19 @@ import (
 	"time"
 )
 
+type ServiceNetwork struct {
+	IPv4 string `yaml:"ipv4_address,omitempty"`
+}
+
 type Service struct {
-	Name        string            `yaml:"-"`
-	Image       string            `yaml:"image,omitempty"`
-	Command     string            `yaml:"command,omitempty"`
-	Environment map[string]string `yaml:"environment,omitempty"`
-	Ports       []string          `yaml:"ports,omitempty"`
-	Volumes     []string          `yaml:"volumes,omitempty"`
-	HealthCheck *HealthCheck      `yaml:"healthcheck,omitempty"`
+	Name        string                    `yaml:"-"`
+	Image       string                    `yaml:"image,omitempty"`
+	Command     string                    `yaml:"command,omitempty"`
+	Environment map[string]string         `yaml:"environment,omitempty"`
+	Ports       []string                  `yaml:"ports,omitempty"`
+	Volumes     []string                  `yaml:"volumes,omitempty"`
+	HealthCheck *HealthCheck              `yaml:"healthcheck,omitempty"`
+	Network     map[string]ServiceNetwork `yaml:"networks,omitempty"`
 }
 
 func (s *Service) Validate() error {


### PR DESCRIPTION
This patch adds: 
- support for defining custom networks in compose tool
- bind9 dns server service to use in e2e tests
- DNS e2e setup