### PR TITLE
Add matcher interface for domains filtering 

### DIFF
--- a/http_proxy.go
+++ b/http_proxy.go
@@ -26,7 +26,6 @@ import (
 	"github.com/saucelabs/forwarder/log"
 	"github.com/saucelabs/forwarder/middleware"
 	"github.com/saucelabs/forwarder/pac"
-	"github.com/saucelabs/forwarder/ruleset"
 )
 
 type ProxyLocalhostMode string
@@ -81,12 +80,12 @@ type HTTPProxyConfig struct {
 	HTTPServerConfig
 	Name                   string
 	MITM                   *MITMConfig
-	MITMDomains            *ruleset.RegexpMatcher
+	MITMDomains            Matcher
 	ProxyLocalhost         ProxyLocalhostMode
 	UpstreamProxy          *url.URL
 	UpstreamProxyFunc      ProxyFunc
-	DenyDomains            *ruleset.RegexpMatcher
-	DirectDomains          *ruleset.RegexpMatcher
+	DenyDomains            Matcher
+	DirectDomains          Matcher
 	RequestIDHeader        string
 	RequestModifiers       []RequestModifier
 	ResponseModifiers      []ResponseModifier
@@ -414,7 +413,7 @@ func (hp *HTTPProxy) denyLocalhost() martian.RequestModifier {
 	})
 }
 
-func (hp *HTTPProxy) denyDomains(r *ruleset.RegexpMatcher) martian.RequestModifier {
+func (hp *HTTPProxy) denyDomains(r Matcher) martian.RequestModifier {
 	return martian.RequestModifierFunc(func(req *http.Request) error {
 		if r.Match(req.URL.Hostname()) {
 			return ErrProxyDenied

--- a/matcher.go
+++ b/matcher.go
@@ -1,0 +1,17 @@
+// Copyright 2022-2024 Sauce Labs Inc., all rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package forwarder
+
+type Matcher interface {
+	Match(string) bool
+}
+
+type MatchFunc func(string) bool
+
+func (m MatchFunc) Match(s string) bool {
+	return m(s)
+}


### PR DESCRIPTION
The Matcher interface replaces RegexpMatcher in forwarder's config.
This allows specifying custom match logic for mitm, deny, and direct domains.