### PR TITLE
utils/compose(service): enable privileged mode

### DIFF
--- a/utils/compose/service.go
+++ b/utils/compose/service.go
@@ -24,6 +24,7 @@ type Service struct {
 	Volumes     []string                  `yaml:"volumes,omitempty"`
 	HealthCheck *HealthCheck              `yaml:"healthcheck,omitempty"`
 	Network     map[string]ServiceNetwork `yaml:"networks,omitempty"`
+	Privileged  bool                      `yaml:"privileged,omitempty"`
 }
 
 func (s *Service) Validate() error {


### PR DESCRIPTION
This is needed for executing commands with root privileges on the container e.g. `iptables`.