### PR TITLE
net: change dial t/o to 25s

### DIFF
--- a/net.go
+++ b/net.go
@@ -38,7 +38,7 @@ type DialConfig struct {
 
 func DefaultDialConfig() *DialConfig {
 	return &DialConfig{
-		DialTimeout: 30 * time.Second,
+		DialTimeout: 25 * time.Second,
 		KeepAlive:   true,
 	}
 }


### PR DESCRIPTION
Browsers use 30s dial t/o. Using 25s t/o in Forwarder allows to distinguish between browser not able to connect to Forwarder and server dial failure.

<!-- Thank you for your hard work on this pull request! -->
