### PR TITLE
net: fix addr2Host for backwards compatibility with isLocalhost()

### DIFF
--- a/net_metrics.go
+++ b/net_metrics.go
@@ -8,6 +8,7 @@ package forwarder
 
 import (
 	"net"
+	"slices"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -63,7 +64,17 @@ func addr2Host(addr string) string {
 		return "unknown"
 	}
 
-	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+	commonLocalhostNames := []string{
+		"localhost",
+		"127.0.0.1",
+		"::1",
+		"::",
+	}
+	if slices.Contains(commonLocalhostNames, host) {
+		return "localhost"
+	}
+
+	if ip := net.ParseIP(host); ip != nil && (ip.IsLoopback() || ip.IsUnspecified()) {
 		return "localhost"
 	}
 

--- a/net_metrics_test.go
+++ b/net_metrics_test.go
@@ -1,0 +1,26 @@
+// Copyright 2022-2024 Sauce Labs Inc., all rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package forwarder
+
+import (
+	"testing"
+)
+
+func TestAddr2HostLocalhost(t *testing.T) {
+	addrs := []string{
+		"localhost:80",
+		"127.0.0.100:80",
+		"[::1]:80",
+		"[::]:52367",
+	}
+
+	for _, addr := range addrs {
+		if host := addr2Host(addr); host != "localhost" {
+			t.Fatalf("addr2Host(%q): got %q, want localhost", addr, host)
+		}
+	}
+}


### PR DESCRIPTION
Since 5ca0e4d7afbf790365edd5a40e1bd3b7f23237bc we do not recognize :: as localhost.

Treat unspecified IP address as localhost - for backwards compatibility with isLocalhost(). Optimize common localhost names.
