### PR TITLE
systemd: restrict permissions

### DIFF
--- a/local/linux/Makefile
+++ b/local/linux/Makefile
@@ -33,7 +33,7 @@ fedora: forwarder.rpm
 
 .PHONY: .up
 .up:
-	@podman run -p 3128:3128 -d -v ./forwarder.$(EXT):/forwarder.$(EXT) --name forwarder-testing --replace $(IMG)
+	@podman run -p 3128:3128 -d -v ./forwarder.$(EXT):/forwarder.$(EXT) --privileged --name forwarder-testing --replace $(IMG)
 	@podman exec forwarder-testing $(INSTALL_CMD) "/forwarder.$(EXT)"
 	@podman cp ./forwarder.yaml forwarder-testing:/etc/forwarder/forwarder.yaml
 	@podman exec forwarder-testing systemctl start forwarder

--- a/packaging/systemd/forwarder.service
+++ b/packaging/systemd/forwarder.service
@@ -6,17 +6,44 @@ After=network-online.target
 Type=simple
 User=forwarder
 Group=forwarder
-LimitCORE=infinity
-EnvironmentFile=/etc/default/forwarder
 ExecStart=/usr/bin/forwarder run
-TimeoutStartSec=900
-TimeoutStopSec=900
+EnvironmentFile=/etc/default/forwarder
+
+PrivateDevices=true
+PrivateTmp=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=invisible
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+RestrictRealtime=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+LockPersonality=true
+ProcSubset=pid
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+# Uncomment the following lines if your service requires binding to ports <1024.
+#AmbientCapabilities=CAP_NET_BIND_SERVICE
+#CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+
 KillMode=process
 Restart=on-failure
+RestartSec=30s
 RestartPreventExitStatus=1
+TimeoutStartSec=60
+TimeoutStopSec=600
+
+SyslogIdentifier=forwarder
 StandardOutput=journal
 StandardError=journal
 SyslogLevelPrefix=false
+
+LimitCORE=infinity
+LimitNPROC=64
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
<!-- Thank you for your hard work on this pull request! -->
Forwarder does not need that many permissions, we can restrict it to minimum.

CAP_NET_BIND_SERVICE can be used to allow this user to bind to a port < 1024 if desired.

The work is based on wireproxy's systemd configuration[1]. Also I found systemd service hardening doc[2] helpful.

DynamicUser/Strict system protection didn't work as package installs forwarder binary at /usr/bin.

[1] https://github.com/pufferffish/wireproxy/pull/103.
[2] https://gist.github.com/ageis/f5595e59b1cddb1513d1b425a323db04