### PR TITLE
log: revert log level to int

### DIFF
--- a/log/level.go
+++ b/log/level.go
@@ -9,11 +9,11 @@ package log
 type Level int32
 
 const (
-	ErrorLevel Level = iota
+	ErrorLevel Level = 1 + iota
 	InfoLevel
 	DebugLevel
 )
 
 func (l Level) String() string {
-	return [3]string{"error", "info", "debug"}[l]
+	return [3]string{"error", "info", "debug"}[l-1]
 }

--- a/log/level.go
+++ b/log/level.go
@@ -6,14 +6,14 @@
 
 package log
 
-type Level string
+type Level int32
 
 const (
-	ErrorLevel Level = "error"
-	InfoLevel  Level = "info"
-	DebugLevel Level = "debug"
+	ErrorLevel Level = iota
+	InfoLevel
+	DebugLevel
 )
 
 func (l Level) String() string {
-	return string(l)
+	return [3]string{"error", "info", "debug"}[l]
 }


### PR DESCRIPTION
The previous idea was wrong. String type messes up the order of log levels.
We will shift it. 
<!-- Thank you for your hard work on this pull request! -->
