### PR TITLE
cobrautil/templates(yaml_flag_printer): support <br>, <code> and <link>

### DIFF
--- a/utils/cobrautil/templates/yaml_flag_printer.go
+++ b/utils/cobrautil/templates/yaml_flag_printer.go
@@ -35,6 +35,11 @@ func (p *YamlFlagPrinter) PrintHelpFlag(f *pflag.Flag) {
 		deprecated = fmt.Sprintf("\nDEPRECATED: %s", f.Deprecated)
 	}
 
+	usage = strings.ReplaceAll(usage, "<br>", "\n\n")
+	usage = strings.ReplaceAll(usage, "<code>", "\"")
+	usage = strings.ReplaceAll(usage, "</code>", "\"")
+	usage = withLinks(usage)
+
 	fmt.Fprintf(p.out, "# %s%s\n#\n", f.Name, name)
 	for _, l := range strings.Split(wordwrap.WrapString(usage, p.wrapLimit-2), "\n") {
 		fmt.Fprintf(p.out, "# %s\n", l)


### PR DESCRIPTION
<!-- Thank you for your hard work on this pull request! -->

This patch adds support for `<br>`, `<code>`, ` </code>`, and `<link>` to yaml printer (config files). 
It should have been added in #752.
