### PR TITLE
log/stdlog: add log line labels

### DIFF
--- a/log/stdlog/opts.go
+++ b/log/stdlog/opts.go
@@ -6,6 +6,13 @@
 
 package stdlog
 
+// WithLabels allows to set labels that are added to each log message.
+func WithLabels(labels ...string) Option {
+	return func(l *Logger) {
+		l.labels = labels
+	}
+}
+
 // WithDecorate allows to a function that modifies the log message before it is written.
 func WithDecorate(f func(string) string) Option {
 	return func(l *Logger) {


### PR DESCRIPTION
Adding stdlog.WithLabels("foo", "bar")

logger := stdlog.New(c.logConfig, stdlog.WithOnError(onError), stdlog.WithLabels("foo", "bar"))

Produces

```
2023/12/11 12:16:38.145946 [foo] [bar] [proxy] [INFO] no upstream proxy specified
2023/12/11 12:16:38.145949 [foo] [bar] [proxy] [INFO] localhost proxying mode=deny
```