### PR TITLE
dialvia(http): read CONNECT response by byte

### DIFF
--- a/dialvia/http.go
+++ b/dialvia/http.go
@@ -12,6 +12,7 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -107,7 +108,7 @@ func (d *HTTPProxyDialer) DialContextR(ctx context.Context, network, addr string
 	}
 
 	pbw := bufio.NewWriterSize(conn, 1024)
-	pbr := bufio.NewReaderSize(conn, 1024)
+	pbr := bufio.NewReaderSize(byteReader{conn}, 1)
 
 	req := http.Request{
 		Method: http.MethodConnect,
@@ -162,4 +163,12 @@ func (d *HTTPProxyDialer) DialContextR(ctx context.Context, network, addr string
 	case res := <-resCh:
 		return res, conn, nil
 	}
+}
+
+type byteReader struct {
+	r io.Reader
+}
+
+func (r byteReader) Read(p []byte) (int, error) {
+	return r.r.Read(p[:1])
 }

--- a/dialvia/http.go
+++ b/dialvia/http.go
@@ -107,7 +107,7 @@ func (d *HTTPProxyDialer) DialContextR(ctx context.Context, network, addr string
 		conn = tls.Client(conn, d.tlsConfig)
 	}
 
-	pbw := bufio.NewWriterSize(conn, 1024)
+	pbw := bufio.NewWriterSize(conn, 512)
 	pbr := bufio.NewReaderSize(byteReader{conn}, 1)
 
 	req := http.Request{

--- a/dialvia/http_test.go
+++ b/dialvia/http_test.go
@@ -59,7 +59,7 @@ func TestHTTPProxyDialerDialContext(t *testing.T) {
 		}
 	})
 
-	t.Run("connect status 404", func(t *testing.T) {
+	t.Run("status 404", func(t *testing.T) {
 		errCh := make(chan error, 1)
 		go func() {
 			errCh <- serveOne(l, func(conn net.Conn) error {


### PR DESCRIPTION
Add byteReader, a reader that reads only one byte at a time. Wrap connection in byteReader when passing to bufio.NewReaderSize() - bufio is required due to http.ReadResponse() api.

Fixes #616