### PR TITLE
http_proxy: print proxy errors in response body

### DIFF
--- a/http_proxy_errors.go
+++ b/http_proxy_errors.go
@@ -50,7 +50,7 @@ func (hp *HTTPProxy) errorResponse(req *http.Request, err error) *http.Response 
 	}
 	if code == 0 {
 		code = http.StatusInternalServerError
-		msg = "An unexpected error occurred"
+		msg = "encountered an unexpected error"
 		label = "unexpected_error"
 	}
 
@@ -78,10 +78,10 @@ func handleNetError(_ *http.Request, err error) (code int, msg, label string) {
 	if errors.As(err, &netErr) {
 		if netErr.Timeout() {
 			code = http.StatusGatewayTimeout
-			msg = "Timed out connecting to remote host"
+			msg = "timed out connecting to remote host"
 		} else {
 			code = http.StatusBadGateway
-			msg = "Failed to connect to remote host"
+			msg = "failed to connect to remote host"
 		}
 		label = "net_" + netErr.Op
 	}
@@ -93,7 +93,7 @@ func handleTLSRecordHeader(_ *http.Request, err error) (code int, msg, label str
 	var headerErr *tls.RecordHeaderError
 	if errors.As(err, &headerErr) {
 		code = http.StatusBadGateway
-		msg = "TLS handshake failed"
+		msg = "tls handshake failed"
 		label = "tls_record_header"
 	}
 
@@ -104,7 +104,7 @@ func handleTLSCertificateError(_ *http.Request, err error) (code int, msg, label
 	var certErr *tls.CertificateVerificationError
 	if errors.As(err, &certErr) {
 		code = http.StatusBadGateway
-		msg = "TLS handshake failed"
+		msg = "tls handshake failed"
 		label = "tls_certificate"
 	}
 

--- a/http_proxy_errors.go
+++ b/http_proxy_errors.go
@@ -56,10 +56,16 @@ func (hp *HTTPProxy) errorResponse(req *http.Request, err error) *http.Response 
 
 	hp.metrics.error(label)
 
-	resp := proxyutil.NewResponse(code, bytes.NewBufferString(msg+"\n"), req)
+	var body bytes.Buffer
+	body.WriteString(msg)
+	body.WriteString("\n")
+	body.WriteString(err.Error())
+	body.WriteString("\n")
+
+	resp := proxyutil.NewResponse(code, &body, req)
 	resp.Header.Set(ErrorHeader, err.Error())
 	resp.Header.Set("Content-Type", "text/plain; charset=utf-8")
-	resp.ContentLength = int64(len(msg) + 1)
+	resp.ContentLength = int64(body.Len())
 	return resp
 }
 

--- a/http_proxy_errors.go
+++ b/http_proxy_errors.go
@@ -57,13 +57,15 @@ func (hp *HTTPProxy) errorResponse(req *http.Request, err error) *http.Response 
 	hp.metrics.error(label)
 
 	var body bytes.Buffer
+	body.WriteString(hp.config.Name)
+	body.WriteString(" ")
 	body.WriteString(msg)
 	body.WriteString("\n")
 	body.WriteString(err.Error())
 	body.WriteString("\n")
 
 	resp := proxyutil.NewResponse(code, &body, req)
-	resp.Header.Set(ErrorHeader, err.Error())
+	resp.Header.Set(ErrorHeader, hp.config.Name+" "+err.Error())
 	resp.Header.Set("Content-Type", "text/plain; charset=utf-8")
 	resp.ContentLength = int64(body.Len())
 	return resp


### PR DESCRIPTION
Responses will now contain proxy name and error:
First line is a generic message, second the error.
```
curl -x localhost:3128 not.exist   
forwarder failed to connect to remote host
dial tcp: lookup not.exist on 192.168.1.1:53: no such host
```

Header:
```
X-Forwarder-Error: forwarder dial tcp: lookup www on 10.255.3.12:53: no such host
```