### PR TITLE
Add prometheus namespace validation 

### DIFF
--- a/bind/flag.go
+++ b/bind/flag.go
@@ -337,9 +337,10 @@ func TLSServerConfig(fs *pflag.FlagSet, cfg *forwarder.TLSServerConfig, namePref
 }
 
 func PromNamespace(fs *pflag.FlagSet, promNamespace *string) {
-	fs.StringVar(promNamespace, "prom-namespace", *promNamespace, "<string>"+
-		"Prometheus namespace to use for metrics. "+
-		"The metrics are available at /metrics endpoint in the API server. ")
+	fs.Var(anyflag.NewValue[string](*promNamespace, promNamespace, forwarder.ParsePrometheusNamespace),
+		"prom-namespace", "<string>"+
+			"Prometheus namespace to use for metrics. "+
+			"The metrics are available at /metrics endpoint in the API server. ")
 }
 
 func LogConfig(fs *pflag.FlagSet, cfg *log.Config) {

--- a/config.go
+++ b/config.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	_ "unsafe" // for go:linkname
@@ -257,4 +258,27 @@ func OpenFileParser(flag int, perm, dirPerm os.FileMode) func(val string) (*os.F
 		}
 		return os.OpenFile(val, flag, perm)
 	}
+}
+
+func ParsePrometheusNamespace(val string) (string, error) {
+	if err := validatePrometheusNamespace(val); err != nil {
+		return "", err
+	}
+
+	return val, nil
+}
+
+// https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
+var promNamespaceRegexp = regexp.MustCompile("^[a-zA-Z_:][a-zA-Z0-9_:]*$")
+
+func validatePrometheusNamespace(val string) error {
+	if val == "" {
+		return nil
+	}
+
+	if !promNamespaceRegexp.MatchString(val) {
+		return fmt.Errorf("invalid namespace: %s, it must match %q", val, promNamespaceRegexp.String())
+	}
+
+	return nil
 }


### PR DESCRIPTION
```
go run ./cmd/forwarder run --prom-namespace upstream-proxy
Error: invalid argument "upstream-proxy" for "--prom-namespace" flag: invalid namespace: upstream-proxy, it must match "^[a-zA-Z_:][a-zA-Z0-9_:]*$"
See 'forwarder run --help' for usage.
exit status 1
```