### PR TITLE
dialvia(http): change read buffer size to hold response line

### DIFF
--- a/dialvia/http.go
+++ b/dialvia/http.go
@@ -108,7 +108,7 @@ func (d *HTTPProxyDialer) DialContextR(ctx context.Context, network, addr string
 	}
 
 	pbw := bufio.NewWriterSize(conn, 512)
-	pbr := bufio.NewReaderSize(byteReader{conn}, 1)
+	pbr := bufio.NewReaderSize(byteReader{conn}, 128)
 
 	req := http.Request{
 		Method: http.MethodConnect,


### PR DESCRIPTION
http.ReadResponse() calls bufio.Reader.ReadLine() to read lines. When line fits we can reuse memory and prevent additional allocation and GC.

The status line should fit below 64 bytes:
HTTP/1.1 (8+1 bytes)
Status-Code (3+1 bytes)
Reason-Phrase (<=31 bytes)
CRLF (2 bytes)
Total bytes: 8 + 1 + 3 + 1 + 31 = 44

With 128 bytes we should be able to read most header lines too.