### PR TITLE
e2e: set dns timeout to 1 second

### DIFF
--- a/e2e/forwarder/service.go
+++ b/e2e/forwarder/service.go
@@ -171,6 +171,11 @@ func (s *Service) WithDNSServer(servers ...string) *Service {
 	return s
 }
 
+func (s *Service) WithDNSTimeout(timeout time.Duration) *Service {
+	s.Environment["FORWARDER_DNS_TIMEOUT"] = timeout.String()
+	return s
+}
+
 func (s *Service) WithHTTPDialTimeout(timeout time.Duration) *Service {
 	s.Environment["FORWARDER_HTTP_DIAL_TIMEOUT"] = timeout.String()
 	return s

--- a/e2e/setups.go
+++ b/e2e/setups.go
@@ -238,7 +238,7 @@ func SetupFlagDNSServer(l *setupList) {
 					forwarder.ProxyService().
 						WithIP(networkName, proxyIPAddr).
 						WithDNSServer(s.servers...).
-						WithHTTPDialTimeout(15 * time.Second)).
+						WithDNSTimeout(1 * time.Second)).
 				AddService(
 					dns.Service().
 						WithIP(networkName, dnsIPAddr)).


### PR DESCRIPTION
This shortens the `flag-dns-fallback` test.

running setup flag-dns-fallback
--- PASS: TestFlagDNSServer (15.12s)

vs

running setup flag-dns-fallback
--- PASS: TestFlagDNSServer (2.08s)