### PR TITLE
e2e/prometheus: use latest image

### DIFF
--- a/e2e/prometheus/service.go
+++ b/e2e/prometheus/service.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	Image = "prom/prometheus:v2.47.2"
+	Image = "prom/prometheus:latest"
 )
 
 func Service() *compose.Service {


### PR DESCRIPTION
This is to unify the image version with `local/monitoring`.

