### PR TITLE
ratelimit: invert read and write limits

### DIFF
--- a/net.go
+++ b/net.go
@@ -127,10 +127,7 @@ func (l *Listener) Listen() error {
 	}
 
 	if rl, wl := l.ReadLimit, l.WriteLimit; rl > 0 || wl > 0 {
-		// Notice that the ReadLimit stands for the read limit *from* a proxy, and the WriteLimit
-		// stands for the write limit *to* a proxy, thus the ReadLimit is in fact
-		// a txBandwidth and the WriteLimit is a rxBandwidth.
-		ll = ratelimit.NewListener(ll, wl, rl)
+		ll = ratelimit.NewListener(ll, rl, wl)
 	}
 
 	l.listener = ll


### PR DESCRIPTION
This patch pushes the invertion of limits down to the listener constructing code. It fits better here. Users do not have to invert it themselves.

The limit is global. 


<!-- Thank you for your hard work on this pull request! -->
