### PR TITLE
cmd/forwarder: add proxy traffic flag group

### DIFF
--- a/cmd/forwarder/root.go
+++ b/cmd/forwarder/root.go
@@ -44,8 +44,22 @@ func rootCommand() *cobra.Command {
 
 	flagGroups := templates.FlagGroups{
 		{
-			Name:   "Options",
+			Name:   "Server options",
 			Prefix: []string{""},
+		},
+		{
+			Name: "Proxy options",
+			Prefix: []string{
+				"proxy",
+				"pac",
+
+				"direct-domains",
+				"deny-domains",
+
+				"header",
+				"proxy-header",
+				"response-header",
+			},
 		},
 		{
 			Name:   "MITM options",
@@ -64,14 +78,11 @@ func rootCommand() *cobra.Command {
 			},
 		},
 		{
-			Name: "Domain options",
+			Name: "API server options",
 			Prefix: []string{
-				"deny-domain",
+				"api",
+				"prom",
 			},
-		},
-		{
-			Name:   "API server options",
-			Prefix: []string{"api"},
 		},
 		{
 			Name:   "Logging options",


### PR DESCRIPTION
```
Server options:
    --address <host:port> (default ':3128') (env FORWARDER_ADDRESS)
        The server address to listen on. If the host is empty, the server will listen on all available interfaces.

    --basic-auth <username[:password]> (env FORWARDER_BASIC_AUTH)
        Basic authentication credentials to protect the server.

    -s, --credentials <username[:password]@host:port,...> (env FORWARDER_CREDENTIALS)
        Site or upstream proxy basic authentication credentials. The host and port can be set to "*" to match all
        hosts and ports respectively. The flag can be specified multiple times to add multiple credentials.

    --name <string> (default 'forwarder') (env FORWARDER_NAME)
        Name of this proxy instance. This value is used in the Via header in requests. The name value in Via header is
        extended with a random string to avoid collisions when several proxies are chained.

    --protocol <http|https> (default http) (env FORWARDER_PROTOCOL)
        The server protocol. For https and h2 protocols, if TLS certificate is not specified, the server will use a
        self-signed certificate.

    --read-header-timeout <duration> (default 1m0s) (env FORWARDER_READ_HEADER_TIMEOUT)
        The amount of time allowed to read request headers.

    --read-limit <bandwidth> (default 0) (env FORWARDER_READ_LIMIT)
        Global read rate limit in bytes per second i.e. how many bytes per second you can receive from a proxy.
        Accepts binary format (e.g. 1.5Ki, 1Mi, 3.6Gi).

    --tls-cert-file <path or base64> (env FORWARDER_TLS_CERT_FILE)
        TLS certificate to use if the server protocol is https or h2. Can be a path to a file or "data:" followed by
        base64 encoded certificate.

    --tls-key-file <path or base64> (env FORWARDER_TLS_KEY_FILE)
        TLS private key to use if the server protocol is https or h2. Can be a path to a file or "data:" followed by
        base64 encoded key.

    --write-limit <bandwidth> (default 0) (env FORWARDER_WRITE_LIMIT)
        Global write rate limit in bytes per second i.e. how many bytes per second you can send to proxy. Accepts
        binary format (e.g. 1.5Ki, 1Mi, 3.6Gi).

Proxy options:
    --deny-domains [-]<regexp>,... (env FORWARDER_DENY_DOMAINS)
        Deny requests to the specified domains. Prefix domains with '-' to exclude requests to certain domains from
        being denied.

    --direct-domains [-]<regexp>,... (env FORWARDER_DIRECT_DOMAINS)
        Connect directly to the specified domains without using the upstream proxy. Prefix domains with '-' to exclude
        requests to certain domains from being directed.This flag takes precedence over the PAC script.

    -H, --header <header> (env FORWARDER_HEADER)
        Add or remove HTTP request headers. Use the format "name: value" to add a header, "name;" to set the header to
        empty value, "-name" to remove the header, "-name*" to remove headers by prefix. The header name will be
        normalized to canonical form. The header value should not contain any newlines or carriage returns. The flag
        can be specified multiple times. Example: -H "Host: example.com" -H "-User-Agent" -H "-X-*".

    -p, --pac <path or URL> (env FORWARDER_PAC)
        Proxy Auto-Configuration file to use for upstream proxy selection. It can be a local file or a URL, you can
        also use '-' to read from stdin. The data URI scheme is supported, the format is data:base64,<encoded data>.

    -x, --proxy [protocol://]host[:port] (env FORWARDER_PROXY)
        Upstream proxy to use. The supported protocols are: http, https, socks5. No protocol specified will be treated
        as HTTP proxy. If the port number is not specified, it is assumed to be 1080. The basic authentication
        username and password can be specified in the host string e.g. user:pass@host:port. Alternatively, you can use
        the -c, --credentials flag to specify the credentials. If both are specified, the proxy flag takes precedence.

    --proxy-header <header> (env FORWARDER_PROXY_HEADER)
        Add or remove HTTP headers on the CONNECT request to the upstream proxy. See the documentation for the -H,
        --header flag for more details on the format.

    --proxy-localhost <allow|deny|direct> (default deny) (env FORWARDER_PROXY_LOCALHOST)
        Setting this to allow enables sending requests to localhost through the upstream proxy. Setting this to direct
        sends requests to localhost directly without using the upstream proxy. By default, requests to localhost are
        denied.

    -R, --response-header <header> (env FORWARDER_RESPONSE_HEADER)
        Add or remove HTTP headers on the received response before sending it to the client. See the documentation for
        the -H, --header flag for more details on the format.

MITM options:
    --mitm <value> (default false) (env FORWARDER_MITM)
        Enable Man-in-the-Middle (MITM) mode. It only works with HTTPS requests, HTTP/2 is not supported. MITM is
        enabled by default when the --mitm-cacert-file flag is set. If the CA certificate is not provided MITM uses a
        generated CA certificate. The CA certificate used can be retrieved from the API server .

    --mitm-cacert-file <path or base64> (env FORWARDER_MITM_CACERT_FILE)
        CA certificate file to use for generating MITM certificates. If the file is not specified, a generated CA
        certificate will be used. See the documentation for the --mitm flag for more details.

    --mitm-cakey-file <path or base64> (env FORWARDER_MITM_CAKEY_FILE)
        CA key file to use for generating MITM certificates.

    --mitm-domains [-]<regexp>,... (env FORWARDER_MITM_DOMAINS)
        Limit MITM to the specified domains. Prefix domains with '-' to exclude requests to certain domains from being
        MITMed.

    --mitm-org <name> (default 'Sauce Labs Inc.') (env FORWARDER_MITM_ORG)
        Organization name to use in the generated MITM certificates.

    --mitm-validity <duration> (default 24h0m0s) (env FORWARDER_MITM_VALIDITY)
        Validity period of the generated MITM certificates. 

DNS options:
    --dns-round-robin <value> (default false) (env FORWARDER_DNS_ROUND_ROBIN)
        If more than one DNS server is specified with the --dns-server flag, passing this flag will enable round-robin
        selection. 

    -n, --dns-server <ip>[:<port>] (env FORWARDER_DNS_SERVER)
        DNS server(s) to use instead of system default. There are two execution policies, when more then one server is
        specified. Fallback: the first server in a list is used as primary, the rest are used as fallbacks. Round
        robin: the servers are used in a round-robin fashion. The port is optional, if not specified the default port
        is 53.

    --dns-timeout <duration> (default 5s) (env FORWARDER_DNS_TIMEOUT)
        Timeout for dialing DNS servers. Only used if DNS servers are specified. 

HTTP client options:
    --cacert-file <path or base64> (env FORWARDER_CACERT_FILE)
        Add your own CA certificates to verify against. The system root certificates will be used in addition to any
        certificates in this list. Can be a path to a file or "data:" followed by base64 encoded certificate. Use this
        flag multiple times to specify multiple CA certificate files.

    --http-dial-timeout <duration> (default 10s) (env FORWARDER_HTTP_DIAL_TIMEOUT)
        The maximum amount of time a dial will wait for a connect to complete. With or without a timeout, the
        operating system may impose its own earlier timeout. For instance, TCP timeouts are often around 3 minutes. 

    --http-idle-conn-timeout <duration> (default 1m30s) (env FORWARDER_HTTP_IDLE_CONN_TIMEOUT)
        The maximum amount of time an idle (keep-alive) connection will remain idle before closing itself. Zero means
        no limit. 

    --http-response-header-timeout <duration> (default 0s) (env FORWARDER_HTTP_RESPONSE_HEADER_TIMEOUT)
        The amount of time to wait for a server's response headers after fully writing the request (including its
        body, if any).This time does not include the time to read the response body. Zero means no limit. 

    --http-tls-handshake-timeout <duration> (default 10s) (env FORWARDER_HTTP_TLS_HANDSHAKE_TIMEOUT)
        The maximum amount of time waiting to wait for a TLS handshake. Zero means no limit.

    --insecure <value> (default false) (env FORWARDER_INSECURE)
        Don't verify the server's certificate chain and host name. Enable to work with self-signed certificates. 

API server options:
    --api-address <host:port> (default 'localhost:10000') (env FORWARDER_API_ADDRESS)
        The server address to listen on. If the host is empty, the server will listen on all available interfaces.

    --api-basic-auth <username[:password]> (env FORWARDER_API_BASIC_AUTH)
        Basic authentication credentials to protect the server.

    --api-log-http <none|short-url|url|headers|body|errors> (default errors) (env FORWARDER_API_LOG_HTTP)
        HTTP request and response logging mode. Setting this to none disables logging. The short-url mode logs
        [scheme://]host[/path] instead of the full URL. The error mode logs request line and headers if status code is
        greater than or equal to 500.

    --api-read-header-timeout <duration> (default 1m0s) (env FORWARDER_API_READ_HEADER_TIMEOUT)
        The amount of time allowed to read request headers.

    --prom-namespace <string> (env FORWARDER_PROM_NAMESPACE)
        Prometheus namespace to use for metrics. The metrics are available at /metrics endpoint in the API server.

Logging options:
    --log-file <path> (env FORWARDER_LOG_FILE)
        Path to the log file, if empty, logs to stdout.

    --log-http <none|short-url|url|headers|body|errors> (default errors) (env FORWARDER_LOG_HTTP)
        HTTP request and response logging mode. Setting this to none disables logging. The short-url mode logs
        [scheme://]host[/path] instead of the full URL. The error mode logs request line and headers if status code is
        greater than or equal to 500.

    --log-http-request-id-header <name> (default 'X-Request-Id') (env FORWARDER_LOG_HTTP_REQUEST_ID_HEADER)
        If the header is present in the request, the proxy will associate the value with the request in the logs.

    --log-level <error|info|debug> (default info) (env FORWARDER_LOG_LEVEL)
        Log level.

```