### PR TITLE
Add support for proxy protocol in martian

### DIFF
--- a/bind/flag.go
+++ b/bind/flag.go
@@ -132,6 +132,9 @@ func HTTPProxyConfig(fs *pflag.FlagSet, cfg *forwarder.HTTPProxyConfig, lcfg *lo
 		"Name of this proxy instance. This value is used in the Via header in requests. "+
 		"The name value in Via header is extended with a random string to avoid collisions when several proxies are chained. ")
 
+	fs.DurationVar(&cfg.ProxyProtocolReadHeaderTimeout, "proxy-protocol-read-header-timeout", cfg.ProxyProtocolReadHeaderTimeout,
+		"The amount of time to wait for PROXY protocol header if present. ")
+
 	fs.StringVar(&cfg.RequestIDHeader, "log-http-request-id-header", cfg.RequestIDHeader,
 		"<name>"+
 			"If the header is present in the request, "+

--- a/command/forwarder/root.go
+++ b/command/forwarder/root.go
@@ -40,8 +40,11 @@ func CommandGroups() templates.CommandGroups {
 func FlagGroups() templates.FlagGroups {
 	return templates.FlagGroups{
 		{
-			Name:   "Server options",
-			Prefix: []string{""},
+			Name: "Server options",
+			Prefix: []string{
+				"proxy-protocol",
+				"",
+			},
 		},
 		{
 			Name: "Proxy options",

--- a/e2e/forwarder/service.go
+++ b/e2e/forwarder/service.go
@@ -33,7 +33,8 @@ func ProxyService() *Service {
 		Name:  ProxyServiceName,
 		Image: Image,
 		Environment: map[string]string{
-			"FORWARDER_API_ADDRESS": ":10000",
+			"FORWARDER_API_ADDRESS":            ":10000",
+			"FORWARDER_PROXY_PROTOCOL_ENABLED": "true",
 		},
 	}
 }

--- a/e2e/tests/proxy_test.go
+++ b/e2e/tests/proxy_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/pires/go-proxyproto"
 	"github.com/saucelabs/forwarder/e2e/forwarder"
 	"github.com/saucelabs/forwarder/utils/httpexpect"
 )
@@ -333,5 +334,49 @@ func TestProxyReuseConnection(t *testing.T) {
 		case <-time.After(10 * time.Second):
 			t.Fatal("timed-out waiting for body read")
 		}
+	}
+}
+
+func TestProxyProxyProtocol(t *testing.T) {
+	if os.Getenv("HTTPBIN_PROTOCOL") != "http" {
+		t.Skip("HTTPBIN_PROTOCOL not set to http")
+	}
+
+	h := proxyproto.Header{
+		Version:           1,
+		Command:           proxyproto.PROXY,
+		TransportProtocol: proxyproto.TCPv4,
+		SourceAddr: &net.TCPAddr{
+			IP:   net.ParseIP("1.1.1.1"),
+			Port: 1000,
+		},
+		DestinationAddr: &net.TCPAddr{
+			IP:   net.ParseIP("2.2.2.2"),
+			Port: 2000,
+		},
+	}
+
+	xff := newClient(t, httpbin, func(tr *http.Transport) {
+		tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			conn, err := net.Dial(network, addr)
+			if err != nil {
+				return nil, err
+			}
+			if _, err := h.WriteTo(conn); err != nil {
+				return nil, err
+			}
+			return conn, nil
+		}
+	}).GET("/headers/").Header["X-Forwarded-For"]
+
+	if len(xff) == 0 {
+		t.Fatal("Expected X-Forwarded-For header, got none")
+	}
+
+	want := h.SourceAddr.(*net.TCPAddr).IP.String() //nolint:forcetypeassert // we know it's a TCPAddr
+
+	xff0, _, _ := strings.Cut(xff[0], ",")
+	if xff0 != want {
+		t.Fatalf("Expected %s, got %s", want, xff[0])
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/kevinburke/hostsfile v0.0.0-20220522040509-e5e984885321
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/mmatczuk/anyflag v0.0.0-20240709090339-eb9e24cd1b44
+	github.com/pires/go-proxyproto v0.7.0
 	github.com/prometheus/client_golang v1.20.4
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.59.1

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
+github.com/pires/go-proxyproto v0.7.0 h1:IukmRewDQFWC7kfnb66CSomk2q/seBuilHBYFwyq0Hs=
+github.com/pires/go-proxyproto v0.7.0/go.mod h1:Vz/1JPY/OACxWGQNIRY2BeyDmpoaWmEP40O9LbuiFR4=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -80,22 +80,23 @@ var ErrConnectFallback = martian.ErrConnectFallback
 
 type HTTPProxyConfig struct {
 	HTTPServerConfig
-	Name              string
-	MITM              *MITMConfig
-	MITMDomains       Matcher
-	ProxyLocalhost    ProxyLocalhostMode
-	UpstreamProxy     *url.URL
-	UpstreamProxyFunc ProxyFunc
-	DenyDomains       Matcher
-	DirectDomains     Matcher
-	RequestIDHeader   string
-	RequestModifiers  []RequestModifier
-	ResponseModifiers []ResponseModifier
-	ConnectFunc       ConnectFunc
-	ConnectTimeout    time.Duration
-	ReadLimit         SizeSuffix
-	WriteLimit        SizeSuffix
-	PromHTTPOpts      []middleware.PrometheusOpt
+	Name                           string
+	MITM                           *MITMConfig
+	MITMDomains                    Matcher
+	ProxyProtocolReadHeaderTimeout time.Duration
+	ProxyLocalhost                 ProxyLocalhostMode
+	UpstreamProxy                  *url.URL
+	UpstreamProxyFunc              ProxyFunc
+	DenyDomains                    Matcher
+	DirectDomains                  Matcher
+	RequestIDHeader                string
+	RequestModifiers               []RequestModifier
+	ResponseModifiers              []ResponseModifier
+	ConnectFunc                    ConnectFunc
+	ConnectTimeout                 time.Duration
+	ReadLimit                      SizeSuffix
+	WriteLimit                     SizeSuffix
+	PromHTTPOpts                   []middleware.PrometheusOpt
 
 	// TestingHTTPHandler uses Martian's [http.Handler] implementation
 	// over [http.Server] instead of the default TCP server.
@@ -113,10 +114,11 @@ func DefaultHTTPProxyConfig() *HTTPProxyConfig {
 				HandshakeTimeout: 10 * time.Second,
 			},
 		},
-		Name:            "forwarder",
-		ProxyLocalhost:  DenyProxyLocalhost,
-		RequestIDHeader: "X-Request-Id",
-		ConnectTimeout:  60 * time.Second, // http.Transport sets a constant 1m timeout for CONNECT requests.
+		Name:                           "forwarder",
+		ProxyProtocolReadHeaderTimeout: 5 * time.Second,
+		ProxyLocalhost:                 DenyProxyLocalhost,
+		RequestIDHeader:                "X-Request-Id",
+		ConnectTimeout:                 60 * time.Second, // http.Transport sets a constant 1m timeout for CONNECT requests.
 	}
 }
 
