### PR TITLE
Fix reading api-address from config file in container

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -2,6 +2,8 @@ ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 FROM ${BASE_IMAGE}
 
+ENV PLATFORM=container
+
 COPY LICENSE /licenses/
 COPY LICENSE.3RD_PARTY /licenses/
 COPY forwarder /usr/bin

--- a/Containerfile
+++ b/Containerfile
@@ -8,5 +8,4 @@ COPY forwarder /usr/bin
 ENTRYPOINT ["/usr/bin/forwarder"]
 CMD ["run"]
 
-ENV FORWARDER_API_ADDRESS="localhost:10000"
 HEALTHCHECK --interval=1s --timeout=3s --retries=10 CMD ["/usr/bin/forwarder", "ready"]

--- a/api.go
+++ b/api.go
@@ -18,6 +18,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+// APIUnixSocket is the path to the Unix socket for the API server.
+// It is currently only used in containerized environments.
+const APIUnixSocket = "/tmp/forwarder.sock"
+
 // APIHandler serves API endpoints.
 // It provides health and readiness endpoints prometheus metrics, and pprof debug endpoints.
 type APIHandler struct {

--- a/e2e/forwarder/service.go
+++ b/e2e/forwarder/service.go
@@ -43,20 +43,17 @@ func UpstreamProxyService() *Service {
 		Name:  UpstreamProxyServiceName,
 		Image: Image,
 		Environment: map[string]string{
-			"FORWARDER_API_ADDRESS": ":10000",
-			"FORWARDER_NAME":        UpstreamProxyServiceName,
+			"FORWARDER_NAME": UpstreamProxyServiceName,
 		},
 	}
 }
 
 func HttpbinService() *Service {
 	return &Service{
-		Name:    HttpbinServiceName,
-		Image:   Image,
-		Command: []string{"test", "httpbin"},
-		Environment: map[string]string{
-			"FORWARDER_API_ADDRESS": ":10000",
-		},
+		Name:        HttpbinServiceName,
+		Image:       Image,
+		Command:     []string{"test", "httpbin"},
+		Environment: map[string]string{},
 	}
 }
 

--- a/utils/httpx/httpx.go
+++ b/utils/httpx/httpx.go
@@ -1,0 +1,49 @@
+// Copyright 2022-2024 Sauce Labs Inc., all rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package httpx
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"time"
+)
+
+func ServeUnixSocket(ctx context.Context, h http.Handler, socketPath string) error {
+	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove Unix socket %s: %w", socketPath, err)
+	}
+	defer os.Remove(socketPath)
+
+	l, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return fmt.Errorf("listen Unix socket %s: %w", socketPath, err)
+	}
+	defer l.Close()
+
+	s := http.Server{
+		Handler:           h,
+		ReadHeaderTimeout: 10 * time.Second,
+		BaseContext: func(_ net.Listener) context.Context {
+			return ctx
+		},
+	}
+
+	go func() {
+		<-ctx.Done()
+		s.Close()
+	}()
+
+	err = s.Serve(l)
+	if errors.Is(err, http.ErrServerClosed) {
+		err = nil
+	}
+	return err
+}

--- a/utils/httpx/httpx_test.go
+++ b/utils/httpx/httpx_test.go
@@ -1,0 +1,76 @@
+// Copyright 2022-2024 Sauce Labs Inc., all rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package httpx
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"os"
+	"testing"
+)
+
+func TestServeUnixSocket(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	socketPath, err := os.CreateTemp("", "socket")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	defer os.Remove(socketPath.Name())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		if err := ServeUnixSocket(ctx, h, socketPath.Name()); err != nil {
+			t.Errorf("serve on Unix socket: %v", err)
+		}
+	}()
+
+	c := http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", socketPath.Name())
+			},
+		},
+	}
+
+	// Wait for the server to start.
+	for {
+		conn, err := net.Dial("unix", socketPath.Name())
+		if err == nil {
+			conn.Close()
+			break
+		}
+	}
+
+	resp, err := c.Get("http://unix" + socketPath.Name())
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	cancel()
+
+	// Wait for the server to stop.
+
+	for {
+		if _, err := os.Stat(socketPath.Name()); os.IsNotExist(err) {
+			break
+		}
+	}
+
+	_, err = c.Get("http://unix" + socketPath.Name())
+	if err == nil {
+		t.Error("get: expected an error")
+	}
+}


### PR DESCRIPTION
This patchset implements checking readiness over a Unix socket.
Unnecessary API servers in e2e tests are removed.
The ready command implementation is extended and improved for better reuse.   

Fixes #873