### PR TITLE
utils/httpexpect: add httptrace.ClientTrace

### DIFF
--- a/e2e/tests/client.go
+++ b/e2e/tests/client.go
@@ -83,6 +83,6 @@ func newClient(t *testing.T, baseURL string, opts ...func(tr *http.Transport)) *
 	}
 
 	c := httpexpect.NewClient(t, baseURL, tr)
-	//c.Trace(true)
+	// c.Trace(true)
 	return c
 }

--- a/e2e/tests/client.go
+++ b/e2e/tests/client.go
@@ -82,5 +82,7 @@ func newClient(t *testing.T, baseURL string, opts ...func(tr *http.Transport)) *
 		opt(tr)
 	}
 
-	return httpexpect.NewClient(t, baseURL, tr)
+	c := httpexpect.NewClient(t, baseURL, tr)
+	//c.Trace(true)
+	return c
 }

--- a/utils/httpexpect/trace.go
+++ b/utils/httpexpect/trace.go
@@ -1,0 +1,72 @@
+// Copyright 2023 Sauce Labs Inc. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package httpexpect
+
+import (
+	"crypto/tls"
+	"net/http/httptrace"
+	"net/textproto"
+	"testing"
+)
+
+func newTestClientTrace(t *testing.T) *httptrace.ClientTrace {
+	return &httptrace.ClientTrace{
+		GetConn: func(hostPort string) {
+			t.Logf("GetConn for hostPort: %s", hostPort)
+		},
+		GotConn: func(info httptrace.GotConnInfo) {
+			t.Logf("GotConn: %+v", info)
+		},
+		PutIdleConn: func(err error) {
+			t.Logf("PutIdleConn with error: %v", err)
+		},
+		GotFirstResponseByte: func() {
+			t.Logf("GotFirstResponseByte")
+		},
+		Got100Continue: func() {
+			t.Logf("Got100Continue")
+		},
+		Got1xxResponse: func(code int, header textproto.MIMEHeader) error {
+			t.Logf("Got1xxResponse: code=%d, header=%v", code, header)
+			return nil
+		},
+		DNSStart: func(info httptrace.DNSStartInfo) {
+			t.Logf("DNSStart: %+v", info)
+		},
+		DNSDone: func(info httptrace.DNSDoneInfo) {
+			t.Logf("DNSDone: %+v", info)
+		},
+		ConnectStart: func(network, addr string) {
+			t.Logf("ConnectStart: network=%s, addr=%s", network, addr)
+		},
+		ConnectDone: func(network, addr string, err error) {
+			t.Logf("ConnectDone: network=%s, addr=%s, err=%v", network, addr, err)
+		},
+		TLSHandshakeStart: func() {
+			t.Logf("TLSHandshakeStart")
+		},
+		TLSHandshakeDone: func(state tls.ConnectionState, err error) {
+			if err != nil {
+				t.Logf("TLSHandshakeDone: state=%+v, err=%v", state, err)
+			} else {
+				t.Logf("TLSHandshakeDone: state=%+v", state)
+			}
+		},
+		WroteHeaderField: func(key string, value []string) {
+			t.Logf("WroteHeaderField: key=%s, value=%v", key, value)
+		},
+		WroteHeaders: func() {
+			t.Logf("WroteHeaders")
+		},
+		Wait100Continue: func() {
+			t.Logf("Wait100Continue")
+		},
+		WroteRequest: func(info httptrace.WroteRequestInfo) {
+			t.Logf("WroteRequest: %+v", info)
+		},
+	}
+}

--- a/utils/httpexpect/trace.go
+++ b/utils/httpexpect/trace.go
@@ -14,6 +14,7 @@ import (
 )
 
 func newTestClientTrace(t *testing.T) *httptrace.ClientTrace {
+	t.Helper()
 	return &httptrace.ClientTrace{
 		GetConn: func(hostPort string) {
 			t.Logf("GetConn for hostPort: %s", hostPort)


### PR DESCRIPTION
This allows to inspect the HTTP client events in the test client. It's not enabled by default.

Example:

```
=== RUN   TestProxyGoogleCom
    trace.go:19: GetConn for hostPort: proxy:3128
    trace.go:38: DNSStart: {Host:proxy}
    trace.go:41: DNSDone: {Addrs:[{IP:172.23.0.3 Zone:}] Err:<nil> Coalesced:false}
    trace.go:44: ConnectStart: network=tcp, addr=172.23.0.3:3128
    trace.go:47: ConnectDone: network=tcp, addr=172.23.0.3:3128, err=<nil>
    trace.go:50: TLSHandshakeStart
    trace.go:56: TLSHandshakeDone: state={Version:772 HandshakeComplete:true DidResume:false CipherSuite:4865 NegotiatedProtocol:http/1.1 NegotiatedProtocolIsMutual:true ServerName:www.google.com PeerCertificates:[0x40002f2680 0x40002f2c00] VerifiedChains:[[0x40002f2680 0x40002f3180]] SignedCertificateTimestamps:[] OCSPResponse:[] TLSUnique:[] ekm:0x1eb060}
    trace.go:22: GotConn: {Conn:0x4000092a80 Reused:false WasIdle:false IdleTime:0s}
    trace.go:60: WroteHeaderField: key=Host, value=[www.google.com]
    trace.go:60: WroteHeaderField: key=User-Agent, value=[Go-http-client/1.1]
    trace.go:63: WroteHeaders
    trace.go:69: WroteRequest: {Err:<nil>}
    trace.go:28: GotFirstResponseByte
    trace.go:25: PutIdleConn with error: <nil>
```