### PR TITLE
config file sections

### DIFF
--- a/cmd/forwarder/root.go
+++ b/cmd/forwarder/root.go
@@ -18,14 +18,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const envPrefix = "FORWARDER"
+const (
+	envPrefix          = "FORWARDER"
+	configFileFlagName = "config-file"
+)
 
 func rootCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "forwarder",
 		Short: "HTTP (forward) proxy server with PAC support and PAC testing tools",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return cobrautil.BindAll(cmd, envPrefix, "config-file")
+			return cobrautil.BindAll(cmd, envPrefix, configFileFlagName)
 		},
 	}
 	bind.ConfigFile(cmd.PersistentFlags(), new(string))
@@ -103,7 +106,7 @@ func rootCommand() *cobra.Command {
 	)
 
 	// Add config-file command to all commands.
-	cobrautil.AddConfigFileForEachCommand(cmd, flagGroups)
+	cobrautil.AddConfigFileForEachCommand(cmd, flagGroups, configFileFlagName)
 
 	return cmd
 }

--- a/utils/cobrautil/config_file.go
+++ b/utils/cobrautil/config_file.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func ConfigFileCommand(g templates.FlagGroups, fs *pflag.FlagSet) *cobra.Command {
+func ConfigFileCommand(g templates.FlagGroups, fs *pflag.FlagSet, configFileFlagName string) *cobra.Command {
 	return &cobra.Command{
 		Use:    "config-file",
 		Args:   cobra.NoArgs,
@@ -28,12 +28,20 @@ func ConfigFileCommand(g templates.FlagGroups, fs *pflag.FlagSet) *cobra.Command
 					continue
 				}
 
-				fmt.Fprintf(w, "# --- %s ---\n", g[i].Name)
-
+				header := true
 				fs.VisitAll(func(flag *pflag.Flag) {
 					if flag.Hidden {
 						return
 					}
+					if flag.Name == configFileFlagName {
+						return
+					}
+
+					if header {
+						fmt.Fprintf(w, "# --- %s ---\n\n", g[i].Name)
+						header = false
+					}
+
 					p.PrintHelpFlag(flag)
 				})
 			}
@@ -41,12 +49,12 @@ func ConfigFileCommand(g templates.FlagGroups, fs *pflag.FlagSet) *cobra.Command
 	}
 }
 
-func AddConfigFileForEachCommand(cmd *cobra.Command, g templates.FlagGroups) {
+func AddConfigFileForEachCommand(cmd *cobra.Command, g templates.FlagGroups, configFileFlagName string) {
 	for _, cmd := range cmd.Commands() {
-		AddConfigFileForEachCommand(cmd, g)
+		AddConfigFileForEachCommand(cmd, g, configFileFlagName)
 	}
 
 	if cmd.IsAvailableCommand() && cmd.Flags().HasFlags() {
-		cmd.AddCommand(ConfigFileCommand(g, cmd.Flags()))
+		cmd.AddCommand(ConfigFileCommand(g, cmd.Flags(), configFileFlagName))
 	}
 }

--- a/utils/cobrautil/config_file.go
+++ b/utils/cobrautil/config_file.go
@@ -7,6 +7,8 @@
 package cobrautil
 
 import (
+	"fmt"
+
 	"github.com/saucelabs/forwarder/utils/cobrautil/templates"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -18,12 +20,15 @@ func ConfigFileCommand(g templates.FlagGroups, fs *pflag.FlagSet) *cobra.Command
 		Args:   cobra.NoArgs,
 		Hidden: true,
 		Run: func(cmd *cobra.Command, _ []string) {
-			p := templates.NewYamlFlagPrinter(cmd.OutOrStdout(), 80)
+			w := cmd.OutOrStdout()
+			p := templates.NewYamlFlagPrinter(w, 80)
 
-			for _, fs := range templates.SplitFlagSet(g, fs) {
+			for i, fs := range templates.SplitFlagSet(g, fs) {
 				if !fs.HasAvailableFlags() {
 					continue
 				}
+
+				fmt.Fprintf(w, "# --- %s ---\n", g[i].Name)
 
 				fs.VisitAll(func(flag *pflag.Flag) {
 					if flag.Hidden {

--- a/utils/cobrautil/templates/yaml_flag_printer.go
+++ b/utils/cobrautil/templates/yaml_flag_printer.go
@@ -39,8 +39,8 @@ func (p *YamlFlagPrinter) PrintHelpFlag(f *pflag.Flag) {
 	if len(flagAndUsage) > 1 {
 		nextLines := strings.Join(flagAndUsage[:len(flagAndUsage)-1], " ")
 		wrappedUsages := wordwrap.WrapString(nextLines, p.wrapLimit-2)
-		wrappedUsages = "# " + strings.ReplaceAll(wrappedUsages, "\n", "\n# ")
-		wrappedStr = wrappedUsages + "\n#" + flagAndUsage[len(flagAndUsage)-1]
+		wrappedUsages = "#\n# " + strings.ReplaceAll(wrappedUsages, "\n", "\n# ")
+		wrappedStr = wrappedUsages + "\n#\n#" + flagAndUsage[len(flagAndUsage)-1]
 	}
 	fmt.Fprintf(p.out, wrappedStr)
 	fmt.Fprintf(p.out, "\n\n")


### PR DESCRIPTION
Add section headers and more light to generated default config file.

Example 

```
# --- DNS options ---

#
# If more than one DNS server is specified with the --dns-server flag, passing
# this flag will enable round-robin selection. 
#
#dns-round-robin: false

#
# DNS server(s) to use instead of system default. There are two execution
# policies, when more then one server is specified. Fallback: the first server
# in a list is used as primary, the rest are used as fallbacks. Round robin: the
# servers are used in a round-robin fashion. The port is optional, if not
# specified the default port is 53.
#
#dns-server:

#
# Timeout for dialing DNS servers. Only used if DNS servers are specified. 
#
#dns-timeout: 5s
```

Also, remove config-file flag from default config file 