@@ -249,6 +251,7 @@ func (hp *HTTPProxy) configureProxy() error {
 	hp.proxy.WithoutWarning = true
 	hp.proxy.ErrorResponse = hp.errorResponse
 	hp.proxy.IdleTimeout = hp.config.IdleTimeout
+	hp.proxy.ReadProxyProtocolHeaderTimeout = hp.config.ProxyProtocolReadHeaderTimeout
 	hp.proxy.ReadTimeout = hp.config.ReadTimeout
 	hp.proxy.ReadHeaderTimeout = hp.config.ReadHeaderTimeout
 	hp.proxy.WriteTimeout = hp.config.WriteTimeout

--- a/internal/martian/proxy.go
+++ b/internal/martian/proxy.go
@@ -93,6 +93,12 @@ type Proxy struct {
 	// ReadHeaderTimeout. It is valid to use them both.
 	ReadTimeout time.Duration
 
+	// ReadProxyProtocolHeaderTimeout is the maximum duration for
+	// reading the proxy protocol header on a connection. If zero,
+	// the value of ReadTimeout is used. If both are zero,
+	// there is no timeout.
+	ReadProxyProtocolHeaderTimeout time.Duration
+
 	// ReadHeaderTimeout is the amount of time allowed to read
 	// request headers. The connection's read deadline is reset
 	// after reading the headers and the Handler can decide what
@@ -281,6 +287,13 @@ func (p *Proxy) handleLoop(conn net.Conn) {
 func (p *Proxy) idleTimeout() time.Duration {
 	if p.IdleTimeout > 0 {
 		return p.IdleTimeout
+	}
+	return p.ReadTimeout
+}
+
+func (p *Proxy) readProxyProtocolHeaderTimeout() time.Duration {
+	if p.ReadProxyProtocolHeaderTimeout > 0 {
+		return p.ReadProxyProtocolHeaderTimeout
 	}
 	return p.ReadTimeout
 }

--- a/internal/martian/proxy.go
+++ b/internal/martian/proxy.go
@@ -263,6 +263,13 @@ func (p *Proxy) handleLoop(conn net.Conn) {
 
 	pc := newProxyConn(p, conn)
 
+	if err := pc.tryReadProxyHeader(); err != nil {
+		if errors.Is(err, errClose) || isCloseable(err) {
+			log.Debugf(context.TODO(), "closing connection from %s duration=%s", conn.RemoteAddr(), time.Since(start))
+			return
+		}
+	}
+
 	const maxConsecutiveErrors = 5
 	errorsN := 0
 	for {


### PR DESCRIPTION
This is version of #915 that implements reading proxy headers in martian.
This has many benefits unfortunately this approach is wrong so I'm sending it for information purposes only.

> The PROXY protocol will take precedence over TLS when establishing a network connection. Here’s why:
> The PROXY protocol is designed to pass client connection information (like the real IP address and port) from a load balancer or proxy to a backend server. It works at the transport layer and is placed before any higher-layer protocol like TLS.

This means we need implementation in forwarder.Listener I'd send another patch.