### PR TITLE
martian/header(via): close looped request

### DIFF
--- a/internal/martian/header/via_modifier.go
+++ b/internal/martian/header/via_modifier.go
@@ -53,6 +53,7 @@ func (m *ViaModifier) ModifyRequest(req *http.Request) error {
 
 	if v := req.Header.Get("Via"); v != "" {
 		if m.hasLoop(v) {
+			req.Close = true
 			return martian.ErrorStatus{
 				Err:    fmt.Errorf("via: detected request loop, header contains %s", via),
 				Status: 400,

--- a/internal/martian/header/via_modifier_test.go
+++ b/internal/martian/header/via_modifier_test.go
@@ -47,4 +47,7 @@ func TestViaModifier(t *testing.T) {
 	if err := m.ModifyRequest(req); err == nil {
 		t.Fatal("ModifyRequest(): got nil, want request loop error")
 	}
+	if !req.Close {
+		t.Fatalf("req.Close: got %v, want true", req.Close)
+	}
 }


### PR DESCRIPTION
This is to remove hanging connections from http.Transport.

Fixes #688

<!-- Thank you for your hard work on this pull request! -->
