### PR TITLE
dial: increase dial t/o to 30s

### DIFF
--- a/net.go
+++ b/net.go
@@ -38,7 +38,7 @@ type DialConfig struct {
 
 func DefaultDialConfig() *DialConfig {
 	return &DialConfig{
-		DialTimeout: 10 * time.Second,
+		DialTimeout: 30 * time.Second,
 		KeepAlive:   true,
 	}
 }


### PR DESCRIPTION
To prevent extended number of t/o errors increase dial t/o by default to 30s.

<!-- Thank you for your hard work on this pull request! -->
