### PR TITLE
refactor recent changes to martian logging

### DIFF
--- a/cmd/forwarder/run/run.go
+++ b/cmd/forwarder/run/run.go
@@ -57,9 +57,6 @@ func (c *command) runE(cmd *cobra.Command, _ []string) error {
 
 	// Google Martian uses a global logger package.
 	ml := logger.Named("proxy")
-	ml.Decorate = func(format string) string {
-		return strings.TrimPrefix(format, "martian: ")
-	}
 	martianlog.SetLogger(ml)
 
 	if len(c.dnsConfig.Servers) > 0 {

--- a/httplog/httplog.go
+++ b/httplog/httplog.go
@@ -12,7 +12,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/saucelabs/forwarder/internal/martian"
+	"github.com/saucelabs/forwarder/internal/martian/log"
 	"github.com/saucelabs/forwarder/internal/martian/messageview"
 	"github.com/saucelabs/forwarder/middleware"
 )
@@ -121,8 +121,8 @@ func (w *logWriter) RouteLine(e middleware.LogEntry) {
 }
 
 func (w *logWriter) trace(e middleware.LogEntry) {
-	if ctx := martian.FromContext(e.Request.Context()); ctx != nil {
-		fmt.Fprintf(&w.b, "trace=%s ", ctx.ID())
+	if trace := e.Request.Context().Value(log.TraceContextKey); trace != nil {
+		fmt.Fprintf(&w.b, "[%s] ", trace)
 	}
 }
 

--- a/internal/martian/context.go
+++ b/internal/martian/context.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 // Context provides information and storage for a single request/response pair.
@@ -251,6 +252,10 @@ func newSessionWithResponseWriter(rw http.ResponseWriter) *Session {
 }
 
 var nextID atomic.Uint64
+
+func init() {
+	nextID.Store(uint64(time.Now().UnixMilli()))
+}
 
 // withSession builds a new context from an existing session.
 // Session must be non-nil.

--- a/internal/martian/context.go
+++ b/internal/martian/context.go
@@ -30,7 +30,7 @@ import (
 // a single connection.
 type Context struct {
 	session *Session
-	id      string
+	id      uint64
 
 	mu            sync.RWMutex
 	vals          map[string]any
@@ -192,7 +192,7 @@ func (ctx *Context) Session() *Session {
 
 // ID returns the context ID.
 func (ctx *Context) ID() string {
-	return ctx.id
+	return strconv.FormatUint(ctx.id, 10)
 }
 
 // Get takes key and returns the associated value from the context.
@@ -257,6 +257,6 @@ var nextID atomic.Uint64
 func withSession(s *Session) *Context {
 	return &Context{
 		session: s,
-		id:      strconv.FormatUint(nextID.Add(1), 10),
+		id:      nextID.Add(1),
 	}
 }

--- a/internal/martian/context.go
+++ b/internal/martian/context.go
@@ -24,6 +24,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/saucelabs/forwarder/internal/martian/log"
 )
 
 // Context provides information and storage for a single request/response pair.
@@ -183,7 +185,8 @@ func (ctx *Context) addToContext(rctx context.Context) context.Context {
 	if rctx == nil {
 		rctx = context.Background()
 	}
-	return context.WithValue(rctx, martianKey, ctx)
+	mctx := context.WithValue(rctx, martianKey, ctx)
+	return context.WithValue(mctx, log.TraceContextKey, ctx.ID())
 }
 
 // Session returns the session for the context.

--- a/internal/martian/context.go
+++ b/internal/martian/context.go
@@ -116,7 +116,7 @@ func (s *Session) Hijack() (conn net.Conn, brw *bufio.ReadWriter, err error) {
 	defer s.mu.Unlock()
 
 	if s.hijacked {
-		return nil, nil, fmt.Errorf("martian: session has already been hijacked")
+		return nil, nil, fmt.Errorf("session has already been hijacked")
 	}
 	defer func() {
 		s.hijacked = err == nil
@@ -129,7 +129,7 @@ func (s *Session) Hijack() (conn net.Conn, brw *bufio.ReadWriter, err error) {
 		return http.NewResponseController(s.rw).Hijack()
 	}
 
-	panic("martian: session has no connection or response writer")
+	panic("session has no connection or response writer")
 }
 
 // HijackResponseWriter takes control of the response writer from the proxy.
@@ -138,7 +138,7 @@ func (s *Session) HijackResponseWriter() (http.ResponseWriter, error) {
 	defer s.mu.Unlock()
 
 	if s.hijacked {
-		return nil, fmt.Errorf("martian: session has already been hijacked")
+		return nil, fmt.Errorf("session has already been hijacked")
 	}
 
 	if s.rw != nil {
@@ -146,7 +146,7 @@ func (s *Session) HijackResponseWriter() (http.ResponseWriter, error) {
 		return s.rw, nil
 	}
 
-	return nil, fmt.Errorf("martian: session has no response writer")
+	return nil, fmt.Errorf("session has no response writer")
 }
 
 // Hijacked returns whether the connection has been hijacked.

--- a/internal/martian/context.go
+++ b/internal/martian/context.go
@@ -192,7 +192,7 @@ func (ctx *Context) Session() *Session {
 
 // ID returns the context ID.
 func (ctx *Context) ID() string {
-	return strconv.FormatUint(ctx.id, 10)
+	return strconv.FormatUint(ctx.id, 16)
 }
 
 // Get takes key and returns the associated value from the context.

--- a/internal/martian/h2/h2.go
+++ b/internal/martian/h2/h2.go
@@ -17,6 +17,7 @@ package h2
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
@@ -54,7 +55,7 @@ type Config struct {
 // h2 is being used. Since no browsers use h2c, it's safe to assume all traffic uses TLS.
 func (c *Config) Proxy(closing chan bool, cc io.ReadWriter, url *url.URL) error {
 	if c.EnableDebugLogs {
-		log.Infof("\u001b[1;35mProxying %v with HTTP/2\u001b[0m", url)
+		log.Infof(context.TODO(), "\u001b[1;35mProxying %v with HTTP/2\u001b[0m", url)
 	}
 	sc, err := tls.Dial("tcp", url.Host, &tls.Config{
 		RootCAs:    c.RootCAs,
@@ -103,13 +104,13 @@ func (c *Config) Proxy(closing chan bool, cc io.ReadWriter, url *url.URL) error 
 	go func() { // Forwards frames from client to server.
 		defer wg.Done()
 		if err := cToS.relayFrames(closing); err != nil {
-			log.Errorf("relaying frame from client to %v: %v", url, err)
+			log.Errorf(context.TODO(), "relaying frame from client to %v: %v", url, err)
 		}
 	}()
 	go func() { // Forwards frames from server to client.
 		defer wg.Done()
 		if err := sToC.relayFrames(closing); err != nil {
-			log.Errorf("relaying frame from %v to client: %v", url, err)
+			log.Errorf(context.TODO(), "relaying frame from %v to client: %v", url, err)
 		}
 	}()
 	wg.Wait()

--- a/internal/martian/h2/relay.go
+++ b/internal/martian/h2/relay.go
@@ -17,6 +17,7 @@ package h2
 import (
 	"bytes"
 	"container/list"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -205,7 +206,7 @@ func (r *relay) relayFrames(closing chan bool) error {
 				return fmt.Errorf("processing frame: %w", err)
 			}
 			if *r.enableDebugLogs {
-				log.Infof("%s--%v-->%s", r.srcLabel, frame, r.destLabel)
+				log.Infof(context.TODO(), "%s--%v-->%s", r.srcLabel, frame, r.destLabel)
 			}
 		case err := <-writerErr:
 			return fmt.Errorf("sending frame: %w", err)
@@ -531,7 +532,7 @@ func (r *relay) encodeFull(headers []hpack.HeaderField) ([]byte, error) {
 		}
 	}
 	if *r.enableDebugLogs {
-		log.Infof("sending headers %s -> %s:\n%s", r.srcLabel, r.destLabel, buf.Bytes())
+		log.Infof(context.TODO(), "sending headers %s -> %s:\n%s", r.srcLabel, r.destLabel, buf.Bytes())
 	}
 	return r.reencoded.Bytes(), nil
 }

--- a/internal/martian/handler.go
+++ b/internal/martian/handler.go
@@ -105,15 +105,15 @@ func (p proxyHandler) handleConnectRequest(ctx *Context, rw http.ResponseWriter,
 	session := ctx.Session()
 
 	if err := p.reqmod.ModifyRequest(req); err != nil {
-		log.Errorf(req.Context(), "martian: error modifying CONNECT request: %v", err)
+		log.Errorf(req.Context(), "error modifying CONNECT request: %v", err)
 		p.warning(req.Header, err)
 	}
 	if session.Hijacked() {
-		log.Debugf(req.Context(), "martian: connection hijacked by request modifier")
+		log.Debugf(req.Context(), "connection hijacked by request modifier")
 		return
 	}
 
-	log.Debugf(req.Context(), "martian: attempting to establish CONNECT tunnel: %s", req.URL.Host)
+	log.Debugf(req.Context(), "attempting to establish CONNECT tunnel: %s", req.URL.Host)
 	var (
 		res  *http.Response
 		cr   io.Reader
@@ -147,24 +147,24 @@ func (p proxyHandler) handleConnectRequest(ctx *Context, rw http.ResponseWriter,
 	}
 
 	if cerr != nil {
-		log.Errorf(req.Context(), "martian: failed to CONNECT: %v", cerr)
+		log.Errorf(req.Context(), "failed to CONNECT: %v", cerr)
 		res = p.errorResponse(req, cerr)
 		p.warning(res.Header, cerr)
 	}
 	defer res.Body.Close()
 
 	if err := p.resmod.ModifyResponse(res); err != nil {
-		log.Errorf(req.Context(), "martian: error modifying CONNECT response: %v", err)
+		log.Errorf(req.Context(), "error modifying CONNECT response: %v", err)
 		p.warning(res.Header, err)
 	}
 	if session.Hijacked() {
-		log.Debugf(req.Context(), "martian: connection hijacked by response modifier")
+		log.Debugf(req.Context(), "connection hijacked by response modifier")
 		return
 	}
 
 	if res.StatusCode != http.StatusOK {
 		if cerr == nil {
-			log.Errorf(req.Context(), "martian: CONNECT rejected with status code: %d", res.StatusCode)
+			log.Errorf(req.Context(), "CONNECT rejected with status code: %d", res.StatusCode)
 		}
 		writeResponse(rw, res)
 		return
@@ -175,7 +175,7 @@ func (p proxyHandler) handleConnectRequest(ctx *Context, rw http.ResponseWriter,
 	}
 
 	if err := p.tunnel("CONNECT", rw, req, res, cw, cr); err != nil {
-		log.Errorf(req.Context(), "martian: CONNECT tunnel: %v", err)
+		log.Errorf(req.Context(), "CONNECT tunnel: %v", err)
 		panic(http.ErrAbortHandler)
 	}
 }
@@ -185,14 +185,14 @@ func (p proxyHandler) handleUpgradeResponse(rw http.ResponseWriter, req *http.Re
 
 	uconn, ok := res.Body.(io.ReadWriteCloser)
 	if !ok {
-		log.Errorf(req.Context(), "martian: %s tunnel: internal error: switching protocols response with non-ReadWriteCloser body", resUpType)
+		log.Errorf(req.Context(), "%s tunnel: internal error: switching protocols response with non-ReadWriteCloser body", resUpType)
 		panic(http.ErrAbortHandler)
 	}
 
 	res.Body = nil
 
 	if err := p.tunnel(resUpType, rw, req, res, uconn, uconn); err != nil {
-		log.Errorf(req.Context(), "martian: %s tunnel: %w", resUpType, err)
+		log.Errorf(req.Context(), "%s tunnel: %w", resUpType, err)
 		panic(http.ErrAbortHandler)
 	}
 }
@@ -236,10 +236,10 @@ func (p proxyHandler) tunnel(name string, rw http.ResponseWriter, req *http.Requ
 		return fmt.Errorf("unsupported protocol version: %d", req.ProtoMajor)
 	}
 
-	log.Debugf(req.Context(), "martian: established %s tunnel, proxying traffic", name)
+	log.Debugf(req.Context(), "established %s tunnel, proxying traffic", name)
 	<-donec
 	<-donec
-	log.Debugf(req.Context(), "martian: closed %s tunnel", name)
+	log.Debugf(req.Context(), "closed %s tunnel", name)
 
 	return nil
 }
@@ -266,21 +266,21 @@ func (p proxyHandler) handleRequest(ctx *Context, rw http.ResponseWriter, req *h
 		}
 	} else if req.URL.Scheme == "http" {
 		if session.IsSecure() && !p.AllowHTTP {
-			log.Infof(req.Context(), "martian: forcing HTTPS inside secure session")
+			log.Infof(req.Context(), "forcing HTTPS inside secure session")
 			req.URL.Scheme = "https"
 		}
 	}
 
 	reqUpType := upgradeType(req.Header)
 	if reqUpType != "" {
-		log.Debugf(req.Context(), "martian: upgrade request: %s", reqUpType)
+		log.Debugf(req.Context(), "upgrade request: %s", reqUpType)
 	}
 	if err := p.reqmod.ModifyRequest(req); err != nil {
-		log.Errorf(req.Context(), "martian: error modifying request: %v", err)
+		log.Errorf(req.Context(), "error modifying request: %v", err)
 		p.warning(req.Header, err)
 	}
 	if session.Hijacked() {
-		log.Debugf(req.Context(), "martian: connection hijacked by request modifier")
+		log.Debugf(req.Context(), "connection hijacked by request modifier")
 		return
 	}
 
@@ -294,7 +294,7 @@ func (p proxyHandler) handleRequest(ctx *Context, rw http.ResponseWriter, req *h
 	// perform the HTTP roundtrip
 	res, err := p.roundTrip(ctx, req)
 	if err != nil {
-		log.Errorf(req.Context(), "martian: failed to round trip: %v", err)
+		log.Errorf(req.Context(), "failed to round trip: %v", err)
 		res = p.errorResponse(req, err)
 		p.warning(res.Header, err)
 	}
@@ -306,14 +306,14 @@ func (p proxyHandler) handleRequest(ctx *Context, rw http.ResponseWriter, req *h
 
 	resUpType := upgradeType(res.Header)
 	if resUpType != "" {
-		log.Debugf(req.Context(), "martian: upgrade response: %s", resUpType)
+		log.Debugf(req.Context(), "upgrade response: %s", resUpType)
 	}
 	if err := p.resmod.ModifyResponse(res); err != nil {
-		log.Errorf(req.Context(), "martian: error modifying response: %v", err)
+		log.Errorf(req.Context(), "error modifying response: %v", err)
 		p.warning(res.Header, err)
 	}
 	if session.Hijacked() {
-		log.Debugf(req.Context(), "martian: connection hijacked by response modifier")
+		log.Debugf(req.Context(), "connection hijacked by response modifier")
 		return
 	}
 
@@ -325,7 +325,7 @@ func (p proxyHandler) handleRequest(ctx *Context, rw http.ResponseWriter, req *h
 	}
 
 	if !req.ProtoAtLeast(1, 1) || req.Close || res.Close || p.Closing() {
-		log.Debugf(req.Context(), "martian: received close request: %v", req.RemoteAddr)
+		log.Debugf(req.Context(), "received close request: %v", req.RemoteAddr)
 		res.Close = true
 	}
 	if p.CloseAfterReply {
@@ -357,7 +357,7 @@ func (w writeFlusher) Write(p []byte) (n int, err error) {
 
 	if n > 0 {
 		if err := w.rc.Flush(); err != nil {
-			log.Errorf(context.TODO(), "martian: got error while flushing response back to client: %v", err)
+			log.Errorf(context.TODO(), "got error while flushing response back to client: %v", err)
 		}
 	}
 
@@ -391,7 +391,7 @@ func writeResponse(rw http.ResponseWriter, res *http.Response) {
 		err = copyBody(rw, res.Body)
 	}
 	if err != nil {
-		log.Errorf(res.Request.Context(), "martian: got error while writing response back to client: %v", err)
+		log.Errorf(res.Request.Context(), "got error while writing response back to client: %v", err)
 		panic(http.ErrAbortHandler)
 	}
 

--- a/internal/martian/log/log.go
+++ b/internal/martian/log/log.go
@@ -15,6 +15,11 @@
 // Package log provides a universal logger for martian packages.
 package log
 
+import (
+	"context"
+	"fmt"
+)
+
 type Logger interface {
 	Infof(format string, args ...any)
 	Debugf(format string, args ...any)
@@ -30,19 +35,30 @@ func SetLogger(l Logger) {
 	currLogger = l
 }
 
+type contextKey string
+
+const TraceContextKey contextKey = "trace"
+
 // Infof logs an info message.
-func Infof(format string, args ...any) {
-	currLogger.Infof(format, args...)
+func Infof(ctx context.Context, format string, args ...any) {
+	currLogger.Infof(withTrace(ctx, format), args...)
 }
 
 // Debugf logs a debug message.
-func Debugf(format string, args ...any) {
-	currLogger.Debugf(format, args...)
+func Debugf(ctx context.Context, format string, args ...any) {
+	currLogger.Debugf(withTrace(ctx, format), args...)
 }
 
 // Errorf logs an error message.
-func Errorf(format string, args ...any) {
-	currLogger.Errorf(format, args...)
+func Errorf(ctx context.Context, format string, args ...any) {
+	currLogger.Errorf(withTrace(ctx, format), args...)
+}
+
+func withTrace(ctx context.Context, format string) string {
+	if v := ctx.Value(TraceContextKey); v != nil {
+		format = fmt.Sprintf("[%s] %s", v, format)
+	}
+	return format
 }
 
 type nopLogger struct{}

--- a/internal/martian/log/log.go
+++ b/internal/martian/log/log.go
@@ -15,16 +15,18 @@
 // Package log provides a universal logger for martian packages.
 package log
 
-import (
-	"github.com/saucelabs/forwarder/log"
-)
+type Logger interface {
+	Infof(format string, args ...any)
+	Debugf(format string, args ...any)
+	Errorf(format string, args ...any)
+}
 
-var currLogger log.Logger = log.NopLogger
+var currLogger Logger = nopLogger{}
 
 // SetLogger changes the default logger. This must be called very first,
 // before interacting with rest of the martian package. Changing it at
 // runtime is not supported.
-func SetLogger(l log.Logger) {
+func SetLogger(l Logger) {
 	currLogger = l
 }
 
@@ -43,8 +45,10 @@ func Errorf(format string, args ...any) {
 	currLogger.Errorf(format, args...)
 }
 
-const traceIDKey = "trace"
+type nopLogger struct{}
 
-func WithTraceID(value string) log.Logger {
-	return currLogger.WithValue(traceIDKey, value)
-}
+func (nopLogger) Infof(_ string, _ ...any) {}
+
+func (nopLogger) Debugf(_ string, _ ...any) {}
+
+func (nopLogger) Errorf(_ string, _ ...any) {}

--- a/internal/martian/mitm/mitm.go
+++ b/internal/martian/mitm/mitm.go
@@ -19,6 +19,7 @@ package mitm
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
@@ -244,7 +245,7 @@ func (c *Config) cert(hostname string) (*tls.Certificate, error) {
 	c.certmu.RUnlock()
 
 	if ok {
-		log.Debugf("mitm: cache hit for %s", hostname)
+		log.Debugf(context.TODO(), "mitm: cache hit for %s", hostname)
 
 		// Check validity of the certificate for hostname match, expiry, etc. In
 		// particular, if the cached certificate has expired, create a new one.
@@ -255,10 +256,10 @@ func (c *Config) cert(hostname string) (*tls.Certificate, error) {
 			return tlsc, nil
 		}
 
-		log.Debugf("mitm: invalid certificate in cache for %s", hostname)
+		log.Debugf(context.TODO(), "mitm: invalid certificate in cache for %s", hostname)
 	}
 
-	log.Debugf("mitm: cache miss for %s", hostname)
+	log.Debugf(context.TODO(), "mitm: cache miss for %s", hostname)
 
 	serial, err := rand.Int(rand.Reader, MaxSerialNumber)
 	if err != nil {

--- a/internal/martian/noop.go
+++ b/internal/martian/noop.go
@@ -15,6 +15,7 @@
 package martian
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/saucelabs/forwarder/internal/martian/log"
@@ -33,12 +34,12 @@ func Noop(id string) RequestResponseModifier {
 
 // ModifyRequest logs a debug line.
 func (nm *noopModifier) ModifyRequest(*http.Request) error {
-	log.Debugf("%s: no request modifier configured", nm.id)
+	log.Debugf(context.TODO(), "%s: no request modifier configured", nm.id)
 	return nil
 }
 
 // ModifyResponse logs a debug line.
 func (nm *noopModifier) ModifyResponse(*http.Response) error {
-	log.Debugf("%s: no response modifier configured", nm.id)
+	log.Debugf(context.TODO(), "%s: no response modifier configured", nm.id)
 	return nil
 }

--- a/internal/martian/nosigpipe/nosigpipe_darwin.go
+++ b/internal/martian/nosigpipe/nosigpipe_darwin.go
@@ -4,6 +4,7 @@
 package nosigpipe
 
 import (
+	"context"
 	"net"
 	"syscall"
 
@@ -22,16 +23,16 @@ func IgnoreSIGPIPE(c net.Conn) {
 	}
 	r, e := s.SyscallConn()
 	if e != nil {
-		log.Errorf("Failed to get SyscallConn: %s", e)
+		log.Errorf(context.TODO(), "Failed to get SyscallConn: %s", e)
 		return
 	}
 	e = r.Control(func(fd uintptr) {
 		intfd := int(fd)
 		if e := syscall.SetsockoptInt(intfd, syscall.SOL_SOCKET, syscall.SO_NOSIGPIPE, 1); e != nil {
-			log.Errorf("Failed to set SO_NOSIGPIPE: %s", e)
+			log.Errorf(context.TODO(), "Failed to set SO_NOSIGPIPE: %s", e)
 		}
 	})
 	if e != nil {
-		log.Errorf("Failed to set SO_NOSIGPIPE: %s", e)
+		log.Errorf(context.TODO(), "Failed to set SO_NOSIGPIPE: %s", e)
 	}
 }

--- a/internal/martian/proxy.go
+++ b/internal/martian/proxy.go
@@ -34,7 +34,6 @@ import (
 	"github.com/saucelabs/forwarder/internal/martian/mitm"
 	"github.com/saucelabs/forwarder/internal/martian/nosigpipe"
 	"github.com/saucelabs/forwarder/internal/martian/proxyutil"
-	forwarderlog "github.com/saucelabs/forwarder/log"
 	"golang.org/x/net/http/httpguts"
 )
 
@@ -371,43 +370,41 @@ func (p *Proxy) readRequest(ctx *Context, conn net.Conn, brw *bufio.ReadWriter) 
 }
 
 func (p *Proxy) handleConnectRequest(ctx *Context, req *http.Request, session *Session, brw *bufio.ReadWriter, conn net.Conn) error {
-	tracedLog := log.WithTraceID(ctx.ID())
-
 	if err := p.reqmod.ModifyRequest(req); err != nil {
-		tracedLog.Errorf("martian: error modifying CONNECT request: %v", err)
+		log.Errorf("martian: error modifying CONNECT request: %v", err)
 		p.warning(req.Header, err)
 	}
 	if session.Hijacked() {
-		tracedLog.Debugf("martian: connection hijacked by request modifier")
+		log.Debugf("martian: connection hijacked by request modifier")
 		return nil
 	}
 
 	if p.mitm != nil {
-		tracedLog.Debugf("martian: attempting MITM for connection: %s / %s", req.Host, req.URL.String())
+		log.Debugf("martian: attempting MITM for connection: %s / %s", req.Host, req.URL.String())
 
 		res := proxyutil.NewResponse(200, nil, req)
 
 		if err := p.resmod.ModifyResponse(res); err != nil {
-			tracedLog.Errorf("martian: error modifying CONNECT response: %v", err)
+			log.Errorf("martian: error modifying CONNECT response: %v", err)
 			p.warning(res.Header, err)
 		}
 		if session.Hijacked() {
-			tracedLog.Debugf("martian: connection hijacked by response modifier")
+			log.Debugf("martian: connection hijacked by response modifier")
 			return nil
 		}
 
 		if err := res.Write(brw); err != nil {
-			tracedLog.Errorf("martian: got error while writing response back to client: %v", err)
+			log.Errorf("martian: got error while writing response back to client: %v", err)
 		}
 		if err := brw.Flush(); err != nil {
-			tracedLog.Errorf("martian: got error while flushing response back to client: %v", err)
+			log.Errorf("martian: got error while flushing response back to client: %v", err)
 		}
 
-		tracedLog.Debugf("martian: completed MITM for connection: %s", req.Host)
+		log.Debugf("martian: completed MITM for connection: %s", req.Host)
 
 		b := make([]byte, 1)
 		if _, err := brw.Read(b); err != nil {
-			tracedLog.Errorf("martian: error peeking message through CONNECT tunnel to determine type: %v", err)
+			log.Errorf("martian: error peeking message through CONNECT tunnel to determine type: %v", err)
 		}
 
 		// Drain all of the rest of the buffered data.
@@ -439,7 +436,7 @@ func (p *Proxy) handleConnectRequest(ctx *Context, req *http.Request, session *S
 		return p.handle(ctx, conn, brw)
 	}
 
-	tracedLog.Debugf("martian: attempting to establish CONNECT tunnel: %s", req.URL.Host)
+	log.Debugf("martian: attempting to establish CONNECT tunnel: %s", req.URL.Host)
 	var (
 		res  *http.Response
 		cr   io.Reader
@@ -463,7 +460,7 @@ func (p *Proxy) handleConnectRequest(ctx *Context, req *http.Request, session *S
 		}
 	} else {
 		var cconn net.Conn
-		res, cconn, cerr = p.connect(ctx, req)
+		res, cconn, cerr = p.connect(req)
 
 		if cconn != nil {
 			defer cconn.Close()
@@ -473,63 +470,63 @@ func (p *Proxy) handleConnectRequest(ctx *Context, req *http.Request, session *S
 	}
 
 	if cerr != nil {
-		tracedLog.Errorf("martian: failed to CONNECT: %v", cerr)
+		log.Errorf("martian: failed to CONNECT: %v", cerr)
 		res = p.errorResponse(req, cerr)
 		p.warning(res.Header, cerr)
 	}
 	defer res.Body.Close()
 
 	if err := p.resmod.ModifyResponse(res); err != nil {
-		tracedLog.Errorf("martian: error modifying CONNECT response: %v", err)
+		log.Errorf("martian: error modifying CONNECT response: %v", err)
 		p.warning(res.Header, err)
 	}
 	if session.Hijacked() {
-		tracedLog.Debugf("martian: connection hijacked by response modifier")
+		log.Debugf("martian: connection hijacked by response modifier")
 		return nil
 	}
 
 	if res.StatusCode != http.StatusOK {
 		if cerr == nil {
-			tracedLog.Errorf("martian: CONNECT rejected with status code: %d", res.StatusCode)
+			log.Errorf("martian: CONNECT rejected with status code: %d", res.StatusCode)
 		}
 		if err := res.Write(brw); err != nil {
-			tracedLog.Errorf("martian: got error while writing response back to client: %v", err)
+			log.Errorf("martian: got error while writing response back to client: %v", err)
 		}
 		err := brw.Flush()
 		if err != nil {
-			tracedLog.Errorf("martian: got error while flushing response back to client: %v", err)
+			log.Errorf("martian: got error while flushing response back to client: %v", err)
 		}
 		return err
 	}
 
 	res.ContentLength = -1
 
-	if err := p.tunnel(ctx, "CONNECT", res, brw, conn, cw, cr); err != nil {
-		tracedLog.Errorf("martian: CONNECT tunnel: %w", err)
+	if err := p.tunnel("CONNECT", res, brw, conn, cw, cr); err != nil {
+		log.Errorf("martian: CONNECT tunnel: %w", err)
 	}
 
 	return errClose
 }
 
-func (p *Proxy) handleUpgradeResponse(ctx *Context, res *http.Response, brw *bufio.ReadWriter, conn net.Conn) error {
+func (p *Proxy) handleUpgradeResponse(res *http.Response, brw *bufio.ReadWriter, conn net.Conn) error {
 	resUpType := upgradeType(res.Header)
 
 	uconn, ok := res.Body.(io.ReadWriteCloser)
 	if !ok {
-		log.WithTraceID(ctx.ID()).Errorf("martian: internal error: switching protocols response with non-writable body")
+		log.Errorf("martian: internal error: switching protocols response with non-writable body")
 		return errClose
 	}
 
 	res.Body = nil
 
-	if err := p.tunnel(ctx, resUpType, res, brw, conn, uconn, uconn); err != nil {
-		log.WithTraceID(ctx.ID()).Errorf("martian: %s tunnel: %w", resUpType, err)
+	if err := p.tunnel(resUpType, res, brw, conn, uconn, uconn); err != nil {
+		log.Errorf("martian: %s tunnel: %w", resUpType, err)
 	}
 
 	return errClose
 }
 
-func (p *Proxy) tunnel(ctx *Context, name string, res *http.Response, brw *bufio.ReadWriter, conn net.Conn, cw io.Writer, cr io.Reader) error {
+func (p *Proxy) tunnel(name string, res *http.Response, brw *bufio.ReadWriter, conn net.Conn, cw io.Writer, cr io.Reader) error {
 	if err := res.Write(brw); err != nil {
 		return fmt.Errorf("got error while writing response back to client: %w", err)
 	}
@@ -540,16 +537,14 @@ func (p *Proxy) tunnel(ctx *Context, name string, res *http.Response, brw *bufio
 		return fmt.Errorf("got error while draining read buffer: %w", err)
 	}
 
-	tracedLog := log.WithTraceID(ctx.ID())
-
 	donec := make(chan bool, 2)
-	go copySync(tracedLog, "outbound "+name, cw, conn, donec)
-	go copySync(tracedLog, "inbound "+name, conn, cr, donec)
+	go copySync("outbound "+name, cw, conn, donec)
+	go copySync("inbound "+name, conn, cr, donec)
 
-	tracedLog.Debugf("martian: switched protocols, proxying %s traffic", name)
+	log.Debugf("martian: switched protocols, proxying %s traffic", name)
 	<-donec
 	<-donec
-	tracedLog.Debugf("martian: closed %s tunnel", name)
+	log.Debugf("martian: closed %s tunnel", name)
 
 	return nil
 }
@@ -572,23 +567,23 @@ var copyBufPool = sync.Pool{
 	},
 }
 
-func copySync(l forwarderlog.Logger, name string, w io.Writer, r io.Reader, donec chan<- bool) {
+func copySync(name string, w io.Writer, r io.Reader, donec chan<- bool) {
 	bufp := copyBufPool.Get().(*[]byte) //nolint:forcetypeassert // It's *[]byte.
 	buf := *bufp
 	defer copyBufPool.Put(bufp)
 
 	if _, err := io.CopyBuffer(w, r, buf); err != nil && !errors.Is(err, io.EOF) {
-		l.Errorf("martian: failed to copy %s tunnel: %v", name, err)
+		log.Errorf("martian: failed to copy %s tunnel: %v", name, err)
 	}
 	if cw, ok := asCloseWriter(w); ok {
 		cw.CloseWrite()
 	} else if pw, ok := w.(*io.PipeWriter); ok {
 		pw.Close()
 	} else {
-		l.Errorf("martian: cannot close write side of %s tunnel (%T)", name, w)
+		log.Errorf("martian: cannot close write side of %s tunnel (%T)", name, w)
 	}
 
-	l.Debugf("martian: %s tunnel finished copying", name)
+	log.Debugf("martian: %s tunnel finished copying", name)
 	donec <- true
 }
 
@@ -603,8 +598,6 @@ func (p *Proxy) handle(ctx *Context, conn net.Conn, brw *bufio.ReadWriter) error
 		return err
 	}
 	defer req.Body.Close()
-
-	tracedLog := log.WithTraceID(ctx.ID())
 
 	if tconn, ok := conn.(*tls.Conn); ok {
 		session.MarkSecure()
@@ -629,21 +622,21 @@ func (p *Proxy) handle(ctx *Context, conn net.Conn, brw *bufio.ReadWriter) error
 		}
 	} else if req.URL.Scheme == "http" {
 		if session.IsSecure() && !p.AllowHTTP {
-			tracedLog.Infof("martian: forcing HTTPS inside secure session")
+			log.Infof("martian: forcing HTTPS inside secure session")
 			req.URL.Scheme = "https"
 		}
 	}
 
 	reqUpType := upgradeType(req.Header)
 	if reqUpType != "" {
-		tracedLog.Debugf("martian: upgrade request: %s", reqUpType)
+		log.Debugf("martian: upgrade request: %s", reqUpType)
 	}
 	if err := p.reqmod.ModifyRequest(req); err != nil {
-		tracedLog.Errorf("martian: error modifying request: %v", err)
+		log.Errorf("martian: error modifying request: %v", err)
 		p.warning(req.Header, err)
 	}
 	if session.Hijacked() {
-		tracedLog.Debugf("martian: connection hijacked by request modifier")
+		log.Debugf("martian: connection hijacked by request modifier")
 		return nil
 	}
 
@@ -657,7 +650,7 @@ func (p *Proxy) handle(ctx *Context, conn net.Conn, brw *bufio.ReadWriter) error
 	// perform the HTTP roundtrip
 	res, err := p.roundTrip(ctx, req)
 	if err != nil {
-		tracedLog.Errorf("martian: failed to round trip: %v", err)
+		log.Errorf("martian: failed to round trip: %v", err)
 		res = p.errorResponse(req, err)
 		p.warning(res.Header, err)
 	}
@@ -669,14 +662,14 @@ func (p *Proxy) handle(ctx *Context, conn net.Conn, brw *bufio.ReadWriter) error
 
 	resUpType := upgradeType(res.Header)
 	if resUpType != "" {
-		tracedLog.Debugf("martian: upgrade response: %s", resUpType)
+		log.Debugf("martian: upgrade response: %s", resUpType)
 	}
 	if err := p.resmod.ModifyResponse(res); err != nil {
-		tracedLog.Errorf("martian: error modifying response: %v", err)
+		log.Errorf("martian: error modifying response: %v", err)
 		p.warning(res.Header, err)
 	}
 	if session.Hijacked() {
-		tracedLog.Debugf("martian: connection hijacked by response modifier")
+		log.Debugf("martian: connection hijacked by response modifier")
 		return nil
 	}
 
@@ -689,19 +682,19 @@ func (p *Proxy) handle(ctx *Context, conn net.Conn, brw *bufio.ReadWriter) error
 
 	var closing error
 	if !req.ProtoAtLeast(1, 1) || req.Close || res.Close || p.Closing() {
-		tracedLog.Debugf("martian: received close request: %v", req.RemoteAddr)
+		log.Debugf("martian: received close request: %v", req.RemoteAddr)
 		res.Close = true
 		closing = errClose
 	}
 
 	// deal with 101 Switching Protocols responses: (WebSocket, h2c, etc)
 	if res.StatusCode == http.StatusSwitchingProtocols {
-		return p.handleUpgradeResponse(ctx, res, brw, conn)
+		return p.handleUpgradeResponse(res, brw, conn)
 	}
 
 	if p.WriteTimeout > 0 {
 		if deadlineErr := conn.SetWriteDeadline(time.Now().Add(p.WriteTimeout)); deadlineErr != nil {
-			tracedLog.Errorf("martian: can't set write deadline: %v", deadlineErr)
+			log.Errorf("martian: can't set write deadline: %v", deadlineErr)
 		}
 	}
 
@@ -721,14 +714,14 @@ func (p *Proxy) handle(ctx *Context, conn net.Conn, brw *bufio.ReadWriter) error
 		}
 	}
 	if err != nil {
-		tracedLog.Errorf("martian: got error while writing response back to client: %v", err)
+		log.Errorf("martian: got error while writing response back to client: %v", err)
 		if errors.Is(err, io.ErrUnexpectedEOF) {
 			closing = errClose
 		}
 	}
 	err = brw.Flush()
 	if err != nil {
-		tracedLog.Errorf("martian: got error while flushing response back to client: %v", err)
+		log.Errorf("martian: got error while flushing response back to client: %v", err)
 	}
 
 	if p.CloseAfterReply {
@@ -751,7 +744,7 @@ func (c *peekedConn) Read(buf []byte) (int, error) { return c.r.Read(buf) }
 
 func (p *Proxy) roundTrip(ctx *Context, req *http.Request) (*http.Response, error) {
 	if ctx.SkippingRoundTrip() {
-		log.WithTraceID(ctx.ID()).Debugf("martian: skipping round trip")
+		log.Debugf("martian: skipping round trip")
 		return proxyutil.NewResponse(200, http.NoBody, req), nil
 	}
 
@@ -772,7 +765,7 @@ func (p *Proxy) errorResponse(req *http.Request, err error) *http.Response {
 	return proxyutil.NewResponse(502, http.NoBody, req)
 }
 
-func (p *Proxy) connect(ctx *Context, req *http.Request) (*http.Response, net.Conn, error) {
+func (p *Proxy) connect(req *http.Request) (*http.Response, net.Conn, error) {
 	var proxyURL *url.URL
 	if p.proxyURL != nil {
 		u, err := p.proxyURL(req)
@@ -783,7 +776,7 @@ func (p *Proxy) connect(ctx *Context, req *http.Request) (*http.Response, net.Co
 	}
 
 	if proxyURL == nil {
-		log.WithTraceID(ctx.ID()).Debugf("martian: CONNECT to host directly: %s", req.URL.Host)
+		log.Debugf("martian: CONNECT to host directly: %s", req.URL.Host)
 
 		conn, err := p.dial(req.Context(), "tcp", req.URL.Host)
 		if err != nil {
@@ -795,16 +788,16 @@ func (p *Proxy) connect(ctx *Context, req *http.Request) (*http.Response, net.Co
 
 	switch proxyURL.Scheme {
 	case "http", "https":
-		return p.connectHTTP(ctx, req, proxyURL)
+		return p.connectHTTP(req, proxyURL)
 	case "socks5":
-		return p.connectSOCKS5(ctx, req, proxyURL)
+		return p.connectSOCKS5(req, proxyURL)
 	default:
 		return nil, nil, fmt.Errorf("martian: unsupported proxy scheme: %s", proxyURL.Scheme)
 	}
 }
 
-func (p *Proxy) connectHTTP(ctx *Context, req *http.Request, proxyURL *url.URL) (res *http.Response, conn net.Conn, err error) {
-	log.WithTraceID(ctx.ID()).Debugf("martian: CONNECT with upstream HTTP proxy: %s", proxyURL.Host)
+func (p *Proxy) connectHTTP(req *http.Request, proxyURL *url.URL) (res *http.Response, conn net.Conn, err error) {
+	log.Debugf("martian: CONNECT with upstream HTTP proxy: %s", proxyURL.Host)
 
 	if proxyURL.Scheme == "https" {
 		d := dialvia.HTTPSProxy(p.dial, proxyURL, p.clientTLSConfig())
@@ -836,8 +829,8 @@ func (p *Proxy) clientTLSConfig() *tls.Config {
 	return &tls.Config{}
 }
 
-func (p *Proxy) connectSOCKS5(ctx *Context, req *http.Request, proxyURL *url.URL) (*http.Response, net.Conn, error) {
-	log.WithTraceID(ctx.ID()).Debugf("martian: CONNECT with upstream SOCKS5 proxy: %s", proxyURL.Host)
+func (p *Proxy) connectSOCKS5(req *http.Request, proxyURL *url.URL) (*http.Response, net.Conn, error) {
+	log.Debugf("martian: CONNECT with upstream SOCKS5 proxy: %s", proxyURL.Host)
 
 	d := dialvia.SOCKS5Proxy(p.dial, proxyURL)
 

--- a/internal/martian/proxy_test.go
+++ b/internal/martian/proxy_test.go
@@ -17,6 +17,7 @@ package martian
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -266,27 +267,27 @@ func TestIntegrationHTTP100Continue(t *testing.T) {
 	go func() {
 		conn, err := sl.Accept()
 		if err != nil {
-			log.Errorf("proxy_test: failed to accept connection: %v", err)
+			log.Errorf(context.TODO(), "proxy_test: failed to accept connection: %v", err)
 			return
 		}
 		defer conn.Close()
 
-		log.Infof("proxy_test: accepted connection: %s", conn.RemoteAddr())
+		log.Infof(context.TODO(), "proxy_test: accepted connection: %s", conn.RemoteAddr())
 
 		req, err := http.ReadRequest(bufio.NewReader(conn))
 		if err != nil {
-			log.Errorf("proxy_test: failed to read request: %v", err)
+			log.Errorf(context.TODO(), "proxy_test: failed to read request: %v", err)
 			return
 		}
 
 		if req.Header.Get("Expect") == "100-continue" {
-			log.Infof("proxy_test: received 100-continue request")
+			log.Infof(context.TODO(), "proxy_test: received 100-continue request")
 
 			conn.Write([]byte("HTTP/1.1 100 Continue\r\n\r\n"))
 
-			log.Infof("proxy_test: sent 100-continue response")
+			log.Infof(context.TODO(), "proxy_test: sent 100-continue response")
 		} else {
-			log.Infof("proxy_test: received non 100-continue request")
+			log.Infof(context.TODO(), "proxy_test: received non 100-continue request")
 
 			res := proxyutil.NewResponse(417, nil, req)
 			res.Header.Set("Connection", "close")
@@ -298,7 +299,7 @@ func TestIntegrationHTTP100Continue(t *testing.T) {
 		res.Header.Set("Connection", "close")
 		res.Write(conn)
 
-		log.Infof("proxy_test: sent 200 response")
+		log.Infof(context.TODO(), "proxy_test: sent 200 response")
 	}()
 
 	tm := martiantest.NewModifier()
@@ -375,34 +376,34 @@ func TestIntegrationHTTP101SwitchingProtocols(t *testing.T) {
 	go func() {
 		conn, err := sl.Accept()
 		if err != nil {
-			log.Errorf("proxy_test: failed to accept connection: %v", err)
+			log.Errorf(context.TODO(), "proxy_test: failed to accept connection: %v", err)
 			return
 		}
 		defer conn.Close()
 
-		log.Infof("proxy_test: accepted connection: %s", conn.RemoteAddr())
+		log.Infof(context.TODO(), "proxy_test: accepted connection: %s", conn.RemoteAddr())
 
 		req, err := http.ReadRequest(bufio.NewReader(conn))
 		if err != nil {
-			log.Errorf("proxy_test: failed to read request: %v", err)
+			log.Errorf(context.TODO(), "proxy_test: failed to read request: %v", err)
 			return
 		}
 
 		if reqUpType := upgradeType(req.Header); reqUpType != "" {
-			log.Infof("proxy_test: received upgrade request")
+			log.Infof(context.TODO(), "proxy_test: received upgrade request")
 
 			res := proxyutil.NewResponse(101, nil, req)
 			res.Header.Set("Connection", "upgrade")
 			res.Header.Set("Upgrade", reqUpType)
 
 			res.Write(conn)
-			log.Infof("proxy_test: sent 101 response")
+			log.Infof(context.TODO(), "proxy_test: sent 101 response")
 
 			if _, err := io.Copy(conn, conn); err != nil {
-				log.Errorf("proxy_test: failed to copy connection: %v", err)
+				log.Errorf(context.TODO(), "proxy_test: failed to copy connection: %v", err)
 			}
 		} else {
-			log.Infof("proxy_test: received non upgrade request")
+			log.Infof(context.TODO(), "proxy_test: received non upgrade request")
 
 			res := proxyutil.NewResponse(417, nil, req)
 			res.Header.Set("Connection", "close")
@@ -410,7 +411,7 @@ func TestIntegrationHTTP101SwitchingProtocols(t *testing.T) {
 			return
 		}
 
-		log.Infof("proxy_test: closed connection")
+		log.Infof(context.TODO(), "proxy_test: closed connection")
 	}()
 
 	tm := martiantest.NewModifier()
@@ -490,16 +491,16 @@ func TestIntegrationUnexpectedUpstreamFailure(t *testing.T) {
 		time.Sleep(1 * time.Second)
 		conn, err := sl.Accept()
 		if err != nil {
-			log.Errorf("proxy_test: failed to accept connection: %v", err)
+			log.Errorf(context.TODO(), "proxy_test: failed to accept connection: %v", err)
 			return
 		}
 		defer conn.Close()
 
-		log.Infof("proxy_test: accepted connection: %s\n", conn.RemoteAddr())
+		log.Infof(context.TODO(), "proxy_test: accepted connection: %s\n", conn.RemoteAddr())
 
 		req, err := http.ReadRequest(bufio.NewReader(conn))
 		if err != nil {
-			log.Errorf("proxy_test: failed to read request: %v", err)
+			log.Errorf(context.TODO(), "proxy_test: failed to read request: %v", err)
 			return
 		}
 
@@ -519,7 +520,7 @@ func TestIntegrationUnexpectedUpstreamFailure(t *testing.T) {
 		res.Write(conn)
 		conn.Close()
 
-		log.Infof("proxy_test: sent 200 response\n")
+		log.Infof(context.TODO(), "proxy_test: sent 200 response\n")
 	}()
 
 	tm := martiantest.NewModifier()

--- a/log/log.go
+++ b/log/log.go
@@ -11,7 +11,6 @@ type Logger interface {
 	Errorf(format string, args ...any)
 	Infof(format string, args ...any)
 	Debugf(format string, args ...any)
-	WithValue(key, value string) Logger
 }
 
 // NopLogger is a logger that does nothing.
@@ -26,8 +25,4 @@ func (l nopLogger) Infof(_ string, _ ...any) {
 }
 
 func (l nopLogger) Debugf(_ string, _ ...any) {
-}
-
-func (l nopLogger) WithValue(_, _ string) Logger {
-	return l
 }

--- a/log/stdlog/stdlog.go
+++ b/log/stdlog/stdlog.go
@@ -32,14 +32,11 @@ func New(cfg *flog.Config) Logger {
 	}
 }
 
-var _ flog.Logger = (*Logger)(nil)
-
 // Logger implements the forwarder.Logger interface using the standard log package.
 type Logger struct {
-	log    *log.Logger
-	name   string
-	level  flog.Level
-	values string
+	log   *log.Logger
+	name  string
+	level flog.Level
 
 	// Decorate allows to modify the log message before it is written.
 	Decorate func(string) string
@@ -53,11 +50,6 @@ func (sl Logger) Named(name string) Logger {
 	return sl
 }
 
-func (sl Logger) WithValue(key, value string) flog.Logger {
-	sl.values += key + "=" + value + " "
-	return sl
-}
-
 func (sl Logger) Errorf(format string, args ...any) {
 	if sl.level < flog.ErrorLevel {
 		return
@@ -65,7 +57,7 @@ func (sl Logger) Errorf(format string, args ...any) {
 	if sl.Decorate != nil {
 		format = sl.Decorate(format)
 	}
-	sl.log.Printf(sl.name+"ERROR: "+sl.values+format, args...)
+	sl.log.Printf(sl.name+"ERROR: "+format, args...)
 }
 
 func (sl Logger) Infof(format string, args ...any) {
@@ -75,7 +67,7 @@ func (sl Logger) Infof(format string, args ...any) {
 	if sl.Decorate != nil {
 		format = sl.Decorate(format)
 	}
-	sl.log.Printf(sl.name+"INFO: "+sl.values+format, args...)
+	sl.log.Printf(sl.name+"INFO: "+format, args...)
 }
 
 func (sl Logger) Debugf(format string, args ...any) {
@@ -85,7 +77,7 @@ func (sl Logger) Debugf(format string, args ...any) {
 	if sl.Decorate != nil {
 		format = sl.Decorate(format)
 	}
-	sl.log.Printf(sl.name+"DEBUG: "+sl.values+format, args...)
+	sl.log.Printf(sl.name+"DEBUG: "+format, args...)
 }
 
 // Unwrap returns the underlying log.Logger pointer.

--- a/log/stdlog/stdlog.go
+++ b/log/stdlog/stdlog.go
@@ -57,7 +57,7 @@ func (sl Logger) Errorf(format string, args ...any) {
 	if sl.Decorate != nil {
 		format = sl.Decorate(format)
 	}
-	sl.log.Printf(sl.name+"ERROR: "+format, args...)
+	sl.log.Printf(sl.name+"[ERROR] "+format, args...)
 }
 
 func (sl Logger) Infof(format string, args ...any) {
@@ -67,7 +67,7 @@ func (sl Logger) Infof(format string, args ...any) {
 	if sl.Decorate != nil {
 		format = sl.Decorate(format)
 	}
-	sl.log.Printf(sl.name+"INFO: "+format, args...)
+	sl.log.Printf(sl.name+"[INFO] "+format, args...)
 }
 
 func (sl Logger) Debugf(format string, args ...any) {
@@ -77,7 +77,7 @@ func (sl Logger) Debugf(format string, args ...any) {
 	if sl.Decorate != nil {
 		format = sl.Decorate(format)
 	}
-	sl.log.Printf(sl.name+"DEBUG: "+format, args...)
+	sl.log.Printf(sl.name+"[DEBUG] "+format, args...)
 }
 
 // Unwrap returns the underlying log.Logger pointer.


### PR DESCRIPTION
Fixes #394 

Example log message:
```
[proxy] [DEBUG] [18a6b0c67a1] msg
```