### PR TITLE
prom: export config

### DIFF
--- a/http_proxy.go
+++ b/http_proxy.go
@@ -542,7 +542,7 @@ func (hp *HTTPProxy) listen() (net.Listener, error) {
 		TLSHandshakeTimeout: hp.config.TLSServerConfig.HandshakeTimeout,
 		ReadLimit:           int64(hp.config.ReadLimit),
 		WriteLimit:          int64(hp.config.WriteLimit),
-		promConfig: promConfig{
+		PromConfig: PromConfig{
 			PromNamespace: hp.config.PromNamespace,
 			PromRegistry:  hp.config.PromRegistry,
 		},

--- a/http_server.go
+++ b/http_server.go
@@ -82,7 +82,7 @@ type HTTPServerConfig struct {
 	WriteTimeout      time.Duration
 	LogHTTPMode       httplog.Mode
 	BasicAuth         *url.Userinfo
-	promConfig
+	PromConfig
 }
 
 func DefaultHTTPServerConfig() *HTTPServerConfig {

--- a/net.go
+++ b/net.go
@@ -33,7 +33,7 @@ type DialConfig struct {
 	// The keep-alive probes are sent with OS specific intervals.
 	KeepAlive bool
 
-	promConfig
+	PromConfig
 }
 
 func DefaultDialConfig() *DialConfig {
@@ -110,7 +110,7 @@ type Listener struct {
 	TLSHandshakeTimeout time.Duration
 	ReadLimit           int64
 	WriteLimit          int64
-	promConfig
+	PromConfig
 
 	listener net.Listener
 	metrics  *listenerMetrics

--- a/net_test.go
+++ b/net_test.go
@@ -35,7 +35,7 @@ func TestDialerMetrics(t *testing.T) {
 	r := prometheus.NewRegistry()
 	d := NewDialer(&DialConfig{
 		DialTimeout: 10 * time.Millisecond,
-		promConfig: promConfig{
+		PromConfig: PromConfig{
 			PromNamespace: "test",
 			PromRegistry:  r,
 		},
@@ -61,7 +61,7 @@ func TestDialerMetricsErrors(t *testing.T) {
 	r := prometheus.NewRegistry()
 	d := NewDialer(&DialConfig{
 		DialTimeout: 10 * time.Millisecond,
-		promConfig: promConfig{
+		PromConfig: PromConfig{
 			PromNamespace: "test",
 			PromRegistry:  r,
 		},
@@ -121,7 +121,7 @@ func TestListenerMetricsAccepted(t *testing.T) {
 	l := Listener{
 		Address: "localhost:0",
 		Log:     log.NopLogger,
-		promConfig: promConfig{
+		PromConfig: PromConfig{
 			PromNamespace: "test",
 			PromRegistry:  r,
 		},
@@ -152,7 +152,7 @@ func TestListenerMetricsAcceptedWithTLS(t *testing.T) {
 		Address:   "localhost:0",
 		Log:       log.NopLogger,
 		TLSConfig: selfSingedCert(),
-		promConfig: promConfig{
+		PromConfig: PromConfig{
 			PromNamespace: "test",
 			PromRegistry:  r,
 		},
@@ -183,7 +183,7 @@ func TestListenerMetricsClosed(t *testing.T) {
 	l := Listener{
 		Address: "localhost:0",
 		Log:     log.NopLogger,
-		promConfig: promConfig{
+		PromConfig: PromConfig{
 			PromNamespace: "test",
 			PromRegistry:  r,
 		},
@@ -222,7 +222,7 @@ func TestListenerMetricsErrors(t *testing.T) {
 	l := Listener{
 		Address: "localhost:0",
 		Log:     log.NopLogger,
-		promConfig: promConfig{
+		PromConfig: PromConfig{
 			PromNamespace: "test",
 			PromRegistry:  r,
 		},
@@ -250,7 +250,7 @@ func TestListenerTLSHandshakeTimeout(t *testing.T) {
 		Log:                 log.NopLogger,
 		TLSConfig:           selfSingedCert(),
 		TLSHandshakeTimeout: 100 * time.Millisecond,
-		promConfig: promConfig{
+		PromConfig: PromConfig{
 			PromNamespace: "test",
 			PromRegistry:  r,
 		},

--- a/prom.go
+++ b/prom.go
@@ -10,8 +10,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// promConfig is a configuration for Prometheus metrics.
-type promConfig struct {
+// PromConfig is a configuration for Prometheus metrics.
+type PromConfig struct {
 	PromNamespace string
 	PromRegistry  prometheus.Registerer
 }


### PR DESCRIPTION
This would prevent from constructing listener outside forwarder package.
