### PR TITLE
Fix content length in CONNECT requests and responses

### DIFF
--- a/internal/martian/proxy_conn.go
+++ b/internal/martian/proxy_conn.go
@@ -240,8 +240,6 @@ func (p *proxyConn) handleConnectRequest(req *http.Request) error {
 		return p.writeErrorResponse(req, cerr)
 	}
 
-	res.ContentLength = -1
-
 	if err := p.modifyResponse(res); err != nil {
 		log.Debugf(ctx, "error modifying CONNECT response: %v", err)
 		return p.writeErrorResponse(req, err)
@@ -252,6 +250,7 @@ func (p *proxyConn) handleConnectRequest(req *http.Request) error {
 		return p.writeResponse(res)
 	}
 
+	res.ContentLength = -1
 	if err := p.tunnel("CONNECT", res, crw); err != nil {
 		log.Errorf(ctx, "CONNECT tunnel: %v", err)
 	}

--- a/internal/martian/proxy_conn.go
+++ b/internal/martian/proxy_conn.go
@@ -92,6 +92,7 @@ func (p *proxyConn) readRequest() (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
+	fixConnectReqContentLength(req)
 	if p.secure {
 		req.TLS = &p.cs
 	}

--- a/internal/martian/proxy_conn.go
+++ b/internal/martian/proxy_conn.go
@@ -251,7 +251,10 @@ func (p *proxyConn) handleConnectRequest(req *http.Request) error {
 		return p.writeResponse(res)
 	}
 
-	res.ContentLength = -1
+	if res.ContentLength != -1 {
+		log.Errorf(ctx, "CONNECT response with Content-Length: %d, ignoring content length", res.ContentLength)
+		res.ContentLength = -1
+	}
 	if err := p.tunnel("CONNECT", res, crw); err != nil {
 		log.Errorf(ctx, "CONNECT tunnel: %v", err)
 	}

--- a/internal/martian/proxy_connect.go
+++ b/internal/martian/proxy_connect.go
@@ -30,6 +30,19 @@ import (
 	"github.com/saucelabs/forwarder/internal/martian/proxyutil"
 )
 
+func fixConnectReqContentLength(req *http.Request) {
+	if req.Method != http.MethodConnect {
+		return
+	}
+
+	if req.Header.Get("Content-Length") != "" {
+		log.Infof(req.Context(), "CONNECT request with Content-Length: %s, ignoring content length",
+			req.Header.Get("Content-Length"))
+	}
+
+	req.ContentLength = -1
+}
+
 // ErrConnectFallback is returned by a ConnectFunc to indicate
 // that the CONNECT request should be handled by martian.
 var ErrConnectFallback = errors.New("martian: connect fallback")

--- a/internal/martian/proxy_handler.go
+++ b/internal/martian/proxy_handler.go
@@ -95,6 +95,8 @@ func (p proxyHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 	outreq.Close = false
 
+	fixConnectReqContentLength(outreq)
+
 	p.handleRequest(rw, outreq)
 }
 

--- a/internal/martian/proxy_handler.go
+++ b/internal/martian/proxy_handler.go
@@ -161,10 +161,7 @@ func (p proxyHandler) handleConnectRequest(rw http.ResponseWriter, req *http.Req
 		return
 	}
 
-	if req.ProtoMajor == 1 {
-		res.ContentLength = -1
-	}
-
+	res.ContentLength = -1
 	if err := p.tunnel("CONNECT", rw, req, res, crw); err != nil {
 		log.Errorf(ctx, "CONNECT tunnel: %v", err)
 		panic(http.ErrAbortHandler)

--- a/internal/martian/proxy_handler.go
+++ b/internal/martian/proxy_handler.go
@@ -163,7 +163,10 @@ func (p proxyHandler) handleConnectRequest(rw http.ResponseWriter, req *http.Req
 		return
 	}
 
-	res.ContentLength = -1
+	if res.ContentLength != -1 {
+		log.Errorf(ctx, "CONNECT response with Content-Length: %d, ignoring content length", res.ContentLength)
+		res.ContentLength = -1
+	}
 	if err := p.tunnel("CONNECT", rw, req, res, crw); err != nil {
 		log.Errorf(ctx, "CONNECT tunnel: %v", err)
 		panic(http.ErrAbortHandler)

--- a/internal/martian/proxy_test.go
+++ b/internal/martian/proxy_test.go
@@ -1077,7 +1077,7 @@ func TestIntegrationConnectFunc(t *testing.T) {
 	p := new(Proxy)
 	p.ConnectFunc = func(req *http.Request) (*http.Response, io.ReadWriteCloser, error) {
 		pr, pw := io.Pipe()
-		return proxyutil.NewResponse(200, nil, req), pipeConn{pr, pw}, nil
+		return newConnectResponse(req), pipeConn{pr, pw}, nil
 	}
 	setTimeout(p, 200*time.Millisecond)
 	defer p.Close()


### PR DESCRIPTION
Make sure that we correctly read and send Content-Length header value for CONNECT requests.  