### PR TITLE
log: change level type to string

### DIFF
--- a/log/level.go
+++ b/log/level.go
@@ -6,14 +6,14 @@
 
 package log
 
-type Level int32
+type Level string
 
 const (
-	ErrorLevel Level = iota
-	InfoLevel
-	DebugLevel
+	ErrorLevel Level = "error"
+	InfoLevel  Level = "info"
+	DebugLevel Level = "debug"
 )
 
 func (l Level) String() string {
-	return [3]string{"error", "info", "debug"}[l]
+	return string(l)
 }


### PR DESCRIPTION
That would eliminate the zero value issue with flags.

```
    --log-level <error|info|debug> (default error) (env FORWARDER_LOG_LEVEL)
        Log level.
```

Fixes #832

<!-- Thank you for your hard work on this pull request! -->
