### PR TITLE
martian: improve error logging in response writing

### DIFF
--- a/http_proxy.go
+++ b/http_proxy.go
@@ -95,7 +95,6 @@ type HTTPProxyConfig struct {
 	ResponseModifiers      []ResponseModifier
 	ConnectRequestModifier func(*http.Request) error
 	ConnectFunc            ConnectFunc
-	CloseAfterReply        bool
 	ReadLimit              SizeSuffix
 	WriteLimit             SizeSuffix
 
@@ -258,7 +257,6 @@ func (hp *HTTPProxy) configureProxy() error {
 	hp.proxy.ConnectFunc = hp.config.ConnectFunc
 	hp.proxy.WithoutWarning = true
 	hp.proxy.ErrorResponse = hp.errorResponse
-	hp.proxy.CloseAfterReply = hp.config.CloseAfterReply
 	hp.proxy.ReadTimeout = hp.config.ReadTimeout
 	hp.proxy.ReadHeaderTimeout = hp.config.ReadHeaderTimeout
 	hp.proxy.WriteTimeout = hp.config.WriteTimeout

--- a/internal/martian/handler.go
+++ b/internal/martian/handler.go
@@ -331,9 +331,6 @@ func (p proxyHandler) handleRequest(ctx *Context, rw http.ResponseWriter, req *h
 		log.Debugf(req.Context(), "received close request: %v", req.RemoteAddr)
 		res.Close = true
 	}
-	if p.CloseAfterReply {
-		res.Close = true
-	}
 
 	// deal with 101 Switching Protocols responses: (WebSocket, h2c, etc)
 	if res.StatusCode == http.StatusSwitchingProtocols {

--- a/internal/martian/proxy.go
+++ b/internal/martian/proxy.go
@@ -155,9 +155,6 @@ type Proxy struct {
 	// A zero or negative value means there will be no timeout.
 	WriteTimeout time.Duration
 
-	// CloseAfterReply closes the connection after the response has been sent.
-	CloseAfterReply bool
-
 	roundTripper http.RoundTripper
 	dial         func(context.Context, string, string) (net.Conn, error)
 	mitm         *mitm.Config
@@ -857,9 +854,6 @@ func (p *Proxy) handle(ctx *Context, conn net.Conn, brw *bufio.ReadWriter) error
 		closing = errClose
 	}
 
-	if p.CloseAfterReply {
-		closing = errClose
-	}
 	return closing
 }
 

--- a/internal/martian/proxy.go
+++ b/internal/martian/proxy.go
@@ -476,7 +476,7 @@ func (p *Proxy) handleMITM(ctx *Context, req *http.Request, session *Session, br
 
 	b, err := brw.Peek(1)
 	if err != nil {
-		if errors.Is(err, io.EOF) {
+		if isClosedConnError(err) {
 			log.Debugf(req.Context(), "mitm: connection closed prematurely: %v", err)
 		} else {
 			log.Errorf(req.Context(), "mitm: failed to peek connection %s: %v", req.Host, err)
@@ -499,7 +499,7 @@ func (p *Proxy) handleMITM(ctx *Context, req *http.Request, session *Session, br
 
 		if err := tlsconn.Handshake(); err != nil {
 			p.mitm.HandshakeErrorCallback(req, err)
-			if errors.Is(err, io.EOF) {
+			if isClosedConnError(err) {
 				log.Debugf(req.Context(), "mitm: connection closed prematurely: %v", err)
 			} else {
 				log.Errorf(req.Context(), "mitm: failed to handshake connection %s: %v", req.Host, err)


### PR DESCRIPTION
This patch extracts response writing to separate method and uses isClosedConnError() for smarter error logging like we do in case if readRequest().

CloseAfrerReply is removed for easier refactoring and later function reuse.