### PR TITLE
http_proxy: do not manually set Connection: close header

### DIFF
--- a/http_proxy.go
+++ b/http_proxy.go
@@ -440,9 +440,6 @@ func (hp *HTTPProxy) writeErrorResponseToResponseWriter(res *http.Response, rw h
 			header.Add(k, v)
 		}
 	}
-	if res.Close {
-		header.Set("Connection", "close")
-	}
 	rw.WriteHeader(res.StatusCode)
 
 	if _, err := io.Copy(rw, res.Body); err != nil {


### PR DESCRIPTION
One should never set Connection header if not owning the connection. If ran in http2 server setting it causes the whole connection to be closed.