### PR TITLE
Add route mode for http logging 

### DIFF
--- a/bind/flag.go
+++ b/bind/flag.go
@@ -254,13 +254,14 @@ func HTTPServerConfig(fs *pflag.FlagSet, cfg *forwarder.HTTPServerConfig, prefix
 
 	httpLogModes := []httplog.Mode{
 		httplog.None,
+		httplog.Route,
 		httplog.URL,
 		httplog.Headers,
 		httplog.Body,
 		httplog.Errors,
 	}
 	fs.Var(anyflag.NewValue[httplog.Mode](cfg.LogHTTPMode, &cfg.LogHTTPMode, anyflag.EnumParser[httplog.Mode](httpLogModes...)),
-		namePrefix+"log-http", "<none|url|headers|body|errors>"+
+		namePrefix+"log-http", "<none|route|url|headers|body|errors>"+
 			"HTTP request and response logging mode. "+
 			"By default, request line and headers are logged if response status code is greater than or equal to 500. "+
 			"Setting this to none disables logging. ")

--- a/httplog/httplog.go
+++ b/httplog/httplog.go
@@ -33,12 +33,12 @@ func (m Mode) String() string {
 }
 
 type Logger struct {
-	log  func(format string, args ...interface{})
+	log  func(format string, args ...any)
 	mode Mode
 }
 
 // NewLogger returns a logger that logs HTTP requests and responses.
-func NewLogger(logFunc func(format string, args ...interface{}), mode Mode) *Logger {
+func NewLogger(logFunc func(format string, args ...any), mode Mode) *Logger {
 	return &Logger{
 		log:  logFunc,
 		mode: mode,

--- a/httplog/httplog.go
+++ b/httplog/httplog.go
@@ -52,21 +52,21 @@ func (l *Logger) LogFunc() middleware.Logger {
 		return func(e middleware.LogEntry) {
 			var w logWriter
 			w.Line(e)
-			l.log(w.String())
+			l.log("%s", w.String())
 		}
 	case Headers:
 		return func(e middleware.LogEntry) {
 			var w logWriter
 			w.Line(e)
 			w.Dump(e)
-			l.log(w.String())
+			l.log("%s", w.String())
 		}
 	case Body:
 		return func(e middleware.LogEntry) {
 			w := logWriter{body: true}
 			w.Line(e)
 			w.Dump(e)
-			l.log(w.String())
+			l.log("%s", w.String())
 		}
 	case Errors:
 		return func(e middleware.LogEntry) {
@@ -77,7 +77,7 @@ func (l *Logger) LogFunc() middleware.Logger {
 			var w logWriter
 			w.Line(e)
 			w.Dump(e)
-			l.log(w.String())
+			l.log("%s", w.String())
 		}
 	default:
 		panic(fmt.Sprintf("unknown log mode %s", l.mode))

--- a/internal/martian/messageview/messageview.go
+++ b/internal/martian/messageview/messageview.go
@@ -77,7 +77,7 @@ func (mv *MessageView) SnapshotRequest(req *http.Request) error {
 	buf := new(bytes.Buffer)
 
 	fmt.Fprintf(buf, "%s %s HTTP/%d.%d\r\n", req.Method,
-		req.URL, req.ProtoMajor, req.ProtoMinor)
+		req.URL.Redacted(), req.ProtoMajor, req.ProtoMinor)
 
 	if req.Host != "" {
 		fmt.Fprintf(buf, "Host: %s\r\n", req.Host)


### PR DESCRIPTION
A `route` mode is like `url`, but it logs only the host+path to make the logs look thin.

Route log example: 
```
2023/08/28 16:54:40 [proxy] INFO: trace=2 GET www.google.com/ status=200 duration=3.140999458s
```