### PR TITLE
packaging: removing service account is safe

### DIFF
--- a/packaging/deb/forwarder.postrm
+++ b/packaging/deb/forwarder.postrm
@@ -21,4 +21,4 @@ fi
 # End automatically added section
 
 # Remove the service account
-/usr/sbin/userdel forwarder
+/usr/sbin/userdel forwarder ||:

--- a/packaging/rpm/forwarder.postrm
+++ b/packaging/rpm/forwarder.postrm
@@ -4,4 +4,4 @@ if [ $1 -ge 1 ] && [ -x /usr/bin/systemctl ]; then
 fi
 
 # Remove the service account
-/usr/sbin/userdel forwarder
+/usr/sbin/userdel forwarder ||:


### PR DESCRIPTION
This patch allows to run forwarder purge even if its service-account is missing. 