### PR TITLE
add `/headers` endpoint to httpbin

### DIFF
--- a/e2e/tests/proxy_test.go
+++ b/e2e/tests/proxy_test.go
@@ -253,25 +253,10 @@ func TestProxyUpstream(t *testing.T) {
 		t.Skip("HTTPBIN_PROTOCOL not set to http")
 	}
 
-	res := string(newClient(t, httpbin).GET("/header/via/").ExpectStatus(http.StatusNotFound).Body)
-	_, viaHeader, ok := strings.Cut(res, "=")
-	if !ok {
-		t.Fatalf("unexpected response: %q", res)
-	}
-
-	l := len("1.1 ")
-	filter := func(s string) string {
-		i := strings.LastIndex(s, "-")
-		if i < l {
-			t.Errorf("unexpected via header: %q", s)
-			return ""
-		}
-		return s[l:i]
-	}
-
+	viaHeader := newClient(t, httpbin).GET("/headers/").Header["Via"]
 	var success bool
-	for _, via := range strings.Split(viaHeader, ", ") {
-		if forwarder.UpstreamProxyServiceName == filter(via) {
+	for _, via := range viaHeader {
+		if strings.Contains(via, forwarder.UpstreamProxyServiceName) {
 			success = true
 		}
 	}

--- a/utils/httpbin/httpbin.go
+++ b/utils/httpbin/httpbin.go
@@ -31,6 +31,7 @@ func Handler() http.Handler {
 	m.HandleFunc("/ws/echo", wsEcho)
 	m.HandleFunc("/ws.html", wsHTML)
 	m.HandleFunc("/header/", headerHandler)
+	m.HandleFunc("/headers/", headersHandler)
 	return m
 }
 
@@ -147,5 +148,13 @@ func headerHandler(w http.ResponseWriter, r *http.Request) {
 	} else {
 		w.WriteHeader(http.StatusNotFound)
 		w.Write([]byte("invalid header: " + k + "=" + vv))
+	}
+}
+
+func headersHandler(w http.ResponseWriter, r *http.Request) {
+	for k, vv := range r.Header {
+		for _, v := range vv {
+			w.Header().Add(k, v)
+		}
 	}
 }


### PR DESCRIPTION
This adds `/headers` endpoint to httpbin, which returns the incoming request's HTTTP headers.

The test `TestProxyUpstream` has been adjusted to use `/headers`. 