### PR TITLE
goreleaser: use github-native changelog

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,17 +6,7 @@ before:
     - ./packaging/completions.sh
 
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - '^chore\s*(:|\()'
-      - '^ci\s*(:|\()'
-      - '^dockerfile\s*(:|\()'
-      - '^gh\s*(:|\()'
-      - '^golangci\s*(:|\()'
-      - '^goreleaser\s*(:|\()'
-      - '^makefile\s*(:|\()'
-      - '^mk\s*(:|\()'
+  use: github-native
 
 source:
   enabled: false


### PR DESCRIPTION
The github-native is based on Pull Requests.
It's now important to provide good PR titles.