### PR TITLE
martian: peek the connection before setting read timeout

### DIFF
--- a/internal/martian/proxy.go
+++ b/internal/martian/proxy.go
@@ -323,6 +323,14 @@ func (p *Proxy) readHeaderTimeout() time.Duration {
 }
 
 func (p *Proxy) readRequest(ctx *Context, conn net.Conn, brw *bufio.ReadWriter) (req *http.Request, err error) {
+	// Wait for the connection to become readable before trying to
+	// read the next request. This prevents a ReadHeaderTimeout or
+	// ReadTimeout from starting until the first bytes of the next request
+	// have been received.
+	if _, err := brw.Peek(1); err != nil {
+		return nil, err
+	}
+
 	var (
 		wholeReqDeadline time.Time // or zero if none
 		hdrDeadline      time.Time // or zero if none

--- a/internal/martian/proxy_test.go
+++ b/internal/martian/proxy_test.go
@@ -1694,11 +1694,14 @@ func TestReadHeaderTimeout(t *testing.T) {
 	}
 	defer conn.Close()
 
-	// Wait for the connection to timeout on reading header.
+	if _, err := conn.Write([]byte("GET / HTTP/1.1\r\n")); err != nil {
+		t.Fatalf("conn.Write(): got %v, want no error", err)
+	}
 	time.Sleep(200 * time.Millisecond)
-
-	_, err = conn.Read([]byte("test"))
-	if !errors.Is(err, io.EOF) {
-		t.Fatalf("conn.Write(): got %v, want EOF", err)
+	if _, err = conn.Write([]byte("Host: example.com\r\n\r\n")); err != nil {
+		t.Fatalf("conn.Write(): got %v, want no error", err)
+	}
+	if _, err = conn.Read(make([]byte, 1)); !errors.Is(err, io.EOF) {
+		t.Fatalf("conn.Read(): got %v, want io.EOF", err)
 	}
 }


### PR DESCRIPTION
Wait for the connection to become readable before trying to read the next request.

Fixes #304