### PR TITLE
e2e: change static IPs in dns test

### DIFF
--- a/e2e/dns/db.rpz
+++ b/e2e/dns/db.rpz
@@ -7,4 +7,4 @@ $TTL 60
                           30m)         ; minimum
                    IN     NS    localhost.
 
-httpbin.local  A        192.168.100.10
+httpbin.local  A        150.150.100.10

--- a/e2e/setups.go
+++ b/e2e/setups.go
@@ -245,10 +245,10 @@ func SetupFlagDNSServer(l *setupList) {
 	const (
 		networkName = "internal"
 
-		dnsIPAddr        = "192.168.100.2"
-		invalidDNSIPAddr = "192.168.100.3"
-		httpbinIPAddr    = "192.168.100.10"
-		proxyIPAddr      = "192.168.100.11"
+		dnsIPAddr        = "150.150.100.2"
+		invalidDNSIPAddr = "150.150.100.3"
+		httpbinIPAddr    = "150.150.100.10"
+		proxyIPAddr      = "150.150.100.11"
 	)
 	for _, s := range []struct {
 		name    string
@@ -282,9 +282,9 @@ func SetupFlagDNSServer(l *setupList) {
 					IPAM: compose.IPAM{
 						Config: []compose.IPAMConfig{
 							{
-								Subnet:  "192.168.100.0/24",
-								Gateway: "192.168.100.1",
-								IPRange: "192.168.100.10/29",
+								Subnet:  "150.150.100.0/24",
+								Gateway: "150.150.100.1",
+								IPRange: "150.150.100.10/29",
 							},
 						},
 					},


### PR DESCRIPTION
As observed in a few CI runs[1] assigning private addresses might result in an overlap with randomly generated networks. Both Podman and Docker assign private addresses (10.0.0.0, 172.16.0.0, 192.168.0.0) when the network is not specified.

This patch changes static IP addresses in dns setups to non-private to minimize the chance of collision.

[1] https://github.com/saucelabs/forwarder/actions/runs/8896336713/job/24428757815

<!-- Thank you for your hard work on this pull request! -->
