### PR TITLE
Add armed Listener with TLS handshake timeout

### DIFF
--- a/bind/flag.go
+++ b/bind/flag.go
@@ -328,6 +328,10 @@ func HTTPLogConfig(fs *pflag.FlagSet, cfg []NamedParam[httplog.Mode]) {
 }
 
 func TLSServerConfig(fs *pflag.FlagSet, cfg *forwarder.TLSServerConfig, namePrefix string) {
+	fs.DurationVar(&cfg.HandshakeTimeout,
+		namePrefix+"tls-handshake-timeout", cfg.HandshakeTimeout,
+		"The maximum amount of time to wait for a TLS handshake before closing connection. Zero means no limit.")
+
 	fs.Var(anyflag.NewValueWithRedact[string](cfg.CertFile, &cfg.CertFile, func(val string) (string, error) { return val, nil }, RedactBase64),
 		namePrefix+"tls-cert-file", "<path or base64>"+
 			"TLS certificate to use if the server protocol is https or h2. "+

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -258,6 +258,7 @@ func (hp *HTTPProxy) configureProxy() error {
 	hp.proxy.RequestIDHeader = hp.config.RequestIDHeader
 	hp.proxy.ConnectRequestModifier = hp.config.ConnectRequestModifier
 	hp.proxy.ConnectFunc = hp.config.ConnectFunc
+	hp.proxy.ConnectTimeout = 60 * time.Second
 	hp.proxy.WithoutWarning = true
 	hp.proxy.ErrorResponse = hp.errorResponse
 	hp.proxy.IdleTimeout = hp.config.IdleTimeout

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -251,6 +251,7 @@ func (hp *HTTPProxy) configureProxy() error {
 				return hp.config.MITMDomains.Match(req.URL.Hostname())
 			}
 		}
+		hp.proxy.MITMTLSHandshakeTimeout = hp.config.TLSServerConfig.HandshakeTimeout
 	}
 
 	hp.proxy.AllowHTTP = true

--- a/net_test.go
+++ b/net_test.go
@@ -1,0 +1,72 @@
+// Copyright 2023 Sauce Labs Inc., all rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package forwarder
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/saucelabs/forwarder/log"
+)
+
+func TestListenerTLSHandshakeTimeout(t *testing.T) {
+	tlsCfg := new(tls.Config)
+	if err := (&TLSServerConfig{HandshakeTimeout: 100 * time.Millisecond}).ConfigureTLSConfig(tlsCfg); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+
+	l := Listener{
+		Address:             "localhost:0",
+		Log:                 log.NopLogger,
+		TLSConfig:           tlsCfg,
+		TLSHandshakeTimeout: 100 * time.Millisecond,
+		Callbacks: &mockListenerCallback{
+			t:    t,
+			done: done,
+		},
+	}
+
+	err := l.Listen()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+
+	go func() {
+		// Accept won't return.
+		_, _ = l.Accept()
+	}()
+
+	conn, err := net.Dial("tcp", l.Addr().String())
+	if err != nil {
+		t.Fatalf("net.Dial(): got %v, want no error", err)
+	}
+	defer conn.Close()
+
+	<-done
+}
+
+type mockListenerCallback struct {
+	t    *testing.T
+	done chan struct{}
+}
+
+func (m *mockListenerCallback) OnAccept(_ net.Conn) {
+}
+
+func (m *mockListenerCallback) OnTLSHandshakeError(_ *tls.Conn, err error) {
+	if !errors.Is(err, context.DeadlineExceeded) {
+		m.t.Errorf("tl.OnTLSHandshakeError(): got %v, want %v", err, context.DeadlineExceeded)
+	}
+	m.done <- struct{}{}
+}

--- a/tls.go
+++ b/tls.go
@@ -70,6 +70,10 @@ func (c *TLSClientConfig) loadRootCAs(tlsCfg *tls.Config) error {
 }
 
 type TLSServerConfig struct {
+	// HandshakeTimeout specifies the maximum amount of time waiting to
+	// wait for a TLS handshake. Zero means no timeout.
+	HandshakeTimeout time.Duration
+
 	// CertFile is the path to the TLS certificate.
 	CertFile string
 


### PR DESCRIPTION
This patch adds server side TLS handshake timeout. It will protect forwarders listener and additionally a handshake in mitm. 

Due to the lack of a convenient solution upstream connect is given a constant 1m timeout to complete.  