### PR TITLE
Read request ID from header and use in logs

### DIFF
--- a/bind/flag.go
+++ b/bind/flag.go
@@ -127,6 +127,11 @@ func HTTPProxyConfig(fs *pflag.FlagSet, cfg *forwarder.HTTPProxyConfig, lcfg *lo
 			"Use this flag multiple times to specify multiple deny domain excludes. "+
 			"This flag takes precedence over deny-domain. "+
 			"Can be specified only if --deny-domain is also specified. ")
+
+	fs.StringVar(&cfg.RequestIDHeader, "log-http-request-id-header", cfg.RequestIDHeader,
+		"<name>"+
+			"If the header is present in the request, "+
+			"the proxy will associate the value with the request in the logs. ")
 }
 
 func MITMConfig(fs *pflag.FlagSet, mitm *bool, cfg *forwarder.MITMConfig) {

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -79,6 +79,7 @@ type HTTPProxyConfig struct {
 	ProxyLocalhost         ProxyLocalhostMode
 	UpstreamProxy          *url.URL
 	UpstreamProxyFunc      ProxyFunc
+	RequestIDHeader        string
 	RequestModifiers       []RequestModifier
 	ResponseModifiers      []ResponseModifier
 	ConnectRequestModifier func(*http.Request) error
@@ -100,8 +101,9 @@ func DefaultHTTPProxyConfig() *HTTPProxyConfig {
 			ReadHeaderTimeout: 1 * time.Minute,
 			LogHTTPMode:       httplog.Errors,
 		},
-		Name:           "forwarder",
-		ProxyLocalhost: DenyProxyLocalhost,
+		Name:            "forwarder",
+		ProxyLocalhost:  DenyProxyLocalhost,
+		RequestIDHeader: "X-Request-Id",
 	}
 }
 
@@ -225,6 +227,7 @@ func (hp *HTTPProxy) configureProxy() error {
 	}
 
 	hp.proxy.AllowHTTP = true
+	hp.proxy.RequestIDHeader = hp.config.RequestIDHeader
 	hp.proxy.ConnectRequestModifier = hp.config.ConnectRequestModifier
 	hp.proxy.ConnectPassthrough = hp.config.ConnectPassthrough
 	hp.proxy.WithoutWarning = true

--- a/internal/martian/handler.go
+++ b/internal/martian/handler.go
@@ -89,7 +89,7 @@ func (p proxyHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 	ctx := withSession(session)
 
-	outreq := req.Clone(ctx.addToContext(req.Context()))
+	outreq := req.Clone(p.requestContext(ctx, req))
 	if req.ContentLength == 0 {
 		outreq.Body = http.NoBody
 	}


### PR DESCRIPTION
The proxy is capable to associate the request id send in request header with logs. 