### PR TITLE
chore: add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @saucelabs/scdev


### PR DESCRIPTION
Add codeowners file to easier determine ownership across the org right at the source instead of excel sheets.