### PR TITLE
http_proxy: support multi-addresses listening

### DIFF
--- a/bind/flag.go
+++ b/bind/flag.go
@@ -244,6 +244,12 @@ func HTTPServerConfig(fs *pflag.FlagSet, cfg *forwarder.HTTPServerConfig, prefix
 			"The server address to listen on. "+
 			"If the host is empty, the server will listen on all available interfaces. ")
 
+	fs.StringSliceVarP(&cfg.OptionalAddrs,
+		namePrefix+"optional-addresses", "", cfg.OptionalAddrs, "<host:port,...>"+
+			"Optional server addresses to listen on. "+
+			"The server will continue to run if the bind fails. "+
+			"Can be specified multiple times.")
+
 	if schemes == nil {
 		schemes = []forwarder.Scheme{
 			forwarder.HTTPScheme,

--- a/e2e/forwarder/service.go
+++ b/e2e/forwarder/service.go
@@ -87,6 +87,11 @@ func GRPCTestService() *Service {
 	return s.WithProtocol("h2")
 }
 
+func (s *Service) WithOptionalAddresses(addresses ...string) *Service {
+	s.Environment["FORWARDER_OPTIONAL_ADDRESSES"] = strings.Join(addresses, ",")
+	return s
+}
+
 func (s *Service) WithProtocol(protocol string) *Service {
 	s.Environment["FORWARDER_PROTOCOL"] = protocol
 

--- a/e2e/setups.go
+++ b/e2e/setups.go
@@ -45,6 +45,7 @@ func AllSetups() []setup.Setup {
 	SetupFlagDenyDomains(l)
 	SetupFlagDirectDomains(l)
 	SetupFlagRateLimit(l)
+	SetupFlagOptionalAddresses(l)
 	SetupSC2450(l)
 
 	return l.Build()
@@ -451,6 +452,21 @@ func SetupFlagRateLimit(l *setupList) {
 			Run: "^TestFlag(Read|Write)Limit$",
 		},
 	)
+}
+
+func SetupFlagOptionalAddresses(l *setupList) {
+	l.Add(
+		setup.Setup{
+			Name: "flag-address-multiple-ports",
+			Compose: compose.NewBuilder().
+				AddService(
+					forwarder.HttpbinService()).
+				AddService(
+					forwarder.ProxyService().
+						WithOptionalAddresses(":4567,:5678")).
+				MustBuild(),
+			Run: "^TestFlagOptionalAddresses$",
+		})
 }
 
 func SetupSC2450(l *setupList) {

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -611,6 +611,7 @@ func (hp *HTTPProxy) listen() (net.Listener, error) {
 
 	l := Listener{
 		Address:             hp.config.Addr,
+		OptionalAddresses:   hp.config.OptionalAddrs,
 		Log:                 hp.log,
 		TLSConfig:           hp.tlsConfig,
 		TLSHandshakeTimeout: hp.config.TLSServerConfig.HandshakeTimeout,

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -170,7 +170,9 @@ func NewHTTPProxy(cfg *HTTPProxyConfig, pr PACResolver, cm *CredentialsMatcher, 
 	}
 	hp.listener = l
 
-	hp.log.Infof("PROXY server listen address=%s protocol=%s", l.Addr(), hp.config.Protocol)
+	for _, addr := range l.Addrs() {
+		hp.log.Infof("PROXY server listen address=%s protocol=%s", addr, hp.config.Protocol)
+	}
 
 	return hp, nil
 }
@@ -602,7 +604,7 @@ func (hp *HTTPProxy) Run(ctx context.Context) error {
 	return nil
 }
 
-func (hp *HTTPProxy) listen() (net.Listener, error) {
+func (hp *HTTPProxy) listen() (*Listener, error) {
 	switch hp.config.Protocol {
 	case HTTPScheme, HTTPSScheme, HTTP2Scheme:
 	default:

--- a/http_server.go
+++ b/http_server.go
@@ -150,7 +150,9 @@ func NewHTTPServer(cfg *HTTPServerConfig, h http.Handler, log log.Logger) (*HTTP
 	}
 	hs.listener = l
 
-	hs.log.Infof("HTTP server listen address=%s protocol=%s", l.Addr(), hs.config.Protocol)
+	for _, addr := range l.Addrs() {
+		hs.log.Infof("HTTP server listen address=%s protocol=%s", addr, hs.config.Protocol)
+	}
 
 	return hs, nil
 }
@@ -230,7 +232,7 @@ func (hs *HTTPServer) Run(ctx context.Context) error {
 	return nil
 }
 
-func (hs *HTTPServer) listen() (net.Listener, error) {
+func (hs *HTTPServer) listen() (*Listener, error) {
 	l := Listener{
 		Address:             hs.config.Addr,
 		OptionalAddresses:   hs.config.OptionalAddrs,

--- a/http_server.go
+++ b/http_server.go
@@ -74,8 +74,9 @@ func h2TLSConfigTemplate() *tls.Config {
 }
 
 type HTTPServerConfig struct {
-	Protocol Scheme
-	Addr     string
+	Protocol      Scheme
+	Addr          string
+	OptionalAddrs []string
 	TLSServerConfig
 	IdleTimeout       time.Duration
 	ReadTimeout       time.Duration
@@ -232,6 +233,7 @@ func (hs *HTTPServer) Run(ctx context.Context) error {
 func (hs *HTTPServer) listen() (net.Listener, error) {
 	l := Listener{
 		Address:             hs.config.Addr,
+		OptionalAddresses:   hs.config.OptionalAddrs,
 		Log:                 hs.log,
 		TLSConfig:           hs.srv.TLSConfig,
 		TLSHandshakeTimeout: hs.config.HandshakeTimeout,


### PR DESCRIPTION
This patch adds multi-addresses listener. 

Fixes #629 