### PR TITLE
martian: cancel request context on downstream disconnection

### DIFF
--- a/internal/martian/errors.go
+++ b/internal/martian/errors.go
@@ -82,18 +82,16 @@ func isClosedConnError(err error) bool {
 
 // isCloseable reports whether err is an error that indicates the client connection should be closed.
 func isCloseable(err error) bool {
-	if errors.Is(err, io.EOF) ||
-		errors.Is(err, io.ErrUnexpectedEOF) ||
-		errors.Is(err, io.ErrClosedPipe) {
-		return true
+	if err == nil {
+		return false
 	}
 
 	var neterr net.Error
-	if ok := errors.As(err, &neterr); ok && neterr.Timeout() {
-		return true
-	}
-
-	return strings.Contains(err.Error(), "tls:")
+	return errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, io.ErrClosedPipe) ||
+		(errors.As(err, &neterr) && !neterr.Timeout()) ||
+		strings.Contains(err.Error(), "tls:")
 }
 
 type ErrorStatus struct { //nolint:errname // ErrorStatus is a type name not a variable.

--- a/internal/martian/proxy.go
+++ b/internal/martian/proxy.go
@@ -323,6 +323,7 @@ func (p *Proxy) handleLoop(conn net.Conn) {
 	}
 
 	pc := newProxyConn(p, conn)
+	defer pc.Close()
 
 	if err := pc.maybeHandshakeTLS(); err != nil {
 		log.Errorf(context.TODO(), "failed to do TLS handshake: %v", err)

--- a/internal/martian/proxy_conn.go
+++ b/internal/martian/proxy_conn.go
@@ -80,7 +80,7 @@ func (p *proxyConn) backgroundRead() {
 		if ok := p.takeReadSem(); !ok {
 			return
 		}
-		if _, err := p.brw.Peek(1); err != nil {
+		if _, err := p.brw.Peek(1); isClosedConnError(err) {
 			p.cancelctx()
 			p.releaseReadSem()
 			return


### PR DESCRIPTION
This patch introduces a background read mechanism for martian proxy conn. Background read affects simple roundTrip path. Once the request body is consumed in roundTrip, background read will begin, canceling conn context in an error occurs. This idea was inspired by http.Server. 

This partially fixes #800. The other patch in progress.