### PR TITLE
perf: use goroutine pooling 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/mmatczuk/anyflag v0.0.0-20240105091245-c64b70bf5d41
+	github.com/panjf2000/ants/v2 v2.9.1
 	github.com/prometheus/client_golang v1.19.0
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.53.0

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mmatczuk/anyflag v0.0.0-20240105091245-c64b70bf5d41 h1:YRrHzEpNLEEpefVq2Ve9hOj/jA3QdYwoJhPGOqdAhnw=
 github.com/mmatczuk/anyflag v0.0.0-20240105091245-c64b70bf5d41/go.mod h1:PT22bA6vWBzPL8tAeK2XCMvWOQ4e19yY3MJIgnTZRaE=
+github.com/panjf2000/ants/v2 v2.9.1 h1:Q5vh5xohbsZXGcD6hhszzGqB7jSSc2/CRr3QKIga8Kw=
+github.com/panjf2000/ants/v2 v2.9.1/go.mod h1:7ZxyxsqE4vvW0M7LSD8aI3cKwgFhBHbxnlN8mDqHa1I=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
 github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -101,6 +103,7 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
@@ -125,6 +128,7 @@ golang.org/x/net v0.24.0 h1:1PcaxkF854Fu3+lvBIx5SYn9wRlBzzcnHZSiaFFAb0w=
 golang.org/x/net v0.24.0/go.mod h1:2Q7sJY5mzlzWjKtYUEXSlBWCdyaioyXzRB2RtU8KVE8=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
 golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/martian/copy.go
+++ b/internal/martian/copy.go
@@ -62,3 +62,11 @@ func copySync(ctx context.Context, name string, w io.Writer, r io.Reader, donec 
 	log.Debugf(ctx, "%s tunnel finished copying", name)
 	donec <- struct{}{}
 }
+
+type copySyncArgs struct {
+	ctx   context.Context //nolint:containedctx // It's func arg.
+	name  string
+	w     io.Writer
+	r     io.Reader
+	donec chan<- struct{}
+}

--- a/internal/martian/copy.go
+++ b/internal/martian/copy.go
@@ -43,7 +43,7 @@ var copyBufPool = sync.Pool{
 	},
 }
 
-func copySync(ctx context.Context, name string, w io.Writer, r io.Reader, donec chan<- bool) {
+func copySync(ctx context.Context, name string, w io.Writer, r io.Reader, donec chan<- struct{}) {
 	bufp := copyBufPool.Get().(*[]byte) //nolint:forcetypeassert // It's *[]byte.
 	buf := *bufp
 	defer copyBufPool.Put(bufp)
@@ -60,5 +60,5 @@ func copySync(ctx context.Context, name string, w io.Writer, r io.Reader, donec 
 	}
 
 	log.Debugf(ctx, "%s tunnel finished copying", name)
-	donec <- true
+	donec <- struct{}{}
 }

--- a/internal/martian/proxy_conn.go
+++ b/internal/martian/proxy_conn.go
@@ -294,7 +294,7 @@ func (p *proxyConn) tunnel(name string, res *http.Response, crw io.ReadWriteClos
 	}
 
 	ctx := res.Request.Context()
-	donec := make(chan bool, 2)
+	donec := make(chan struct{}, 2)
 	go copySync(ctx, "outbound "+name, crw, p.conn, donec)
 	go copySync(ctx, "inbound "+name, p.conn, crw, donec)
 

--- a/internal/martian/proxy_handler.go
+++ b/internal/martian/proxy_handler.go
@@ -194,7 +194,7 @@ func (p proxyHandler) tunnel(name string, rw http.ResponseWriter, req *http.Requ
 
 	var (
 		rc    = http.NewResponseController(rw)
-		donec = make(chan bool, 2)
+		donec = make(chan struct{}, 2)
 	)
 	switch req.ProtoMajor {
 	case 1:


### PR DESCRIPTION
<!-- Thank you for your hard work on this pull request! -->

This patch applies ants - goroutines pooling to improve performance.

compose:
```
services:
    proxy:
        image: saucelabs/forwarder:${FORWARDER_VERSION}
        environment:
            FORWARDER_API_ADDRESS: :10000
            FORWARDER_LOG_HTTP: none
            FORWARDER_LOG_LEVEL: info
            FORWARDER_PROTOCOL: http
            GOMAXPROCS: "4"
        ports:
            - 3128:3128
            - 10000:10000
        cpus: 4
```

test: `local/browser`

allocs (old vs new):
<img width="1726" alt="Screenshot 2024-05-02 at 17 34 59" src="https://github.com/saucelabs/forwarder/assets/57443889/ec4e0143-d255-4f13-845d-b8198ceceb89">

heap (old vs new):
<img width="1726" alt="Screenshot 2024-05-02 at 17 35 43" src="https://github.com/saucelabs/forwarder/assets/57443889/b049e121-a3f1-49f7-8dc3-6db329a68b0d">

cpu (old vs new):
<img width="1727" alt="Screenshot 2024-05-02 at 17 36 10" src="https://github.com/saucelabs/forwarder/assets/57443889/b884d612-211b-4a02-ac15-a206ed29de4f">
