### PR TITLE
command/run: add default GOMEMLIMIT

### DIFF
--- a/cmd/forwarder/main.go
+++ b/cmd/forwarder/main.go
@@ -18,6 +18,9 @@ func main() {
 	if _, err := maxprocs.Set(maxprocs.Logger(nil)); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to set GOMAXPROCS: %v\n", err)
 	}
+	if _, ok := os.LookupEnv("GOMEMLIMIT"); !ok {
+		os.Setenv("GOMEMLIMIT", "250MiB")
+	}
 
 	if err := forwarder.Command().Execute(); err != nil {
 		os.WriteFile("/dev/termination-log", []byte(err.Error()), 0o644) //nolint // best effort

--- a/command/run/run.go
+++ b/command/run/run.go
@@ -73,11 +73,7 @@ func (c *command) runE(cmd *cobra.Command, _ []string) (cmdErr error) {
 	}()
 
 	logger.Infof("Forwarder %s (%s)", version.Version, version.Commit)
-	if limit, ok := os.LookupEnv("GOMEMLIMIT"); ok {
-		logger.Debugf("resource limits: GOMAXPROCS=%d GOMEMLIMIT=%s", runtime.GOMAXPROCS(0), limit)
-	} else {
-		logger.Debugf("resource limits: GOMAXPROCS=%d", runtime.GOMAXPROCS(0))
-	}
+	logger.Debugf("resource limits: GOMAXPROCS=%d GOMEMLIMIT=%s", runtime.GOMAXPROCS(0), os.Getenv("GOMEMLIMIT"))
 
 	var ep []forwarder.APIEndpoint
 


### PR DESCRIPTION
Setting GOMEMLIMIT has very positive impact on the GC policy. It allows to defer GC til there is less work.
In my tests, using mainly local/browser test, the Heap usage is bellow 40MiB and the system allocated memory bellow 100MiB.