### PR TITLE
martian: add graceful close timeout for bicopy

### DIFF
--- a/http_proxy_errors.go
+++ b/http_proxy_errors.go
@@ -8,6 +8,7 @@ package forwarder
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -50,6 +51,7 @@ func (hp *HTTPProxy) errorResponse(req *http.Request, err error) *http.Response 
 		handleMartianErrorStatus,
 		handleAuthenticationError,
 		handleDenyError,
+		handleContextCancelationError,
 		handleStatusText,
 	}
 
@@ -220,6 +222,16 @@ func handleDenyError(req *http.Request, err error) (code int, msg, label string)
 		code = http.StatusForbidden
 		msg = fmt.Sprintf("proxying is denied to host %q", req.Host)
 		label = skipMetricsLabel
+	}
+
+	return
+}
+
+func handleContextCancelationError(_ *http.Request, err error) (code int, msg, label string) {
+	if errors.Is(err, context.Canceled) {
+		code = http.StatusInternalServerError
+		msg = "request context canceled"
+		label = "request_ctx_canceled"
 	}
 
 	return

--- a/internal/martian/close.go
+++ b/internal/martian/close.go
@@ -43,3 +43,11 @@ func asCloseWriter(w io.Writer) (closeWriter, bool) {
 
 	return reflectx.LookupImpl[closeWriter](reflect.ValueOf(w))
 }
+
+func asCloser(w any) (io.Closer, bool) {
+	if c, ok := w.(io.Closer); ok {
+		return c, ok
+	}
+
+	return reflectx.LookupImpl[io.Closer](reflect.ValueOf(w))
+}

--- a/internal/martian/errors.go
+++ b/internal/martian/errors.go
@@ -82,18 +82,16 @@ func isClosedConnError(err error) bool {
 
 // isCloseable reports whether err is an error that indicates the client connection should be closed.
 func isCloseable(err error) bool {
-	if errors.Is(err, io.EOF) ||
-		errors.Is(err, io.ErrUnexpectedEOF) ||
-		errors.Is(err, io.ErrClosedPipe) {
-		return true
+	if err == nil {
+		return false
 	}
 
 	var neterr net.Error
-	if ok := errors.As(err, &neterr); ok && neterr.Timeout() {
-		return true
-	}
-
-	return strings.Contains(err.Error(), "tls:")
+	return errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, io.ErrClosedPipe) ||
+		(errors.As(err, &neterr) && !neterr.Timeout()) ||
+		strings.Contains(err.Error(), "tls:")
 }
 
 type ErrorStatus struct { //nolint:errname // ErrorStatus is a type name not a variable.


### PR DESCRIPTION
This will prevent the proxy from leaking connections with defective servers.

Given limited resources, this is the best we can do for #800 right now.

That fix cannot be tested due to https://github.com/saucelabs/forwarder/issues/1013. Enable the test again once that is fixed.
For now I tested it manually.
