### PR TITLE
log/stdlog: allow to pass options when creating a sublogger

### DIFF
--- a/log/stdlog/opts.go
+++ b/log/stdlog/opts.go
@@ -6,10 +6,19 @@
 
 package stdlog
 
+import flog "github.com/saucelabs/forwarder/log"
+
 // WithLabels allows to set labels that are added to each log message.
 func WithLabels(labels ...string) Option {
 	return func(l *Logger) {
 		l.labels = labels
+	}
+}
+
+// WithLevel allows to set the logging level.
+func WithLevel(level flog.Level) Option {
+	return func(l *Logger) {
+		l.level = level
 	}
 }
 

--- a/log/stdlog/stdlog.go
+++ b/log/stdlog/stdlog.go
@@ -68,12 +68,16 @@ type Logger struct {
 	onError  func(name string)
 }
 
-func (sl Logger) Named(name string) *Logger { //nolint:gocritic // we pass by value to get a copy
+func (sl Logger) Named(name string, opts ...Option) *Logger { //nolint:gocritic // we pass by value to get a copy
 	sl.name = name
 
 	sl.errorPfx = logLinePrefix(sl.labels, name, "ERROR")
 	sl.infoPfx = logLinePrefix(sl.labels, name, "INFO")
 	sl.debugPfx = logLinePrefix(sl.labels, name, "DEBUG")
+
+	for _, opt := range opts {
+		opt(&sl)
+	}
 
 	return &sl
 }

--- a/log/stdlog/stdlog_test.go
+++ b/log/stdlog/stdlog_test.go
@@ -1,0 +1,20 @@
+// Copyright 2022-2024 Sauce Labs Inc., all rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package stdlog
+
+import (
+	"testing"
+
+	flog "github.com/saucelabs/forwarder/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoggerNamedAllowsToPassCustomLevel(t *testing.T) {
+	l := New(flog.DefaultConfig())
+	f := l.Named("foo", WithLevel(0))
+	assert.Equal(t, flog.Level(0), f.level)
+}


### PR DESCRIPTION
I want to be able to modify the sublogger level. It should be possible to pass custom options when creating a sublogger.