### PR TITLE
cobrautil/templates: support custom formats in usages 

### DIFF
--- a/utils/cobrautil/templates/help_flags_printer.go
+++ b/utils/cobrautil/templates/help_flags_printer.go
@@ -59,7 +59,8 @@ func (p *HelpFlagPrinter) PrintHelpFlag(flag *flag.Flag) {
 	// It always has at least 2 elements.
 	flagStr, usageStr := flagAndUsage[0], strings.Join(flagAndUsage[1:], " ")
 
-	wrappedUsages := wordwrap.WrapString(usageStr, p.wrapLimit-offset)
+	usageWithBreakLines := strings.ReplaceAll(usageStr, "<br>", "\n\n")
+	wrappedUsages := wordwrap.WrapString(usageWithBreakLines, p.wrapLimit-offset)
 	wrappedStr = flagStr + "\n" + wrappedUsages
 	appendTabStr := strings.ReplaceAll(wrappedStr, "\n", "\n\t")
 

--- a/utils/cobrautil/templates/help_flags_printer.go
+++ b/utils/cobrautil/templates/help_flags_printer.go
@@ -57,9 +57,9 @@ func (p *HelpFlagPrinter) PrintHelpFlag(flag *flag.Flag) {
 	flagAndUsage := strings.Split(formatBuf.String(), "\n")
 
 	// It always has at least 2 elements.
-	flagStr, nextLines := flagAndUsage[0], strings.Join(flagAndUsage[1:], " ")
+	flagStr, usageStr := flagAndUsage[0], strings.Join(flagAndUsage[1:], " ")
 
-	wrappedUsages := wordwrap.WrapString(nextLines, p.wrapLimit-offset)
+	wrappedUsages := wordwrap.WrapString(usageStr, p.wrapLimit-offset)
 	wrappedStr = flagStr + "\n" + wrappedUsages
 	appendTabStr := strings.ReplaceAll(wrappedStr, "\n", "\n\t")
 

--- a/utils/cobrautil/templates/help_flags_printer.go
+++ b/utils/cobrautil/templates/help_flags_printer.go
@@ -55,14 +55,12 @@ func (p *HelpFlagPrinter) PrintHelpFlag(flag *flag.Flag) {
 
 	wrappedStr := formatBuf.String()
 	flagAndUsage := strings.Split(formatBuf.String(), "\n")
-	flagStr := flagAndUsage[0]
 
-	// if the flag usage is longer than one line, wrap it again
-	if len(flagAndUsage) > 1 {
-		nextLines := strings.Join(flagAndUsage[1:], " ")
-		wrappedUsages := wordwrap.WrapString(nextLines, p.wrapLimit-offset)
-		wrappedStr = flagStr + "\n" + wrappedUsages
-	}
+	// It always has at least 2 elements.
+	flagStr, nextLines := flagAndUsage[0], strings.Join(flagAndUsage[1:], " ")
+
+	wrappedUsages := wordwrap.WrapString(nextLines, p.wrapLimit-offset)
+	wrappedStr = flagStr + "\n" + wrappedUsages
 	appendTabStr := strings.ReplaceAll(wrappedStr, "\n", "\n\t")
 
 	fmt.Fprintf(p.out, appendTabStr+"\n\n")

--- a/utils/cobrautil/templates/help_flags_printer.go
+++ b/utils/cobrautil/templates/help_flags_printer.go
@@ -61,8 +61,8 @@ func (p *HelpFlagPrinter) PrintHelpFlag(flag *flag.Flag) {
 	flagStr, usageStr := flagAndUsage[0], strings.Join(flagAndUsage[1:], " ")
 
 	usageWithBreakLines := strings.ReplaceAll(usageStr, "<br>", "\n\n")
-	usageWithExamples := strings.ReplaceAll(usageWithBreakLines, "<ex>", "\"")
-	usageWithLinks := withLinks(usageWithExamples)
+	usageWithCodeBlocks := strings.ReplaceAll(strings.ReplaceAll(usageWithBreakLines, "<code>", "\""), "</code>", "\"")
+	usageWithLinks := withLinks(usageWithCodeBlocks)
 	wrappedUsages := wordwrap.WrapString(usageWithLinks, p.wrapLimit-offset)
 	wrappedStr = flagStr + "\n" + wrappedUsages
 	appendTabStr := strings.ReplaceAll(wrappedStr, "\n", "\n\t")

--- a/utils/cobrautil/templates/help_flags_printer.go
+++ b/utils/cobrautil/templates/help_flags_printer.go
@@ -60,7 +60,8 @@ func (p *HelpFlagPrinter) PrintHelpFlag(flag *flag.Flag) {
 	flagStr, usageStr := flagAndUsage[0], strings.Join(flagAndUsage[1:], " ")
 
 	usageWithBreakLines := strings.ReplaceAll(usageStr, "<br>", "\n\n")
-	wrappedUsages := wordwrap.WrapString(usageWithBreakLines, p.wrapLimit-offset)
+	usageWithExamples := strings.ReplaceAll(usageWithBreakLines, "<ex>", "\"")
+	wrappedUsages := wordwrap.WrapString(usageWithExamples, p.wrapLimit-offset)
 	wrappedStr = flagStr + "\n" + wrappedUsages
 	appendTabStr := strings.ReplaceAll(wrappedStr, "\n", "\n\t")
 

--- a/utils/cobrautil/templates/link.go
+++ b/utils/cobrautil/templates/link.go
@@ -1,0 +1,4 @@
+package templates
+
+// Regular expression pattern to match "<link text,root,path>".
+var linkPattern = `<link (.*?),(.*?),(.*?)>`

--- a/utils/cobrautil/templates/markdown_flag_printer.go
+++ b/utils/cobrautil/templates/markdown_flag_printer.go
@@ -35,7 +35,8 @@ func (p *MarkdownFlagPrinter) PrintHelpFlag(f *pflag.Flag) {
 	body := p.body(f)
 	body = strings.ReplaceAll(body, ". ", ".\n")
 	body = strings.ReplaceAll(body, "<br>", "\n")
-	body = strings.ReplaceAll(body, "<ex>", "\n```\n")
+	body = strings.ReplaceAll(body, "<code>", "```\n")
+	body = strings.ReplaceAll(body, "</code>", "\n```\n")
 	body = withMarkdownLinks(body)
 
 	fmt.Fprintf(p.out, body)

--- a/utils/cobrautil/templates/markdown_flag_printer.go
+++ b/utils/cobrautil/templates/markdown_flag_printer.go
@@ -33,6 +33,7 @@ func (p *MarkdownFlagPrinter) PrintHelpFlag(f *pflag.Flag) {
 
 	body := p.body(f)
 	body = strings.ReplaceAll(body, ". ", ".\n")
+	body = strings.ReplaceAll(body, "<br>", "\n")
 	fmt.Fprintf(p.out, body)
 	fmt.Fprintf(p.out, "\n\n")
 }

--- a/utils/cobrautil/templates/markdown_flag_printer.go
+++ b/utils/cobrautil/templates/markdown_flag_printer.go
@@ -34,6 +34,8 @@ func (p *MarkdownFlagPrinter) PrintHelpFlag(f *pflag.Flag) {
 	body := p.body(f)
 	body = strings.ReplaceAll(body, ". ", ".\n")
 	body = strings.ReplaceAll(body, "<br>", "\n")
+	body = strings.ReplaceAll(body, "<ex>", "\n```\n")
+
 	fmt.Fprintf(p.out, body)
 	fmt.Fprintf(p.out, "\n\n")
 }


### PR DESCRIPTION
<!-- Thank you for your hard work on this pull request! -->

This patch implements custom formatting of `<br>`,`<ex>`, and `<link ...>` for help and markdown printers. 