### PR TITLE
martian: support server sent events without chunked encoding

### DIFF
--- a/internal/martian/flush_test.go
+++ b/internal/martian/flush_test.go
@@ -1,0 +1,56 @@
+package martian
+
+import (
+	"testing"
+)
+
+type mockWriter struct{}
+
+func (m *mockWriter) Write(p []byte) (n int, err error) {
+	return len(p), nil
+}
+
+// Mock Flusher to capture flush calls.
+type mockFlusher struct {
+	flushes int
+}
+
+func (m *mockFlusher) Flush() error {
+	m.flushes++
+	return nil
+}
+
+func TestFlushWriter(t *testing.T) {
+	tests := []struct {
+		name      string
+		pattern   [2]byte
+		input     []string
+		wantFlush int
+	}{
+		{"no pattern", [2]byte{'a', 'b'}, []string{"hello world"}, 0},
+		{"pattern", [2]byte{'a', 'b'}, []string{"ab"}, 1},
+		{"pattern at start", [2]byte{'a', 'b'}, []string{"abhello world"}, 1},
+		{"pattern at end", [2]byte{'a', 'b'}, []string{"hello worldab"}, 1},
+		{"double write", [2]byte{'a', 'b'}, []string{"hello a", "bworld"}, 1},
+		{"triple write", [2]byte{'a', 'b'}, []string{"hello ab", "world a", "b"}, 2},
+		{"repeat last byte", [2]byte{'a', 'b'}, []string{"a", "b", "b"}, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &mockWriter{}
+			f := &mockFlusher{}
+			fw := newPatternFlushWriter(w, f, tt.pattern)
+
+			for _, input := range tt.input {
+				if _, err := fw.Write([]byte(input)); err != nil {
+					t.Fatalf("expected nil, got %v", err)
+				}
+			}
+
+			if f.flushes != tt.wantFlush {
+				t.Errorf("expected %d flushes, got %d", tt.wantFlush, f.flushes)
+			}
+		})
+	}
+}

--- a/utils/httpbin/sse.go
+++ b/utils/httpbin/sse.go
@@ -31,6 +31,7 @@ func events(w http.ResponseWriter, r *http.Request) {
 	// Set the headers related to event streaming.
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Transfer-Encoding", "identity")
 
 	var i int
 	for {


### PR DESCRIPTION
<!-- Thank you for your hard work on this pull request! -->
This patch applies patternFlushWriter to support
- non-chunked SSE i.e. flush after '\n\n'
- chunked-encoding i.e. flush after '\r\n'
