### PR TITLE
Add support for proxy protocol in listener

### DIFF
--- a/bind/flag.go
+++ b/bind/flag.go
@@ -201,6 +201,17 @@ func MITMDomains(fs *pflag.FlagSet, cfg *[]ruleset.RegexpListItem) {
 			"Prefix domains with '-' to exclude requests to certain domains from being MITMed.")
 }
 
+func ProxyProtocol(fs *pflag.FlagSet, enabled *bool, cfg *forwarder.ProxyProtocolConfig) {
+	fs.BoolVar(enabled, "proxy-protocol", *enabled,
+		"The PROXY protocol is used to correctly pass the client's IP address to the server. "+
+			"When enabled the proxy will expect the client to send the PROXY protocol header before the actual request. "+
+			"It is still possible to connect to the proxy without the PROXY protocol header when this flag is enabled. ")
+
+	fs.DurationVar(&cfg.ReadHeaderTimeout, "proxy-protocol-read-header-timeout", cfg.ReadHeaderTimeout,
+		"The amount of time to wait for PROXY protocol header. "+
+			"Zero means no limit. ")
+}
+
 func Credentials(fs *pflag.FlagSet, credentials *[]*forwarder.HostPortUser) {
 	fs.VarP(anyflag.NewSliceValueWithRedact[*forwarder.HostPortUser](*credentials, credentials, forwarder.ParseHostPortUser, forwarder.RedactHostPortUser),
 		"credentials", "s", "<username[:password]@host:port,...>"+

--- a/bind/flag.go
+++ b/bind/flag.go
@@ -202,8 +202,8 @@ func MITMDomains(fs *pflag.FlagSet, cfg *[]ruleset.RegexpListItem) {
 }
 
 func ProxyProtocol(fs *pflag.FlagSet, enabled *bool, cfg *forwarder.ProxyProtocolConfig) {
-	fs.BoolVar(enabled, "proxy-protocol", *enabled,
-		"The PROXY protocol is used to correctly pass the client's IP address to the server. "+
+	fs.BoolVar(enabled, "proxy-protocol-enabled", *enabled,
+		"The PROXY protocol is used to correctly read the client's IP address. "+
 			"When enabled the proxy will expect the client to send the PROXY protocol header before the actual request. "+
 			"It is still possible to connect to the proxy without the PROXY protocol header when this flag is enabled. ")
 

--- a/command/forwarder/root.go
+++ b/command/forwarder/root.go
@@ -40,8 +40,11 @@ func CommandGroups() templates.CommandGroups {
 func FlagGroups() templates.FlagGroups {
 	return templates.FlagGroups{
 		{
-			Name:   "Server options",
-			Prefix: []string{""},
+			Name: "Server options",
+			Prefix: []string{
+				"proxy-protocol",
+				"",
+			},
 		},
 		{
 			Name: "Proxy options",

--- a/command/run/run.go
+++ b/command/run/run.go
@@ -53,6 +53,8 @@ type command struct {
 	mitm                bool
 	mitmConfig          *forwarder.MITMConfig
 	mitmDomains         []ruleset.RegexpListItem
+	proxyProtocol       bool
+	proxyProtocolConfig *forwarder.ProxyProtocolConfig
 	apiServerConfig     *forwarder.HTTPServerConfig
 	logConfig           *log.Config
 
@@ -207,6 +209,10 @@ func (c *command) runE(cmd *cobra.Command, _ []string) (cmdErr error) {
 			}
 			c.httpProxyConfig.MITMDomains = dd
 		}
+	}
+
+	if c.proxyProtocol {
+		c.httpProxyConfig.ProxyProtocolConfig = c.proxyProtocolConfig
 	}
 
 	g := runctx.NewGroup()
@@ -424,6 +430,7 @@ func Command() *cobra.Command {
 	bind.HTTPProxyConfig(fs, c.httpProxyConfig, c.logConfig)
 	bind.MITMConfig(fs, &c.mitm, c.mitmConfig)
 	bind.MITMDomains(fs, &c.mitmDomains)
+	bind.ProxyProtocol(fs, &c.proxyProtocol, c.proxyProtocolConfig)
 	bind.HTTPServerConfig(fs, c.apiServerConfig, "api", forwarder.HTTPScheme)
 	bind.HTTPLogConfig(fs, []bind.NamedParam[httplog.Mode]{
 		{Name: "api", Param: &c.apiServerConfig.LogHTTPMode},
@@ -476,6 +483,7 @@ func makeCommand() command {
 		httpTransportConfig: forwarder.DefaultHTTPTransportConfig(),
 		httpProxyConfig:     forwarder.DefaultHTTPProxyConfig(),
 		mitmConfig:          forwarder.DefaultMITMConfig(),
+		proxyProtocolConfig: forwarder.DefaultProxyProtocolConfig(),
 		apiServerConfig:     forwarder.DefaultHTTPServerConfig(),
 		logConfig:           log.DefaultConfig(),
 	}

--- a/e2e/forwarder/service.go
+++ b/e2e/forwarder/service.go
@@ -34,6 +34,7 @@ func ProxyService() *Service {
 		Image: Image,
 		Environment: map[string]string{
 			"FORWARDER_API_ADDRESS": ":10000",
+			"FORWARDER_PROXY_PROTOCOL_ENABLED": "true",
 		},
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/kevinburke/hostsfile v0.0.0-20220522040509-e5e984885321
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/mmatczuk/anyflag v0.0.0-20240709090339-eb9e24cd1b44
+	github.com/pires/go-proxyproto v0.7.0
 	github.com/prometheus/client_golang v1.20.3
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.59.1
@@ -59,3 +60,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240604185151-ef581f913117 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
+
+replace github.com/pires/go-proxyproto => github.com/mmatczuk/go-proxyproto v0.0.0-20240917110340-b4098fdcd2fa

--- a/go.sum
+++ b/go.sum
@@ -67,10 +67,14 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mmatczuk/anyflag v0.0.0-20240709090339-eb9e24cd1b44 h1:Ds9W8Yj5ti4kQXITpCozfNNibS1fUA8+aK2T5th0vXE=
 github.com/mmatczuk/anyflag v0.0.0-20240709090339-eb9e24cd1b44/go.mod h1:PT22bA6vWBzPL8tAeK2XCMvWOQ4e19yY3MJIgnTZRaE=
+github.com/mmatczuk/go-proxyproto v0.0.0-20240917110340-b4098fdcd2fa h1:b9g3zb1SgOg207QvN+B9klEphEzEurDgAvmD0IkoYBg=
+github.com/mmatczuk/go-proxyproto v0.0.0-20240917110340-b4098fdcd2fa/go.mod h1:iknsfgnH8EkjrMeMyvfKByp9TiBZCKZM0jx2xmKqnVY=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
+github.com/pires/go-proxyproto v0.7.0 h1:IukmRewDQFWC7kfnb66CSomk2q/seBuilHBYFwyq0Hs=
+github.com/pires/go-proxyproto v0.7.0/go.mod h1:Vz/1JPY/OACxWGQNIRY2BeyDmpoaWmEP40O9LbuiFR4=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -80,22 +80,23 @@ var ErrConnectFallback = martian.ErrConnectFallback
 
 type HTTPProxyConfig struct {
 	HTTPServerConfig
-	Name              string
-	MITM              *MITMConfig
-	MITMDomains       Matcher
-	ProxyLocalhost    ProxyLocalhostMode
-	UpstreamProxy     *url.URL
-	UpstreamProxyFunc ProxyFunc
-	DenyDomains       Matcher
-	DirectDomains     Matcher
-	RequestIDHeader   string
-	RequestModifiers  []RequestModifier
-	ResponseModifiers []ResponseModifier
-	ConnectFunc       ConnectFunc
-	ConnectTimeout    time.Duration
-	ReadLimit         SizeSuffix
-	WriteLimit        SizeSuffix
-	PromHTTPOpts      []middleware.PrometheusOpt
+	Name                string
+	MITM                *MITMConfig
+	MITMDomains         Matcher
+	ProxyLocalhost      ProxyLocalhostMode
+	UpstreamProxy       *url.URL
+	UpstreamProxyFunc   ProxyFunc
+	DenyDomains         Matcher
+	DirectDomains       Matcher
+	RequestIDHeader     string
+	RequestModifiers    []RequestModifier
+	ResponseModifiers   []ResponseModifier
+	ConnectFunc         ConnectFunc
+	ConnectTimeout      time.Duration
+	ProxyProtocolConfig *ProxyProtocolConfig
+	ReadLimit           SizeSuffix
+	WriteLimit          SizeSuffix
+	PromHTTPOpts        []middleware.PrometheusOpt
 
 	// TestingHTTPHandler uses Martian's [http.Handler] implementation
 	// over [http.Server] instead of the default TCP server.
@@ -554,6 +555,7 @@ func (hp *HTTPProxy) listen() (net.Listener, error) {
 	l := Listener{
 		Address:             hp.config.Addr,
 		Log:                 hp.log,
+		ProxyProtocolConfig: hp.config.ProxyProtocolConfig,
 		TLSConfig:           hp.tlsConfig,
 		TLSHandshakeTimeout: hp.config.TLSServerConfig.HandshakeTimeout,
 		ReadLimit:           int64(hp.config.ReadLimit),

--- a/net.go
+++ b/net.go
@@ -17,6 +17,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/pires/go-proxyproto"
 	"github.com/saucelabs/forwarder/log"
 	"github.com/saucelabs/forwarder/ratelimit"
 )
@@ -140,11 +141,22 @@ func Listen(network, address string) (net.Listener, error) {
 	return defaultListenConfig().Listen(context.Background(), network, address)
 }
 
+type ProxyProtocolConfig struct {
+	ReadHeaderTimeout time.Duration
+}
+
+func DefaultProxyProtocolConfig() *ProxyProtocolConfig {
+	return &ProxyProtocolConfig{
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+}
+
 type Listener struct {
 	Address             string
 	Log                 log.Logger
 	TLSConfig           *tls.Config
 	TLSHandshakeTimeout time.Duration
+	ProxyProtocolConfig *ProxyProtocolConfig
 	ReadLimit           int64
 	WriteLimit          int64
 	PromConfig
@@ -161,6 +173,13 @@ func (l *Listener) Listen() error {
 	ll, err := Listen("tcp", l.Address)
 	if err != nil {
 		return err
+	}
+
+	if l.ProxyProtocolConfig != nil {
+		ll = &proxyproto.Listener{
+			Listener:          ll,
+			ReadHeaderTimeout: l.ProxyProtocolConfig.ReadHeaderTimeout,
+		}
 	}
 
 	if rl, wl := l.ReadLimit, l.WriteLimit; rl > 0 || wl > 0 {


### PR DESCRIPTION
Added server options

```
    --proxy-protocol-enabled <value> (default false) (env FORWARDER_PROXY_PROTOCOL_ENABLED)
        The PROXY protocol is used to correctly read the client's IP address. When enabled the proxy will expect the
        client to send the PROXY protocol header before the actual request. It is still possible to connect to the
        proxy without the PROXY protocol header when this flag is enabled.

    --proxy-protocol-read-header-timeout <duration> (default 10s) (env FORWARDER_PROXY_PROTOCOL_READ_HEADER_TIMEOUT)
        The amount of time to wait for PROXY protocol header. Zero means no limit.
```

Fixes #912