### PR TITLE
mk: allow for custom container runtime in update-devel-image target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,16 +65,17 @@ coverage:
 	@go tool cover -func=coverage.out
 
 .PHONY: update-devel-image
+update-devel-image: CONTAINER_RUNTIME?=docker
 update-devel-image: TAG=devel
 update-devel-image: TMPDIR:=$(shell mktemp -d)
 update-devel-image:
 	@ln Dockerfile LICENSE LICENSE.3RD_PARTY $(TMPDIR)
 ifeq ($(shell uname),Linux)
 	@CGO_ENABLED=1 GOOS=linux go build -race -o $(TMPDIR)/forwarder ./cmd/forwarder
-	@docker buildx build --build-arg BASE_IMAGE=ubuntu:latest -t saucelabs/forwarder:$(TAG) $(TMPDIR)
+	@$(CONTAINER_RUNTIME) buildx build --build-arg BASE_IMAGE=ubuntu:latest -t saucelabs/forwarder:$(TAG) $(TMPDIR)
 else
 	@CGO_ENABLED=0 GOOS=linux go build -o $(TMPDIR)/forwarder ./cmd/forwarder
-	@docker buildx build --build-arg BASE_IMAGE=gcr.io/distroless/static:nonroot -t saucelabs/forwarder:$(TAG) $(TMPDIR)
+	@$(CONTAINER_RUNTIME) buildx build --build-arg BASE_IMAGE=gcr.io/distroless/static:nonroot -t saucelabs/forwarder:$(TAG) $(TMPDIR)
 endif
 	@rm -rf $(TMPDIR)
 


### PR DESCRIPTION
This allows to build devel images with podman.