### PR TITLE
ruleset: export RegexpListItem.Exclude

### DIFF
--- a/ruleset/regexp.go
+++ b/ruleset/regexp.go
@@ -74,7 +74,7 @@ func (r *RegexpMatcher) match(s string) bool {
 
 type RegexpListItem struct {
 	*regexp.Regexp
-	exclude bool
+	Exclude bool
 }
 
 func ParseRegexpListItem(val string) (RegexpListItem, error) {
@@ -87,7 +87,7 @@ func ParseRegexpListItem(val string) (RegexpListItem, error) {
 }
 
 func (r RegexpListItem) String() string {
-	if r.exclude {
+	if r.Exclude {
 		return "-" + r.Regexp.String()
 	}
 	return r.Regexp.String()
@@ -96,7 +96,7 @@ func (r RegexpListItem) String() string {
 func NewRegexpMatcherFromList(l []RegexpListItem) (*RegexpMatcher, error) {
 	var include, exclude []*regexp.Regexp
 	for i := range l {
-		if l[i].exclude {
+		if l[i].Exclude {
 			exclude = append(exclude, l[i].Regexp)
 		} else {
 			include = append(include, l[i].Regexp)

--- a/ruleset/regexp_test.go
+++ b/ruleset/regexp_test.go
@@ -145,7 +145,7 @@ func TestParseRegexpListItem(t *testing.T) {
 			input: "-foo",
 			expected: RegexpListItem{
 				Regexp:  regexp.MustCompile("foo"),
-				exclude: true,
+				Exclude: true,
 			},
 		},
 	}
@@ -160,8 +160,8 @@ func TestParseRegexpListItem(t *testing.T) {
 			if r.Regexp.String() != tc.expected.Regexp.String() {
 				t.Errorf("expected regexp %q, got %q", tc.expected.Regexp.String(), r.Regexp.String())
 			}
-			if r.exclude != tc.expected.exclude {
-				t.Errorf("expected exclude %v, got %v", tc.expected.exclude, r.exclude)
+			if r.Exclude != tc.expected.Exclude {
+				t.Errorf("expected exclude %v, got %v", tc.expected.Exclude, r.Exclude)
 			}
 		})
 	}


### PR DESCRIPTION
This allows to have other parsing mechanisms and still use NewRegexpMatcherFromList().