### PR TITLE
chore: unify header

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,7 +1,3 @@
-# Copyright 2021 The forwarder Authors. All rights reserved.
-# Use of this source code is governed by a MIT
-# license that can be found in the LICENSE file.
-
 ---
 name: Go
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-# Copyright 2021 The forwarder Authors. All rights reserved.
-# Use of this source code is governed by a MIT
-# license that can be found in the LICENSE file.
-
 # Binaries for programs and plugins
 *.exe
 *.dll

--- a/.go-header-template.yml
+++ b/.go-header-template.yml
@@ -1,4 +1,4 @@
-Copyright {{ year }} Sauce Labs Inc. All rights reserved.
+Copyright {{ year }} Sauce Labs Inc., all rights reserved.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/.golangci-fmt.yml
+++ b/.golangci-fmt.yml
@@ -1,7 +1,3 @@
-# Copyright 2021 The forwarder Authors. All rights reserved.
-# Use of this source code is governed by a MIT
-# license that can be found in the LICENSE file.
-
 ---
 run:
   deadline: 5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,3 @@
-# Copyright 2021 The forwarder Authors. All rights reserved.
-# Use of this source code is governed by a MIT
-# license that can be found in the LICENSE file.
-
 ---
 run:
   timeout: 5m

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,3 @@
-# Copyright 2021 The forwarder Authors. All rights reserved.
-# Use of this source code is governed by a MIT
-# license that can be found in the LICENSE file.
-
 export GOBIN ?= $(CURDIR)/bin
 export PATH  := $(GOBIN):$(PATH)
 

--- a/api.go
+++ b/api.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/bind/file.go
+++ b/bind/file.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/bind/flag.go
+++ b/bind/flag.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/bind/log.go
+++ b/bind/log.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/bind/log_test.go
+++ b/bind/log_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/bind/named.go
+++ b/bind/named.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/bind/redact.go
+++ b/bind/redact.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/cmd/forwarder/main.go
+++ b/cmd/forwarder/main.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/command/forwarder/root.go
+++ b/command/forwarder/root.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/command/httpbin/httpbin.go
+++ b/command/httpbin/httpbin.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/command/pac/eval/eval.go
+++ b/command/pac/eval/eval.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/command/pac/pac.go
+++ b/command/pac/pac.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/command/pac/server/server.go
+++ b/command/pac/server/server.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/command/ready/bind.go
+++ b/command/ready/bind.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/command/ready/ready.go
+++ b/command/ready/ready.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/command/run/run.go
+++ b/command/run/run.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/command/version/version.go
+++ b/command/version/version.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/config.go
+++ b/config.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/config_test.go
+++ b/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/credentials.go
+++ b/credentials.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/dial.go
+++ b/dial.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/dialvia/dial.go
+++ b/dialvia/dial.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/dialvia/http.go
+++ b/dialvia/http.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/dialvia/http_test.go
+++ b/dialvia/http_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/dialvia/socks5.go
+++ b/dialvia/socks5.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/doc.go
+++ b/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/e2e/dns/service.go
+++ b/e2e/dns/service.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/e2e/forwarder/scheme.go
+++ b/e2e/forwarder/scheme.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/e2e/forwarder/service.go
+++ b/e2e/forwarder/service.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/e2e/prometheus/service.go
+++ b/e2e/prometheus/service.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/e2e/run.go
+++ b/e2e/run.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/e2e/setup/callback.go
+++ b/e2e/setup/callback.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/e2e/setup/setup.go
+++ b/e2e/setup/setup.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/e2e/setups.go
+++ b/e2e/setups.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/e2e/tests/bench_test.go
+++ b/e2e/tests/bench_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/e2e/tests/client.go
+++ b/e2e/tests/client.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/e2e/tests/flag_test.go
+++ b/e2e/tests/flag_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/e2e/tests/proxy_test.go
+++ b/e2e/tests/proxy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/e2e/tests/sc_test.go
+++ b/e2e/tests/sc_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/fileurl/fileurl.go
+++ b/fileurl/fileurl.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/fileurl/fileurl_test.go
+++ b/fileurl/fileurl_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/header/header.go
+++ b/header/header.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/header/header_test.go
+++ b/header/header_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/http_proxy_errors.go
+++ b/http_proxy_errors.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/http_proxy_metrics.go
+++ b/http_proxy_metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/http_proxy_test.go
+++ b/http_proxy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/http_server.go
+++ b/http_server.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/http_transport.go
+++ b/http_transport.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/httplog/httplog.go
+++ b/httplog/httplog.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/httplog/httplog_test.go
+++ b/httplog/httplog_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/internal/martian/closewriter.go
+++ b/internal/martian/closewriter.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // Copyright 2015 Google Inc. All rights reserved.
 //

--- a/internal/martian/closewriter_test.go
+++ b/internal/martian/closewriter_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // Copyright 2015 Google Inc. All rights reserved.
 //

--- a/internal/martian/connect.go
+++ b/internal/martian/connect.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // Copyright 2015 Google Inc. All rights reserved.
 //

--- a/internal/martian/flush.go
+++ b/internal/martian/flush.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // Copyright 2015 Google Inc. All rights reserved.
 //

--- a/internal/martian/handler.go
+++ b/internal/martian/handler.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // Copyright 2015 Google Inc. All rights reserved.
 //

