### PR TITLE
e2e: do not log http in api module while in debug mode

### DIFF
--- a/e2e/run.go
+++ b/e2e/run.go
@@ -59,7 +59,7 @@ func main() {
 				for _, srv := range s.Compose.Services {
 					if strings.HasPrefix(srv.Image, "saucelabs/forwarder") {
 						srv.Environment["FORWARDER_LOG_LEVEL"] = "debug"
-						srv.Environment["FORWARDER_LOG_HTTP"] = "headers"
+						srv.Environment["FORWARDER_LOG_HTTP"] = "headers,api:errors"
 					}
 				}
 			}


### PR DESCRIPTION
API servers receive healthcheck requests which pollutes the logs.