### PR TITLE
bind: fix passing default value for --dns-server flag

### DIFF
--- a/bind/flag.go
+++ b/bind/flag.go
@@ -35,7 +35,7 @@ func ConfigFile(fs *pflag.FlagSet, configFile *string) {
 }
 
 func DNSConfig(fs *pflag.FlagSet, cfg *forwarder.DNSConfig) {
-	fs.VarP(anyflag.NewSliceValue[netip.AddrPort](nil, &cfg.Servers, forwarder.ParseDNSAddress),
+	fs.VarP(anyflag.NewSliceValue[netip.AddrPort](cfg.Servers, &cfg.Servers, forwarder.ParseDNSAddress),
 		"dns-server", "n", "<ip>[:<port>]"+
 			"DNS server(s) to use instead of system default. "+
 			"There are two execution policies, when more then one server is specified. "+


### PR DESCRIPTION
That allows to pass default dns servers to the bind.

<!-- Thank you for your hard work on this pull request! -->