--- a/internal/martian/head.go
+++ b/internal/martian/head.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // Copyright 2015 Google Inc. All rights reserved.
 //

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/local/linux/lib.sh
+++ b/local/linux/lib.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2023 Sauce Labs Inc. All rights reserved.
+# Copyright 2023 Sauce Labs Inc., all rights reserved.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/local/linux/run-debian.sh
+++ b/local/linux/run-debian.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2023 Sauce Labs Inc. All rights reserved.
+# Copyright 2023 Sauce Labs Inc., all rights reserved.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/local/linux/run-fedora.sh
+++ b/local/linux/run-fedora.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2023 Sauce Labs Inc. All rights reserved.
+# Copyright 2023 Sauce Labs Inc., all rights reserved.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/log/config.go
+++ b/log/config.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/log/level.go
+++ b/log/level.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/log/log.go
+++ b/log/log.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/log/martianlog/martianlog.go
+++ b/log/martianlog/martianlog.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/log/stdlog/opts.go
+++ b/log/stdlog/opts.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/log/stdlog/stdlog.go
+++ b/log/stdlog/stdlog.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/middleware/basic_auth.go
+++ b/middleware/basic_auth.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/middleware/basic_auth_test.go
+++ b/middleware/basic_auth_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/middleware/prometheus.go
+++ b/middleware/prometheus.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/middleware/prometheus_test.go
+++ b/middleware/prometheus_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/mitm.go
+++ b/mitm.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pac.go
+++ b/pac.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pac/doc.go
+++ b/pac/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pac/embed.go
+++ b/pac/embed.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pac/export_test.go
+++ b/pac/export_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pac/netutil.go
+++ b/pac/netutil.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pac/pac.go
+++ b/pac/pac.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pac/pac_ipv4.go
+++ b/pac/pac_ipv4.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pac/pac_ipv6.go
+++ b/pac/pac_ipv6.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pac/pac_test.go
+++ b/pac/pac_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pac/pool.go
+++ b/pac/pool.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pac/pool_test.go
+++ b/pac/pool_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pac/proxy.go
+++ b/pac/proxy.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pac/proxy_test.go
+++ b/pac/proxy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pac/utils.go
+++ b/pac/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/ratelimit/conn.go
+++ b/ratelimit/conn.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/ratelimit/listener.go
+++ b/ratelimit/listener.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/readurl.go
+++ b/readurl.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/readurl_test.go
+++ b/readurl_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/resolver.go
+++ b/resolver.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/ruleset/regexp.go
+++ b/ruleset/regexp.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/ruleset/regexp_test.go
+++ b/ruleset/regexp_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/runctx/runctx.go
+++ b/runctx/runctx.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/runctx/runctx_test.go
+++ b/runctx/runctx_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/runctx/runctx_unix_test.go
+++ b/runctx/runctx_unix_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/runctx/runctx_windows_test.go
+++ b/runctx/runctx_windows_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/tls.go
+++ b/tls.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/utils/certutil/cert.go
+++ b/utils/certutil/cert.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/utils/certutil/cert_test.go
+++ b/utils/certutil/cert_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/utils/cobrautil/bind.go
+++ b/utils/cobrautil/bind.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/utils/cobrautil/bind_test.go
+++ b/utils/cobrautil/bind_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/utils/cobrautil/config_file.go
+++ b/utils/cobrautil/config_file.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/utils/cobrautil/describe.go
+++ b/utils/cobrautil/describe.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/utils/cobrautil/describe_test.go
+++ b/utils/cobrautil/describe_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/utils/cobrautil/templates/flag_groups.go
+++ b/utils/cobrautil/templates/flag_groups.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/utils/cobrautil/templates/yaml_flag_printer.go
+++ b/utils/cobrautil/templates/yaml_flag_printer.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/utils/compose/builder.go
+++ b/utils/compose/builder.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/utils/compose/compose.go
+++ b/utils/compose/compose.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/utils/compose/network.go
+++ b/utils/compose/network.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/utils/compose/os.go
+++ b/utils/compose/os.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/utils/compose/service.go
+++ b/utils/compose/service.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/utils/golden/prometheus.go
+++ b/utils/golden/prometheus.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/utils/httpbin/httpbin.go
+++ b/utils/httpbin/httpbin.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/utils/httpbin/io.go
+++ b/utils/httpbin/io.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/utils/httpbin/io_test.go
+++ b/utils/httpbin/io_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/utils/httpbin/sse.go
+++ b/utils/httpbin/sse.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/utils/httpbin/ws.go
+++ b/utils/httpbin/ws.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/utils/httpexpect/httpexpect.go
+++ b/utils/httpexpect/httpexpect.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/utils/httpexpect/trace.go
+++ b/utils/httpexpect/trace.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/utils/httphandler/httphandler.go
+++ b/utils/httphandler/httphandler.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/utils/httpx/rt.go
+++ b/utils/httpx/rt.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sauce Labs Inc. All rights reserved.
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this


### PR DESCRIPTION
Unify header with the one that's in SauceLabs.com page footer[1].

<img width="1554" alt="saucelabs_header_in_footer" src="https://github.com/saucelabs/forwarder/assets/57443889/f11f3911-d4e6-4111-9057-8d7c0ce68afb">

[1] https://saucelabs.com

