### PR TITLE
utils/cobrautil(bind): set flags directly in FlagSet

### DIFF
--- a/utils/cobrautil/bind.go
+++ b/utils/cobrautil/bind.go
@@ -76,7 +76,7 @@ func BindAll(cmd *cobra.Command, envPrefix, configFileFlagName string) error {
 }
 
 func setFlagFromViper(f *pflag.Flag, v any) error {
-	if vs, ok := v.([]interface{}); ok {
+	if vs, ok := v.([]any); ok {
 		sr, ok := f.Value.(sliceReplacer)
 		if !ok {
 			return fmt.Errorf("trying to set list to %s", f.Value.Type())


### PR DESCRIPTION
pflag.FlagSet contains various metadata about the flags e.g. if one has been changed. Using pflag.Flag.Value.Set does not update pflag.FlagSet state.

The flags must be set by FlagSet.Set, otherwise it is easy to violate its internal state.