### PR TITLE
martian: add TLS termination in CONNECT

### DIFF
--- a/internal/martian/handler.go
+++ b/internal/martian/handler.go
@@ -121,7 +121,7 @@ func (p proxyHandler) handleConnectRequest(ctx *Context, rw http.ResponseWriter,
 		cw   io.WriteCloser
 		cerr error
 	)
-	if p.ConnectPassthrough {
+	if p.ConnectPassthrough { //nolint:nestif // to be fixed in #445
 		pr, pw := io.Pipe()
 		req.Body = pr
 		defer req.Body.Close()

--- a/internal/martian/proxy.go
+++ b/internal/martian/proxy.go
@@ -507,7 +507,7 @@ func (p *Proxy) handleConnectRequest(ctx *Context, req *http.Request, session *S
 		cw   io.WriteCloser
 		cerr error
 	)
-	if p.ConnectPassthrough {
+	if p.ConnectPassthrough { //nolint:nestif // to be fixed in #445
 		pr, pw := io.Pipe()
 		req.Body = pr
 		defer req.Body.Close()


### PR DESCRIPTION
This adds support for special header "X-Martian-Terminate-TLS". When set to true the proxy will perform TLS handshake before returning the connection.

This has the benefit of using the proxy's TLS configuration for the handshake.