### PR TITLE
martian: refactor copySync() for easier bidirectional copying

### DIFF
--- a/internal/martian/copy.go
+++ b/internal/martian/copy.go
@@ -43,7 +43,7 @@ var copyBufPool = sync.Pool{
 	},
 }
 
-func copySync(ctx context.Context, name string, w io.Writer, r io.Reader, donec chan<- bool) {
+func copySync(ctx context.Context, name string, w io.Writer, r io.Reader, donec chan<- struct{}) {
 	bufp := copyBufPool.Get().(*[]byte) //nolint:forcetypeassert // It's *[]byte.
 	buf := *bufp
 	defer copyBufPool.Put(bufp)
@@ -60,5 +60,5 @@ func copySync(ctx context.Context, name string, w io.Writer, r io.Reader, donec 
 	}
 
 	log.Debugf(ctx, "%s tunnel finished copying", name)
-	donec <- true
+	donec <- struct{}{}
 }

--- a/internal/martian/proxy_conn.go
+++ b/internal/martian/proxy_conn.go
@@ -295,7 +295,7 @@ func (p *proxyConn) tunnel(name string, res *http.Response, crw io.ReadWriteClos
 	}
 
 	ctx := res.Request.Context()
-	donec := make(chan bool, 2)
+	donec := make(chan struct{}, 2)
 	go copySync(ctx, "outbound "+name, crw, p.conn, donec)
 	go copySync(ctx, "inbound "+name, p.conn, crw, donec)
 

--- a/internal/martian/proxy_conn.go
+++ b/internal/martian/proxy_conn.go
@@ -295,13 +295,12 @@ func (p *proxyConn) tunnel(name string, res *http.Response, crw io.ReadWriteClos
 	}
 
 	ctx := res.Request.Context()
-	donec := make(chan struct{}, 2)
-	go copySync(ctx, "outbound "+name, crw, p.conn, donec)
-	go copySync(ctx, "inbound "+name, p.conn, crw, donec)
 
 	log.Debugf(ctx, "switched protocols, proxying %s traffic", name)
-	<-donec
-	<-donec
+	bicopy(ctx,
+		copier{"outbound " + name, crw, p.conn},
+		copier{"inbound " + name, p.conn, crw},
+	)
 	log.Debugf(ctx, "closed %s tunnel duration=%s", name, ContextDuration(ctx))
 
 	p.traceWroteResponse(res, nil)

--- a/internal/martian/proxy_handler.go
+++ b/internal/martian/proxy_handler.go
@@ -192,10 +192,9 @@ func (p proxyHandler) handleUpgradeResponse(rw http.ResponseWriter, req *http.Re
 func (p proxyHandler) tunnel(name string, rw http.ResponseWriter, req *http.Request, res *http.Response, crw io.ReadWriteCloser) error {
 	ctx := req.Context()
 
-	var (
-		rc    = http.NewResponseController(rw)
-		donec = make(chan bool, 2)
-	)
+	rc := http.NewResponseController(rw)
+	donec := make(chan struct{}, 2)
+
 	switch req.ProtoMajor {
 	case 1:
 		conn, brw, err := rc.Hijack()


### PR DESCRIPTION
This work is ported from failed #834.