### PR TITLE
Ruleset adjustments

### DIFF
--- a/bind/flag.go
+++ b/bind/flag.go
@@ -119,8 +119,7 @@ func HTTPProxyConfig(fs *pflag.FlagSet, cfg *forwarder.HTTPProxyConfig, lcfg *lo
 			"Exclude requests to the specified domains from being denied. "+
 			"Use this flag multiple times to specify multiple deny domain excludes. "+
 			"This flag takes precedence over deny-domain. "+
-			"When --deny-domain-exclude is specified and --deny-domain is not, "+
-			"all requests to domains that do not match any of the deny-domain-exclude patterns will be denied. ")
+			"Can be specified only if --deny-domain is also specified. ")
 }
 
 func MITMConfig(fs *pflag.FlagSet, mitm *bool, cfg *forwarder.MITMConfig) {

--- a/e2e/setups.go
+++ b/e2e/setups.go
@@ -357,17 +357,6 @@ func SetupFlagDenyDomain(l *setupList) {
 				MustBuild(),
 			Run: run,
 		},
-		setup.Setup{
-			Name: "flag-deny-domain-only-exclude",
-			Compose: compose.NewBuilder().
-				AddService(
-					forwarder.HttpbinService()).
-				AddService(
-					forwarder.ProxyService().
-						WithDenyDomainExclude("httpbin")).
-				MustBuild(),
-			Run: run,
-		},
 	)
 }
 

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -28,7 +28,7 @@ import (
 	"github.com/saucelabs/forwarder/log"
 	"github.com/saucelabs/forwarder/middleware"
 	"github.com/saucelabs/forwarder/pac"
-	"github.com/saucelabs/forwarder/regex"
+	"github.com/saucelabs/forwarder/ruleset"
 )
 
 type ProxyLocalhostMode string
@@ -277,7 +277,7 @@ func (hp *HTTPProxy) middlewareStack() martian.RequestResponseModifier {
 		topg.AddRequestModifier(hp.denyLocalhost())
 	}
 	if len(hp.config.DenyDomains) != 0 || len(hp.config.DenyDomainsExclude) != 0 {
-		ruleSet := regex.NewRuleSet(hp.config.DenyDomains, hp.config.DenyDomainsExclude)
+		ruleSet := ruleset.NewRuleSet(hp.config.DenyDomains, hp.config.DenyDomainsExclude)
 		topg.AddRequestModifier(hp.denyDomains(ruleSet))
 	}
 
@@ -395,7 +395,7 @@ func (hp *HTTPProxy) denyLocalhost() martian.RequestModifier {
 	}, errors.New("localhost access denied"))
 }
 
-func (hp *HTTPProxy) denyDomains(ruleSet *regex.RuleSet) martian.RequestModifier {
+func (hp *HTTPProxy) denyDomains(ruleSet *ruleset.RuleSet) martian.RequestModifier {
 	return hp.abortIf(func(req *http.Request) bool {
 		return ruleSet.Match(req.URL.Hostname())
 	}, func(req *http.Request) *http.Response {

--- a/ruleset/ruleset.go
+++ b/ruleset/ruleset.go
@@ -7,6 +7,7 @@
 package ruleset
 
 import (
+	"errors"
 	"regexp"
 	"strings"
 )
@@ -16,11 +17,12 @@ type Regexp struct {
 	exclude *regexp.Regexp
 }
 
+var ErrNoIncludeRules = errors.New("no include rules specified")
+
 // NewRegexp returns the Regexp with given include and exclude rules.
-// When only the exclude rules are specified, the include rule is set to match everything.
-func NewRegexp(include, exclude []*regexp.Regexp) *Regexp {
-	if len(include) == 0 && len(exclude) != 0 {
-		include = []*regexp.Regexp{regexp.MustCompile(".*")}
+func NewRegexp(include, exclude []*regexp.Regexp) (*Regexp, error) {
+	if len(include) == 0 {
+		return nil, ErrNoIncludeRules
 	}
 
 	build := func(rules []*regexp.Regexp) *regexp.Regexp {
@@ -40,7 +42,7 @@ func NewRegexp(include, exclude []*regexp.Regexp) *Regexp {
 	return &Regexp{
 		include: build(include),
 		exclude: build(exclude),
-	}
+	}, nil
 }
 
 // Match returns true if the given string matches at least one of the include rules

--- a/ruleset/ruleset.go
+++ b/ruleset/ruleset.go
@@ -11,14 +11,14 @@ import (
 	"strings"
 )
 
-type RuleSet struct {
+type Regexp struct {
 	include *regexp.Regexp
 	exclude *regexp.Regexp
 }
 
-// NewRuleSet returns the RuleSet with given include and exclude rules.
+// NewRegexp returns the Regexp with given include and exclude rules.
 // When only the exclude rules are specified, the include rule is set to match everything.
-func NewRuleSet(include, exclude []*regexp.Regexp) *RuleSet {
+func NewRegexp(include, exclude []*regexp.Regexp) *Regexp {
 	if len(include) == 0 && len(exclude) != 0 {
 		include = []*regexp.Regexp{regexp.MustCompile(".*")}
 	}
@@ -37,7 +37,7 @@ func NewRuleSet(include, exclude []*regexp.Regexp) *RuleSet {
 		return nil
 	}
 
-	return &RuleSet{
+	return &Regexp{
 		include: build(include),
 		exclude: build(exclude),
 	}
@@ -45,7 +45,7 @@ func NewRuleSet(include, exclude []*regexp.Regexp) *RuleSet {
 
 // Match returns true if the given string matches at least one of the include rules
 // and does not match the exclude rules.
-func (r *RuleSet) Match(s string) bool {
+func (r *Regexp) Match(s string) bool {
 	if r.exclude != nil && r.exclude.MatchString(s) {
 		return false
 	}

--- a/ruleset/ruleset.go
+++ b/ruleset/ruleset.go
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package regex
+package ruleset
 
 import (
 	"regexp"

--- a/ruleset/ruleset_test.go
+++ b/ruleset/ruleset_test.go
@@ -83,7 +83,7 @@ func TestRuleSet(t *testing.T) {
 	for i := range tests {
 		tc := tests[i]
 		t.Run(tc.name, func(t *testing.T) {
-			rs := NewRuleSet(tc.include, tc.exclude)
+			rs := NewRegexp(tc.include, tc.exclude)
 			for _, m := range tc.match {
 				if !rs.Match(m) {
 					t.Errorf("expected %q to match", m)

--- a/ruleset/ruleset_test.go
+++ b/ruleset/ruleset_test.go
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package regex
+package ruleset
 
 import (
 	"regexp"


### PR DESCRIPTION
- renaming: `regex.Ruleset` -> `ruleset.Regexp`
- `ruleset.Regexp` returns an error on creation if no include rules are specified
- adjusted unit tests
- adjusted `--deny-domains-exlude` usage description