### PR TITLE
Improve debugging 

### DIFF
--- a/log/stdlog/stdlog.go
+++ b/log/stdlog/stdlog.go
@@ -27,7 +27,7 @@ func New(cfg *flog.Config) Logger {
 		w = cfg.File
 	}
 	return Logger{
-		log:   log.New(w, "", log.Ldate|log.Ltime|log.LUTC),
+		log:   log.New(w, "", log.Ldate|log.Ltime|log.Lmicroseconds|log.LUTC),
 		level: cfg.Level,
 	}
 }


### PR DESCRIPTION
- Improve request IDs format 
- Log timestamp with microseconds resolution

The logs are as follows:
```
2023/10/05 09:05:16.534433 [proxy] [INFO] no upstream proxy specified
2023/10/05 09:05:16.534436 [proxy] [INFO] localhost proxying mode=deny
2023/10/05 09:05:16.534972 [proxy] [INFO] PROXY server listen address=[::]:3128 protocol=http
2023/10/05 09:05:30.007872 [proxy] [DEBUG] accepted connection from 127.0.0.1:51274
2023/10/05 09:05:30.008515 [proxy] [DEBUG] waiting for request: 127.0.0.1:51274
2023/10/05 09:05:30.013913 [proxy] [DEBUG] [2-9AC543C0] attempting to establish CONNECT tunnel: google.com:443
2023/10/05 09:05:30.013941 [proxy] [DEBUG] [2-9AC543C0] CONNECT to host directly: google.com:443
2023/10/05 09:05:30.082053 [proxy] [INFO] [2-9AC543C0] CONNECT google.com:443 status=200 duration=68.121083ms
2023/10/05 09:05:30.082257 [proxy] [DEBUG] [2-9AC543C0] switched protocols, proxying CONNECT traffic
2023/10/05 09:05:30.234736 [proxy] [DEBUG] [2-9AC543C0] outbound CONNECT tunnel finished copying
2023/10/05 09:05:30.247317 [proxy] [DEBUG] [2-9AC543C0] inbound CONNECT tunnel finished copying
2023/10/05 09:05:30.247381 [proxy] [DEBUG] [2-9AC543C0] closed CONNECT tunnel
2023/10/05 09:05:30.247511 [proxy] [DEBUG] closing connection: 127.0.0.1:51274
```