### PR TITLE
middleware(prom): add customizable label for http metrics

### DIFF
--- a/http_proxy.go
+++ b/http_proxy.go
@@ -93,6 +93,7 @@ type HTTPProxyConfig struct {
 	ConnectTimeout    time.Duration
 	ReadLimit         SizeSuffix
 	WriteLimit        SizeSuffix
+	PromHTTPOpts      []middleware.PrometheusOpt
 
 	// TestingHTTPHandler uses Martian's [http.Handler] implementation
 	// over [http.Server] instead of the default TCP server.
@@ -366,7 +367,7 @@ func (hp *HTTPProxy) middlewareStack() (martian.RequestResponseModifier, *martia
 	}
 
 	if hp.config.PromRegistry != nil {
-		p := middleware.NewPrometheus(hp.config.PromRegistry, hp.config.PromNamespace)
+		p := middleware.NewPrometheus(hp.config.PromRegistry, hp.config.PromNamespace, hp.config.PromHTTPOpts...)
 		stack.AddRequestModifier(p)
 		stack.AddResponseModifier(p)
 


### PR DESCRIPTION
It can be used to partition the metrics by custom conditions. e.g. Label direct/tunnel mode in SC5.

PrometheusOpt was chosen to ensure compatibility with existing prom instances.

<!-- Thank you for your hard work on this pull request! -->
