### PR TITLE
utils/cobrautil: support pasring lists from env vars and config file

### DIFF
--- a/utils/cobrautil/bind.go
+++ b/utils/cobrautil/bind.go
@@ -55,7 +55,11 @@ func BindAll(cmd *cobra.Command, envPrefix, configFileFlagName string) error {
 		ok = true
 		fs.VisitAll(func(f *pflag.Flag) {
 			if !f.Changed && v.IsSet(f.Name) {
-				if err := fs.Set(f.Name, fmt.Sprintf("%v", v.Get(f.Name))); err != nil {
+				s := fmt.Sprintf("%v", v.Get(f.Name))
+				s = strings.TrimPrefix(s, "[")
+				s = strings.TrimSuffix(s, "]")
+				s = strings.NewReplacer(", ", ",", " ", ",").Replace(s)
+				if err := fs.Set(f.Name, s); err != nil {
 					fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
 					ok = false
 				}


### PR DESCRIPTION
This trims and reformats string values set from viper. It allows reading yaml and json format lists e.g.
```
dns-server:
 - 1.2.3.4
 - 4.3.2.1
```
```
{
  "dns-server": ["8.8.8.8", "5.5.5.5"]
}
```
and env vars:
```
FORWARDER_DNS_SERVER="1.2.3.4 4.3.2.1" forwarder run
```

It does not affect reading and parsing flags from command line.