### PR TITLE
docsgen: add ID in the footer for cli 

### DIFF
--- a/docs/content/cli/forwarder_pac_eval.md
+++ b/docs/content/cli/forwarder_pac_eval.md
@@ -1,4 +1,5 @@
 ---
+id: eval
 title: forwarder pac eval
 weight: 102
 ---

--- a/docs/content/cli/forwarder_pac_server.md
+++ b/docs/content/cli/forwarder_pac_server.md
@@ -1,4 +1,5 @@
 ---
+id: server
 title: forwarder pac server
 weight: 103
 ---

--- a/docs/content/cli/forwarder_ready.md
+++ b/docs/content/cli/forwarder_ready.md
@@ -1,4 +1,5 @@
 ---
+id: ready
 title: forwarder ready
 weight: 104
 ---

--- a/docs/content/cli/forwarder_run.md
+++ b/docs/content/cli/forwarder_run.md
@@ -1,4 +1,5 @@
 ---
+id: run
 title: forwarder run
 weight: 101
 ---

--- a/docs/content/cli/forwarder_test_grpc.md
+++ b/docs/content/cli/forwarder_test_grpc.md
@@ -1,4 +1,5 @@
 ---
+id: grpc
 title: forwarder test grpc
 ---
 

--- a/docs/content/cli/forwarder_test_httpbin.md
+++ b/docs/content/cli/forwarder_test_httpbin.md
@@ -1,4 +1,5 @@
 ---
+id: httpbin
 title: forwarder test httpbin
 ---
 

--- a/utils/docsgen/command.go
+++ b/utils/docsgen/command.go
@@ -76,6 +76,7 @@ func WriteCommandDoc(cmd *cobra.Command, cliDir string) error {
 		}
 
 		fmt.Fprintf(f, "---\n")
+		fmt.Fprintf(f, "id: %s\n", cmd.Name())
 		fmt.Fprintf(f, "title: %s\n", cobrautil.FullCommandName(cmd))
 		if idx, ok := cmdIndex[cobrautil.FullCommandName(cmd)]; ok {
 			fmt.Fprintf(f, "weight: %d\n", cliWeight+idx)


### PR DESCRIPTION
<!-- Thank you for your hard work on this pull request! -->
SC docs use `id` to organize and structure sidebar. It does not break anything in forwarder.
