### PR TITLE
utils/cobrautil/templates: print help and usage to stdout

### DIFF
--- a/utils/cobrautil/templates/templater.go
+++ b/utils/cobrautil/templates/templater.go
@@ -97,7 +97,7 @@ func (templater *templater) HelpFunc() func(*cobra.Command, []string) {
 		t := template.New("help")
 		t.Funcs(templater.templateFuncs())
 		template.Must(t.Parse(templater.HelpTemplate))
-		out := term.NewWordWrapWriter(c.OutOrStderr(), DefaultWrapLimit)
+		out := term.NewWordWrapWriter(c.OutOrStdout(), DefaultWrapLimit)
 		err := t.Execute(out, c)
 		if err != nil {
 			c.Println(err)
@@ -110,7 +110,7 @@ func (templater *templater) UsageFunc(exposedFlags ...string) func(*cobra.Comman
 		t := template.New("usage")
 		t.Funcs(templater.templateFuncs(exposedFlags...))
 		template.Must(t.Parse(templater.UsageTemplate))
-		out := term.NewWordWrapWriter(c.OutOrStderr(), DefaultWrapLimit)
+		out := term.NewWordWrapWriter(c.OutOrStdout(), DefaultWrapLimit)
 		return t.Execute(out, c)
 	}
 }


### PR DESCRIPTION
Having --help text go to stderr makes it unusable with tools like grep or less.

According to GNU Coding Standards[1] the --help option should print on standard output.

[1] https://www.gnu.org/prep/standards/html_node/_002d_002dhelp.html

<!-- Thank you for your hard work on this pull request! -->
