### PR TITLE
header: support custom functions to evaluate add header value

### DIFF
--- a/dialvia/http.go
+++ b/dialvia/http.go
@@ -115,6 +115,7 @@ func (d *HTTPProxyDialer) DialContextR(ctx context.Context, network, addr string
 		Host:   addr,
 		Header: http.Header{},
 	}
+	req = *req.WithContext(ctx)
 
 	// Don't send the default Go HTTP client User-Agent.
 	req.Header.Add("User-Agent", "")


### PR DESCRIPTION
This patch adds `id` function to declare more advanced add header value. 
Usage: `--proxy-header: "X-Request-Id: {{id}}"` - This will add a header with request's internal id.