### PR TITLE
martian(test): implement testHelper pattern

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,14 +11,16 @@ linters:
     - contextcheck
     - cyclop
     - depguard
+    - execinquery
     - exhaustive
     - exhaustruct
+    - exportloopref
     - funlen
     - gochecknoglobals
     - gochecknoinits
     - goconst
     - godox
-    - goerr113
+    - err113
     - gomnd
     - gomoddirectives
     - inamedparam


### PR DESCRIPTION
When I was trying to change martian behaviour that needed some tests to be adjusted, I realised they are in a poor condition. This patch introduces a testHelper to add some structure and reuse similar code blocks. That way it reduces around 150 LoC. It also leaves the tests in better shape for further refactors. 