### PR TITLE
bind: improve header flag usage with tags

### DIFF
--- a/bind/flag.go
+++ b/bind/flag.go
@@ -90,7 +90,7 @@ func RequestHeaders(fs *pflag.FlagSet, headers *[]header.Header) {
 			"The header name will be normalized to canonical form. "+
 			"The header value should not contain any newlines or carriage returns. "+
 			"The flag can be specified multiple times. "+
-			"Example: -H \"Host: example.com\" -H \"-User-Agent\" -H \"-X-*\". ")
+			"Example: -H \"-User-Agent\" -H \"-X-*\". ")
 }
 
 func ResponseHeaders(fs *pflag.FlagSet, headers *[]header.Header) {

--- a/bind/flag.go
+++ b/bind/flag.go
@@ -83,14 +83,19 @@ func RequestHeaders(fs *pflag.FlagSet, headers *[]header.Header) {
 	fs.VarP(anyflag.NewSliceValueWithRedact[header.Header](*headers, headers, header.ParseHeader, RedactHeader),
 		"header", "H", "<header>"+
 			"Add or remove HTTP request headers. "+
-			"Use the format \"name: value\" to add a header, "+
-			"\"name;\" to set the header to empty value, "+
-			"\"-name\" to remove the header, "+
-			"\"-name*\" to remove headers by prefix. "+
+			"<p/>"+
+			"Use the format:"+
+			"<ul>"+
+			"<li>name:value to add a header"+
+			"<li>name; to set the header to empty value"+
+			"<li>-name to remove the header"+
+			"<li>-name* to remove headers by prefix"+
+			"</ul>"+
 			"The header name will be normalized to canonical form. "+
 			"The header value should not contain any newlines or carriage returns. "+
 			"The flag can be specified multiple times. "+
-			"Example: -H \"-User-Agent\" -H \"-X-*\". ")
+			"The following example removes the User-Agent header and all headers starting with X-. "+
+			"<code-block>-H \"-User-Agent\" -H \"-X-*\"</code-block>")
 }
 
 func ResponseHeaders(fs *pflag.FlagSet, headers *[]header.Header) {

--- a/docs/content/cli/forwarder_run.md
+++ b/docs/content/cli/forwarder_run.md
@@ -182,11 +182,22 @@ This flag takes precedence over the PAC script.
 * Value Format: `<header>`
 
 Add or remove HTTP request headers.
-Use the format "name: value" to add a header, "name;" to set the header to empty value, "-name" to remove the header, "-name*" to remove headers by prefix.
+
+Use the format:
+
+- name:value to add a header
+- name; to set the header to empty value
+- -name to remove the header
+- -name* to remove headers by prefix
+
 The header name will be normalized to canonical form.
 The header value should not contain any newlines or carriage returns.
 The flag can be specified multiple times.
-Example: -H "Host: example.com" -H "-User-Agent" -H "-X-*".
+The following example removes the User-Agent header and all headers starting with X-.
+
+```
+-H "-User-Agent" -H "-X-*"
+```
 
 ### `-p, --pac` {#pac}
 

--- a/docs/content/config/forwarder_run.yaml
+++ b/docs/content/config/forwarder_run.yaml
@@ -101,12 +101,20 @@
 
 # header <header>
 #
-# Add or remove HTTP request headers. Use the format "name: value" to add a
-# header, "name;" to set the header to empty value, "-name" to remove the
-# header, "-name*" to remove headers by prefix. The header name will be
-# normalized to canonical form. The header value should not contain any newlines
-# or carriage returns. The flag can be specified multiple times. Example: -H
-# "Host: example.com" -H "-User-Agent" -H "-X-*".
+# Add or remove HTTP request headers. 
+# 
+# Use the format:
+# - name:value to add a header
+# - name; to set the header to empty value
+# - -name to remove the header
+# - -name* to remove headers by prefix
+# 
+# The header name will be normalized to canonical form. The header value should
+# not contain any newlines or carriage returns. The flag can be specified
+# multiple times. The following example removes the User-Agent header and all
+# headers starting with X-. 
+# 
+# -H "-User-Agent" -H "-X-*"
 #header: 
 
 # pac <path or URL>


### PR DESCRIPTION
<!-- Thank you for your hard work on this pull request! -->
```
    -H, --header <header> (env FORWARDER_HEADER)
        Add or remove HTTP request headers. 
        
        Use the format:
        - name:value to add a header
        - name; to set the header to empty value
        - -name to remove the header
        - -name* to remove headers by prefix
        
        The header name will be normalized to canonical form. The header value should not contain any newlines or
        carriage returns. The flag can be specified multiple times. The following example removes the User-Agent
        header and all headers starting with X-. 
        
        -H "-User-Agent" -H "-X-*"

```