### PR TITLE
e2e: enable goleak check

### DIFF
--- a/command/run/run.go
+++ b/command/run/run.go
@@ -276,6 +276,7 @@ func (c *command) runE(cmd *cobra.Command, _ []string) (cmdErr error) {
 		defer func() {
 			if err := goleak.Find(); err != nil {
 				fmt.Fprintf(cmd.ErrOrStderr(), "goleak: %s", err)
+				os.Exit(1)
 			}
 		}()
 	}

--- a/e2e/sc-2450/server.py
+++ b/e2e/sc-2450/server.py
@@ -2,6 +2,8 @@
 
 import os
 import time
+import signal
+import sys
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 # Headers taken from `failed.pcapng`
@@ -108,9 +110,21 @@ class RequestHandler(BaseHTTPRequestHandler):
         self.wfile.write(self.data[15:])
         print("Done")
 
+def signal_handler(signum, frame):
+    print("Received signal to terminate. Exiting gracefully...")
+    sys.exit(0)
 
 if __name__ == "__main__":
     port = 8307
     print("Listening on 0.0.0.0:%s" % port)
     server = HTTPServer(("", port), RequestHandler)
-    server.serve_forever()
+
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        print("Shutting down server.")
+        server.server_close()

--- a/e2e/setup/runner.go
+++ b/e2e/setup/runner.go
@@ -189,7 +189,20 @@ func (r *Runner) runSetup(s *Setup) (runErr error) {
 	}
 
 	// Run the test service.
-	return cmd.Up("--force-recreate", "--exit-code-from", TestServiceName, TestServiceName)
+	if err := cmd.Up("--force-recreate", "--exit-code-from", TestServiceName, TestServiceName); err != nil {
+		return err
+	}
+
+	if !r.Debug {
+		if err := cmd.Stop(); err != nil {
+			return fmt.Errorf("compose stop: %w", err)
+		}
+		if err := cmd.ExitedSuccessfully(r.services(s)); err != nil {
+			return fmt.Errorf("services failed to exit: %w", err)
+		}
+	}
+
+	return nil
 }
 
 func (r *Runner) services(s *Setup) []string {

--- a/e2e/setups.go
+++ b/e2e/setups.go
@@ -65,7 +65,8 @@ func SetupDefaults(l *setupList) {
 							WithProtocol(httpbinScheme)).
 					AddService(
 						forwarder.ProxyService().
-							WithProtocol(proxyScheme)).
+							WithProtocol(proxyScheme).
+							WithGoleak()).
 					MustBuild(),
 				Run: run,
 			})
@@ -79,10 +80,12 @@ func SetupDefaults(l *setupList) {
 						AddService(
 							forwarder.ProxyService().
 								WithProtocol(proxyScheme).
-								WithUpstream(forwarder.UpstreamProxyServiceName, upstreamProxyScheme)).
+								WithUpstream(forwarder.UpstreamProxyServiceName, upstreamProxyScheme).
+								WithGoleak()).
 						AddService(
 							forwarder.UpstreamProxyService().
-								WithProtocol(upstreamProxyScheme)).
+								WithProtocol(upstreamProxyScheme).
+								WithGoleak()).
 						MustBuild(),
 					Run: run,
 				})
@@ -357,7 +360,8 @@ func SetupFlagMITMCACert(l *setupList) {
 				forwarder.ProxyService().
 					WithResponseHeader("test-resp-add:test-resp-value").
 					WithMITMCACert().
-					Insecure()).
+					Insecure().
+					WithGoleak()).
 			MustBuild(),
 		Run: run,
 	})
@@ -373,10 +377,12 @@ func SetupFlagMITMCACert(l *setupList) {
 						WithResponseHeader("test-resp-add:test-resp-value").
 						WithMITMCACert().
 						Insecure().
-						WithUpstream(forwarder.UpstreamProxyServiceName, upstreamProxyScheme)).
+						WithUpstream(forwarder.UpstreamProxyServiceName, upstreamProxyScheme).
+						WithGoleak()).
 				AddService(
 					forwarder.UpstreamProxyService().
-						WithProtocol(upstreamProxyScheme)).
+						WithProtocol(upstreamProxyScheme).
+						WithGoleak()).
 				MustBuild(),
 			Run: run,
 		})

--- a/utils/compose/cmd.go
+++ b/utils/compose/cmd.go
@@ -102,6 +102,10 @@ func (c *Command) Up(args ...string) error {
 	return c.run(c.cmd("up", args))
 }
 
+func (c *Command) Stop(args ...string) error {
+	return c.quietRun(c.cmd("stop", args))
+}
+
 func (c *Command) Down(args ...string) error {
 	return c.quietRun(c.cmd("down", args))
 }

--- a/utils/compose/cmd.go
+++ b/utils/compose/cmd.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -104,6 +105,41 @@ func (c *Command) Up(args ...string) error {
 
 func (c *Command) Stop(args ...string) error {
 	return c.quietRun(c.cmd("stop", args))
+}
+
+func (c *Command) ExitedSuccessfully(services []string) error {
+	for _, s := range services {
+		exitCode, err := c.serviceExitCode(s)
+		if err != nil {
+			return err
+		}
+		if exitCode != 0 {
+			return fmt.Errorf("service %s exited with code %d", s, exitCode)
+		}
+	}
+	return nil
+}
+
+func (c *Command) serviceExitCode(s string) (int, error) {
+	args := []string{
+		"inspect",
+		"--format",
+		"{{.State.ExitCode}}",
+		c.serviceContainerName(s),
+	}
+
+	cmd := exec.Command(c.rt, args...) //nolint:gosec // this is a command runner
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		stdout.WriteTo(c.stdout)
+		stderr.WriteTo(c.stderr)
+		return 0, err
+	}
+
+	return strconv.Atoi(strings.TrimSpace(stdout.String()))
 }
 
 func (c *Command) Down(args ...string) error {


### PR DESCRIPTION
<!-- Thank you for your hard work on this pull request! -->
This patch extends compose with functionality to check exit codes of services. It improves tests quality as it enforces that all services exit with code 0. That allows to correctly assert goleak errors. 


Fixes #516