### PR TITLE
utils/cobrautil: add funtion to add ConfigFileCommand recursively

### DIFF
--- a/cmd/forwarder/root.go
+++ b/cmd/forwarder/root.go
@@ -96,12 +96,14 @@ func rootCommand() *cobra.Command {
 
 	templates.ActsAsRootCommand(cmd, nil, commandGroups, flagGroups, envPrefix)
 
-	// Add other commands
+	// Add other commands.
 	cmd.AddCommand(
 		httpbin.Command(), // hidden
-		cobrautil.ConfigFileCommand(flagGroups, run.Command().Flags()), // hidden
 		version.Command(),
 	)
+
+	// Add config-file command to all commands.
+	cobrautil.AddConfigFileForEachCommand(cmd, flagGroups)
 
 	return cmd
 }

--- a/packaging/config.sh
+++ b/packaging/config.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-go run ./cmd/forwarder config-file > "forwarder.yaml"
+go run ./cmd/forwarder run config-file > "forwarder.yaml"

--- a/utils/cobrautil/config_file.go
+++ b/utils/cobrautil/config_file.go
@@ -35,3 +35,13 @@ func ConfigFileCommand(g templates.FlagGroups, fs *pflag.FlagSet) *cobra.Command
 		},
 	}
 }
+
+func AddConfigFileForEachCommand(cmd *cobra.Command, g templates.FlagGroups) {
+	for _, cmd := range cmd.Commands() {
+		AddConfigFileForEachCommand(cmd, g)
+	}
+
+	if cmd.IsAvailableCommand() && cmd.Flags().HasFlags() {
+		cmd.AddCommand(ConfigFileCommand(g, cmd.Flags()))
+	}
+}


### PR DESCRIPTION
This allows to have config files for any subcommand. It also improves command ergonomics ex. go run ./cmd/forwarder/ pac server config-file.