### PR TITLE
martian(mitm): check if peeked data is not nil

### DIFF
--- a/internal/martian/proxy.go
+++ b/internal/martian/proxy.go
@@ -461,7 +461,7 @@ func (p *Proxy) handleMITM(ctx *Context, req *http.Request, session *Session, br
 
 	// 22 is the TLS handshake.
 	// https://tools.ietf.org/html/rfc5246#section-6.2.1
-	if b[0] == 22 {
+	if len(b) > 0 && b[0] == 22 {
 		// Prepend the previously read data to be read again by http.ReadRequest.
 		tlsconn := tls.Server(&peekedConn{
 			conn,


### PR DESCRIPTION
This check prevents the proxy from panic in the following scenario:
1. There isn't any buffered data.
2. Connection goes down.
3. Peek returns an error and nil slice.
4. Checking the first byte to determine a type results in reading from an empty slice.