### PR TITLE
httplog: Merge the log-http and api-log-http CLI options

### DIFF
--- a/bind/log.go
+++ b/bind/log.go
@@ -51,7 +51,7 @@ func httplogUpdate(dst, src []NamedParam[httplog.Mode]) {
 	}
 
 	// Find default mode if set.
-	defaultMode := httplog.Errors
+	defaultMode := httplog.DefaultMode
 	for i := range src {
 		j := len(src) - i - 1
 		if src[j].Name == "" {

--- a/bind/log.go
+++ b/bind/log.go
@@ -50,8 +50,8 @@ func httplogUpdate(dst, src []NamedParam[httplog.Mode]) {
 		}
 	}
 
-	// Find default mode if set.
-	defaultMode := httplog.DefaultMode
+	// Find default mode.
+	var defaultMode httplog.Mode
 	for i := range src {
 		j := len(src) - i - 1
 		if src[j].Name == "" {
@@ -60,10 +60,12 @@ func httplogUpdate(dst, src []NamedParam[httplog.Mode]) {
 		}
 	}
 
-	// Set default mode for unset values.
-	for i := range dst {
-		if !changed[i] {
-			*dst[i].Param = defaultMode
+	// If default mode is set, update dst with it.
+	if defaultMode != "" {
+		for i := range dst {
+			if !changed[i] {
+				*dst[i].Param = defaultMode
+			}
 		}
 	}
 }

--- a/bind/log.go
+++ b/bind/log.go
@@ -1,0 +1,79 @@
+// Copyright 2023 Sauce Labs Inc. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package bind
+
+import (
+	"github.com/mmatczuk/anyflag"
+	"github.com/saucelabs/forwarder/httplog"
+)
+
+type httplogFlag struct {
+	*anyflag.SliceValue[NamedParam[httplog.Mode]]
+	update func()
+}
+
+func (f httplogFlag) Set(val string) (err error) {
+	err = f.SliceValue.Set(val)
+
+	if err == nil {
+		f.update()
+	}
+
+	return
+}
+
+func (f httplogFlag) Replace(vals []string) (err error) {
+	err = f.SliceValue.Replace(vals)
+
+	if err == nil {
+		f.update()
+	}
+
+	return
+}
+
+func httplogUpdate(dst, src []NamedParam[httplog.Mode]) {
+	changed := make([]bool, len(dst))
+
+	// Update dst with src values.
+	for i := range dst {
+		for j := range src {
+			if dst[i].Name == src[j].Name {
+				*dst[i].Param = *src[j].Param
+				changed[i] = true
+				break
+			}
+		}
+	}
+
+	// Find default mode if set.
+	defaultMode := httplog.Errors
+	for i := range src {
+		j := len(src) - i - 1
+		if src[j].Name == "" {
+			defaultMode = *src[j].Param
+			break
+		}
+	}
+
+	// Set default mode for unset values.
+	for i := range dst {
+		if !changed[i] {
+			*dst[i].Param = defaultMode
+		}
+	}
+}
+
+func httplogExtractNames(cfg []NamedParam[httplog.Mode]) []string {
+	names := make([]string, 0, len(cfg))
+	for _, c := range cfg {
+		if c.Name != "" {
+			names = append(names, c.Name)
+		}
+	}
+	return names
+}

--- a/bind/log_test.go
+++ b/bind/log_test.go
@@ -1,0 +1,67 @@
+// Copyright 2023 Sauce Labs Inc. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package bind
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/saucelabs/forwarder/httplog"
+)
+
+func TestHTTPLogUpdate(t *testing.T) {
+	ptr := func(m httplog.Mode) *httplog.Mode {
+		return &m
+	}
+
+	dst := []NamedParam[httplog.Mode]{
+		{
+			Name:  "foo",
+			Param: new(httplog.Mode),
+		},
+		{
+			Name:  "bar",
+			Param: new(httplog.Mode),
+		},
+		{
+			Name:  "baz",
+			Param: new(httplog.Mode),
+		},
+	}
+
+	src := []NamedParam[httplog.Mode]{
+		{
+			Name:  "",
+			Param: ptr(httplog.None),
+		},
+		{
+			Name:  "foo",
+			Param: ptr(httplog.ShortURL),
+		},
+	}
+
+	expected := []NamedParam[httplog.Mode]{
+		{
+			Name:  "foo",
+			Param: ptr(httplog.ShortURL),
+		},
+		{
+			Name:  "bar",
+			Param: ptr(httplog.None),
+		},
+		{
+			Name:  "baz",
+			Param: ptr(httplog.None),
+		},
+	}
+
+	httplogUpdate(dst, src)
+
+	if diff := cmp.Diff(expected, dst); diff != "" {
+		t.Errorf("unexpected diff (-want +got):\n%s", diff)
+	}
+}

--- a/bind/log_test.go
+++ b/bind/log_test.go
@@ -65,3 +65,52 @@ func TestHTTPLogUpdate(t *testing.T) {
 		t.Errorf("unexpected diff (-want +got):\n%s", diff)
 	}
 }
+
+func TestHTTPLogUpdateWithoutDefault(t *testing.T) {
+	ptr := func(m httplog.Mode) *httplog.Mode {
+		return &m
+	}
+
+	dst := []NamedParam[httplog.Mode]{
+		{
+			Name:  "foo",
+			Param: new(httplog.Mode),
+		},
+		{
+			Name:  "bar",
+			Param: new(httplog.Mode),
+		},
+		{
+			Name:  "baz",
+			Param: new(httplog.Mode),
+		},
+	}
+
+	src := []NamedParam[httplog.Mode]{
+		{
+			Name:  "foo",
+			Param: ptr(httplog.ShortURL),
+		},
+	}
+
+	expected := []NamedParam[httplog.Mode]{
+		{
+			Name:  "foo",
+			Param: ptr(httplog.ShortURL),
+		},
+		{
+			Name:  "bar",
+			Param: ptr(""),
+		},
+		{
+			Name:  "baz",
+			Param: ptr(""),
+		},
+	}
+
+	httplogUpdate(dst, src)
+
+	if diff := cmp.Diff(expected, dst); diff != "" {
+		t.Errorf("unexpected diff (-want +got):\n%s", diff)
+	}
+}

--- a/bind/named.go
+++ b/bind/named.go
@@ -1,0 +1,24 @@
+// Copyright 2023 Sauce Labs Inc. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package bind
+
+import (
+	"fmt"
+)
+
+type NamedParam[T fmt.Stringer] struct {
+	Name  string
+	Param *T
+}
+
+func (p NamedParam[T]) String() string {
+	if p.Name == "" {
+		return (*p.Param).String()
+	}
+
+	return p.Name + ":" + (*p.Param).String()
+}

--- a/cmd/forwarder/httpbin/httpbin.go
+++ b/cmd/forwarder/httpbin/httpbin.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/saucelabs/forwarder"
 	"github.com/saucelabs/forwarder/bind"
+	"github.com/saucelabs/forwarder/httplog"
 	"github.com/saucelabs/forwarder/internal/version"
 	"github.com/saucelabs/forwarder/log"
 	"github.com/saucelabs/forwarder/log/stdlog"
@@ -95,6 +96,10 @@ func Command() *cobra.Command {
 	fs := cmd.Flags()
 	bind.HTTPServerConfig(fs, c.httpServerConfig, "")
 	bind.HTTPServerConfig(fs, c.apiServerConfig, "api", forwarder.HTTPScheme)
+	bind.HTTPLogConfig(fs, []bind.NamedParam[httplog.Mode]{
+		{Name: "api", Param: &c.apiServerConfig.LogHTTPMode},
+		{Name: "server", Param: &c.httpServerConfig.LogHTTPMode},
+	})
 	bind.LogConfig(fs, c.logConfig)
 
 	bind.AutoMarkFlagFilename(cmd)

--- a/cmd/forwarder/pac/server/server.go
+++ b/cmd/forwarder/pac/server/server.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/saucelabs/forwarder"
 	"github.com/saucelabs/forwarder/bind"
+	"github.com/saucelabs/forwarder/httplog"
 	"github.com/saucelabs/forwarder/log"
 	"github.com/saucelabs/forwarder/log/stdlog"
 	"github.com/saucelabs/forwarder/pac"
@@ -134,8 +135,11 @@ func Command() *cobra.Command {
 	bind.PAC(fs, &c.pac)
 	bind.DNSConfig(fs, c.dnsConfig)
 	bind.HTTPServerConfig(fs, c.httpServerConfig, "")
-	bind.LogConfig(fs, c.logConfig)
 	bind.HTTPTransportConfig(fs, c.httpTransportConfig)
+	bind.HTTPLogConfig(fs, []bind.NamedParam[httplog.Mode]{
+		{Name: "server", Param: &c.httpServerConfig.LogHTTPMode},
+	})
+	bind.LogConfig(fs, c.logConfig)
 
 	bind.AutoMarkFlagFilename(cmd)
 

--- a/cmd/forwarder/run/run.go
+++ b/cmd/forwarder/run/run.go
@@ -19,6 +19,7 @@ import (
 	"github.com/saucelabs/forwarder"
 	"github.com/saucelabs/forwarder/bind"
 	"github.com/saucelabs/forwarder/header"
+	"github.com/saucelabs/forwarder/httplog"
 	martianlog "github.com/saucelabs/forwarder/internal/martian/log"
 	"github.com/saucelabs/forwarder/internal/version"
 	"github.com/saucelabs/forwarder/log"
@@ -299,6 +300,10 @@ func Command() *cobra.Command {
 	bind.MITMConfig(fs, &c.mitm, c.mitmConfig)
 	bind.MITMDomains(fs, &c.mitmDomains)
 	bind.HTTPServerConfig(fs, c.apiServerConfig, "api", forwarder.HTTPScheme)
+	bind.HTTPLogConfig(fs, []bind.NamedParam[httplog.Mode]{
+		{Name: "api", Param: &c.apiServerConfig.LogHTTPMode},
+		{Name: "proxy", Param: &c.httpProxyConfig.LogHTTPMode},
+	})
 	bind.PromNamespace(fs, &c.httpProxyConfig.PromNamespace)
 	bind.AutoMarkFlagFilename(cmd)
 	cmd.MarkFlagsMutuallyExclusive("proxy", "pac")

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -103,7 +103,6 @@ func DefaultHTTPProxyConfig() *HTTPProxyConfig {
 			Protocol:          HTTPScheme,
 			Addr:              ":3128",
 			ReadHeaderTimeout: 1 * time.Minute,
-			LogHTTPMode:       httplog.Errors,
 		},
 		Name:            "forwarder",
 		ProxyLocalhost:  DenyProxyLocalhost,

--- a/http_server.go
+++ b/http_server.go
@@ -92,7 +92,6 @@ func DefaultHTTPServerConfig() *HTTPServerConfig {
 		Protocol:          HTTPScheme,
 		Addr:              ":8080",
 		ReadHeaderTimeout: 1 * time.Minute,
-		LogHTTPMode:       httplog.Errors,
 	}
 }
 

--- a/httplog/httplog.go
+++ b/httplog/httplog.go
@@ -63,6 +63,8 @@ func SplitNameMode(val string) (name string, mode Mode, err error) {
 	return
 }
 
+var DefaultMode = Errors
+
 type Logger struct {
 	log  func(format string, args ...any)
 	mode Mode
@@ -70,6 +72,9 @@ type Logger struct {
 
 // NewLogger returns a logger that logs HTTP requests and responses.
 func NewLogger(logFunc func(format string, args ...any), mode Mode) *Logger {
+	if mode == "" {
+		mode = DefaultMode
+	}
 	return &Logger{
 		log:  logFunc,
 		mode: mode,

--- a/httplog/httplog.go
+++ b/httplog/httplog.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/saucelabs/forwarder/internal/martian/log"
 	"github.com/saucelabs/forwarder/internal/martian/messageview"
@@ -30,6 +31,36 @@ const (
 
 func (m Mode) String() string {
 	return string(m)
+}
+
+func SplitNameMode(val string) (name string, mode Mode, err error) {
+	n, m, ok := strings.Cut(val, ":")
+	if ok {
+		name = n
+		mode = Mode(m)
+	} else {
+		name = ""
+		mode = Mode(val)
+	}
+
+	switch mode {
+	case None:
+		mode = None
+	case ShortURL:
+		mode = ShortURL
+	case URL:
+		mode = URL
+	case Headers:
+		mode = Headers
+	case Body:
+		mode = Body
+	case Errors:
+		mode = Errors
+	default:
+		return "", "", fmt.Errorf("invalid mode %q", mode)
+	}
+
+	return
 }
 
 type Logger struct {

--- a/httplog/httplog_test.go
+++ b/httplog/httplog_test.go
@@ -1,0 +1,62 @@
+// Copyright 2023 Sauce Labs Inc. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package httplog
+
+import (
+	"testing"
+)
+
+func TestSplitNameMode(t *testing.T) {
+	tests := []struct {
+		val  string
+		name string
+		mode Mode
+	}{
+		{
+			val:  "api:none",
+			name: "api",
+			mode: None,
+		},
+		{
+			val:  "errors",
+			name: "",
+			mode: Errors,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.val, func(t *testing.T) {
+			n, m, err := SplitNameMode(tc.val)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if n != tc.name {
+				t.Errorf("expected name %q, got %q", tc.name, n)
+			}
+			if m != tc.mode {
+				t.Errorf("expected mode %q, got %q", tc.mode, m)
+			}
+		})
+	}
+}
+
+func TestSplitNameModeError(t *testing.T) {
+	tests := []string{
+		"api:invalid",
+		"invalid",
+	}
+
+	for _, tc := range tests {
+		t.Run(tc, func(t *testing.T) {
+			_, _, err := SplitNameMode(tc)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			t.Log(err)
+		})
+	}
+}


### PR DESCRIPTION
Instead of having separate log-http and api-log-http options, merge them into `--log-http [<module>:]<mode>`

This adds a Config type to `httplog` which contains a map of the module name (used a prefix to the log mode in the CLI) to the log mode:

```go
type Config struct {
        ModeOptions []map[string]Mode                                 
        defaults    map[string]Mode                                   
}                                                           
```

Examples from the forwarder commands showing the various options of single module, multiple modules, or no modules.

```
$ ./dist/forwarder_linux_amd64_v1/forwarder run --help 2>&1 | grep "log-http "
    --log-http [<api>|<proxy>:]<none|short-url|url|headers|body|errors> (env FORWARDER_LOG_HTTP)
$ ./dist/forwarder_linux_amd64_v1/forwarder httpbin --help 2>&1 | grep "log-http "
    --log-http [<api>:]<none|short-url|url|headers|body|errors> (env FORWARDER_LOG_HTTP)
$ ± ./dist/forwarder_linux_amd65_v1/forwarder pac server --help 2>&1 | grep "log-http "
    --log-http <none|short-url|url|headers|body|errors> (env FORWARDER_LOG_HTTP)

```
