### PR TITLE
bind: change data URI scheme format in pac flag usage

### DIFF
--- a/bind/flag.go
+++ b/bind/flag.go
@@ -55,10 +55,10 @@ func DNSConfig(fs *pflag.FlagSet, cfg *osdns.Config) {
 
 func PAC(fs *pflag.FlagSet, pac **url.URL) {
 	fs.VarP(anyflag.NewValue[*url.URL](*pac, pac, fileurl.ParseFilePathOrURL),
-		"pac", "p", "<path or URL>"+
+		"pac", "p", "`<path or URL>`"+
 			"Proxy Auto-Configuration file to use for upstream proxy selection. "+
 			"It can be a local file or a URL, you can also use '-' to read from stdin. "+
-			"The data URI scheme is supported, the format is data:base64,<encoded data>. ")
+			"The data URI scheme is supported, the format is `data:base64,<encoded data>`. ")
 }
 
 func ProxyHeaders(fs *pflag.FlagSet, headers *[]header.Header) {


### PR DESCRIPTION
'<' and '>' make a mess in sc docs.

```
-p, --pac <path or URL> (env FORWARDER_PAC)
    Proxy Auto-Configuration file to use for upstream proxy selection. It can be a local file or a URL, you can
    also use '-' to read from stdin. The data URI scheme is supported, the format is "data:base64,encoded_data".
```