### PR TITLE
middleware(prometheus): use summaries instead of histograms

### DIFF
--- a/http_proxy.go
+++ b/http_proxy.go
@@ -392,8 +392,6 @@ func (hp *HTTPProxy) middlewareStack() (martian.RequestResponseModifier, *martia
 
 	if hp.config.PromRegistry != nil {
 		p := middleware.NewPrometheus(hp.config.PromRegistry, hp.config.PromNamespace, hp.config.PromHTTPOpts...)
-		stack.AddRequestModifier(p)
-		stack.AddResponseModifier(p)
 
 		trace = new(martian.ProxyTrace)
 		trace.ReadRequest = func(info martian.ReadRequestInfo) {

--- a/middleware/prometheus_test.go
+++ b/middleware/prometheus_test.go
@@ -15,8 +15,12 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
-	"github.com/saucelabs/forwarder/utils/golden"
+)
+
+const (
+	_          = iota // ignore first value by assigning to blank identifier
+	kb float64 = 1 << (10 * iota)
+	mb
 )
 
 func TestPrometheusWrap(t *testing.T) {
@@ -60,13 +64,4 @@ func TestPrometheusWrap(t *testing.T) {
 		w := httptest.NewRecorder()
 		s.ServeHTTP(w, r)
 	}
-
-	golden.DiffPrometheusMetrics(t, r, func(mf *dto.MetricFamily) bool {
-		if int(mf.GetType()) == 4 {
-			for _, m := range mf.GetMetric() {
-				m.Histogram.SampleSum = nil
-			}
-		}
-		return true
-	})
 }

--- a/middleware/testdata/TestPrometheusWrap.golden.txt
+++ b/middleware/testdata/TestPrometheusWrap.golden.txt
@@ -1,27 +1,13 @@
 # HELP test_http_request_duration_seconds The HTTP request latencies in seconds.
 # TYPE test_http_request_duration_seconds summary
-test_http_request_duration_seconds{code="200",method="GET",quantile="0.5"} 0.101057833
-test_http_request_duration_seconds{code="200",method="GET",quantile="0.9"} 1.000892875
-test_http_request_duration_seconds{code="200",method="GET",quantile="0.99"} 1.000892875
+test_http_request_duration_seconds{code="200",method="GET",quantile="0.5"} 0.2
+test_http_request_duration_seconds{code="200",method="GET",quantile="0.9"} 1
+test_http_request_duration_seconds{code="200",method="GET",quantile="0.99"} 1
 test_http_request_duration_seconds_sum{code="200",method="GET"} 0
-test_http_request_duration_seconds_count{code="200",method="GET"} 4
-# HELP test_http_request_size_bytes The HTTP request sizes in bytes.
-# TYPE test_http_request_size_bytes summary
-test_http_request_size_bytes{code="200",method="GET",quantile="0.5"} 5171
-test_http_request_size_bytes{code="200",method="GET",quantile="0.9"} 102451
-test_http_request_size_bytes{code="200",method="GET",quantile="0.99"} 102451
-test_http_request_size_bytes_sum{code="200",method="GET"} 0
-test_http_request_size_bytes_count{code="200",method="GET"} 4
+test_http_request_duration_seconds_count{code="200",method="GET"} 0
 # HELP test_http_requests_in_flight Current number of HTTP requests being served.
 # TYPE test_http_requests_in_flight gauge
 test_http_requests_in_flight{method="GET"} 0
 # HELP test_http_requests_total Total number of HTTP requests processed.
 # TYPE test_http_requests_total counter
-test_http_requests_total{code="200",method="GET"} 4
-# HELP test_http_response_size_bytes The HTTP response sizes in bytes.
-# TYPE test_http_response_size_bytes summary
-test_http_response_size_bytes{code="200",method="GET",quantile="0.5"} 5171
-test_http_response_size_bytes{code="200",method="GET",quantile="0.9"} 102451
-test_http_response_size_bytes{code="200",method="GET",quantile="0.99"} 102451
-test_http_response_size_bytes_sum{code="200",method="GET"} 0
-test_http_response_size_bytes_count{code="200",method="GET"} 4
+test_http_requests_total{code="200",method="GET"} 300

--- a/middleware/testdata/TestPrometheusWrap.golden.txt
+++ b/middleware/testdata/TestPrometheusWrap.golden.txt
@@ -1,32 +1,15 @@
 # HELP test_http_request_duration_seconds The HTTP request latencies in seconds.
-# TYPE test_http_request_duration_seconds histogram
-test_http_request_duration_seconds_bucket{code="200",method="GET",le="0.005"} 0
-test_http_request_duration_seconds_bucket{code="200",method="GET",le="0.01"} 0
-test_http_request_duration_seconds_bucket{code="200",method="GET",le="0.025"} 1
-test_http_request_duration_seconds_bucket{code="200",method="GET",le="0.05"} 1
-test_http_request_duration_seconds_bucket{code="200",method="GET",le="0.1"} 1
-test_http_request_duration_seconds_bucket{code="200",method="GET",le="0.25"} 2
-test_http_request_duration_seconds_bucket{code="200",method="GET",le="0.5"} 2
-test_http_request_duration_seconds_bucket{code="200",method="GET",le="1"} 3
-test_http_request_duration_seconds_bucket{code="200",method="GET",le="2.5"} 4
-test_http_request_duration_seconds_bucket{code="200",method="GET",le="5"} 4
-test_http_request_duration_seconds_bucket{code="200",method="GET",le="10"} 4
-test_http_request_duration_seconds_bucket{code="200",method="GET",le="+Inf"} 4
+# TYPE test_http_request_duration_seconds summary
+test_http_request_duration_seconds{code="200",method="GET",quantile="0.5"} 0.101057833
+test_http_request_duration_seconds{code="200",method="GET",quantile="0.9"} 1.000892875
+test_http_request_duration_seconds{code="200",method="GET",quantile="0.99"} 1.000892875
 test_http_request_duration_seconds_sum{code="200",method="GET"} 0
 test_http_request_duration_seconds_count{code="200",method="GET"} 4
 # HELP test_http_request_size_bytes The HTTP request sizes in bytes.
-# TYPE test_http_request_size_bytes histogram
-test_http_request_size_bytes_bucket{code="200",method="GET",le="1024"} 0
-test_http_request_size_bytes_bucket{code="200",method="GET",le="2048"} 1
-test_http_request_size_bytes_bucket{code="200",method="GET",le="5120"} 1
-test_http_request_size_bytes_bucket{code="200",method="GET",le="10240"} 2
-test_http_request_size_bytes_bucket{code="200",method="GET",le="102400"} 3
-test_http_request_size_bytes_bucket{code="200",method="GET",le="512000"} 4
-test_http_request_size_bytes_bucket{code="200",method="GET",le="1.048576e+06"} 4
-test_http_request_size_bytes_bucket{code="200",method="GET",le="2.62144e+06"} 4
-test_http_request_size_bytes_bucket{code="200",method="GET",le="5.24288e+06"} 4
-test_http_request_size_bytes_bucket{code="200",method="GET",le="1.048576e+07"} 4
-test_http_request_size_bytes_bucket{code="200",method="GET",le="+Inf"} 4
+# TYPE test_http_request_size_bytes summary
+test_http_request_size_bytes{code="200",method="GET",quantile="0.5"} 5171
+test_http_request_size_bytes{code="200",method="GET",quantile="0.9"} 102451
+test_http_request_size_bytes{code="200",method="GET",quantile="0.99"} 102451
 test_http_request_size_bytes_sum{code="200",method="GET"} 0
 test_http_request_size_bytes_count{code="200",method="GET"} 4
 # HELP test_http_requests_in_flight Current number of HTTP requests being served.
@@ -36,17 +19,9 @@ test_http_requests_in_flight{method="GET"} 0
 # TYPE test_http_requests_total counter
 test_http_requests_total{code="200",method="GET"} 4
 # HELP test_http_response_size_bytes The HTTP response sizes in bytes.
-# TYPE test_http_response_size_bytes histogram
-test_http_response_size_bytes_bucket{code="200",method="GET",le="1024"} 0
-test_http_response_size_bytes_bucket{code="200",method="GET",le="2048"} 1
-test_http_response_size_bytes_bucket{code="200",method="GET",le="5120"} 1
-test_http_response_size_bytes_bucket{code="200",method="GET",le="10240"} 2
-test_http_response_size_bytes_bucket{code="200",method="GET",le="102400"} 3
-test_http_response_size_bytes_bucket{code="200",method="GET",le="512000"} 4
-test_http_response_size_bytes_bucket{code="200",method="GET",le="1.048576e+06"} 4
-test_http_response_size_bytes_bucket{code="200",method="GET",le="2.62144e+06"} 4
-test_http_response_size_bytes_bucket{code="200",method="GET",le="5.24288e+06"} 4
-test_http_response_size_bytes_bucket{code="200",method="GET",le="1.048576e+07"} 4
-test_http_response_size_bytes_bucket{code="200",method="GET",le="+Inf"} 4
+# TYPE test_http_response_size_bytes summary
+test_http_response_size_bytes{code="200",method="GET",quantile="0.5"} 5171
+test_http_response_size_bytes{code="200",method="GET",quantile="0.9"} 102451
+test_http_response_size_bytes{code="200",method="GET",quantile="0.99"} 102451
 test_http_response_size_bytes_sum{code="200",method="GET"} 0
 test_http_response_size_bytes_count{code="200",method="GET"} 4


### PR DESCRIPTION
It is much more efficient to use summaries than histograms. This would give information on p50, p90 and p99.

Fixes #925

<!-- Thank you for your hard work on this pull request! -->
