### PR TITLE
httplog: add structured logger

### DIFF
--- a/httplog/httplog.go
+++ b/httplog/httplog.go
@@ -7,14 +7,10 @@
 package httplog
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
-	"github.com/saucelabs/forwarder/internal/martian"
-	"github.com/saucelabs/forwarder/internal/martian/messageview"
 	"github.com/saucelabs/forwarder/middleware"
 )
 
@@ -128,102 +124,4 @@ func (l *Logger) LogFunc() middleware.Logger {
 	default:
 		panic(fmt.Sprintf("unknown log mode %s", l.mode))
 	}
-}
-
-type logWriter struct {
-	b    bytes.Buffer
-	body bool
-}
-
-func (w *logWriter) String() string {
-	return w.b.String()
-}
-
-func (w *logWriter) URLLine(e middleware.LogEntry) {
-	w.trace(e)
-	fmt.Fprintf(&w.b, "%s %s status=%v duration=%s\n",
-		e.Request.Method,
-		e.Request.URL.Redacted(),
-		e.Status,
-		e.Duration,
-	)
-}
-
-func (w *logWriter) ShortURLLine(e middleware.LogEntry) {
-	w.trace(e)
-
-	u := e.Request.URL
-	scheme, host, path := u.Scheme, u.Host, u.Path
-	if scheme != "" {
-		scheme += "://"
-	}
-	if path != "" && path[0] != '/' {
-		path = "/" + path
-	}
-
-	fmt.Fprintf(&w.b, "%s %s status=%v duration=%s\n",
-		e.Request.Method,
-		scheme+host+path,
-		e.Status,
-		e.Duration,
-	)
-}
-
-func (w *logWriter) trace(e middleware.LogEntry) {
-	if trace := martian.ContextTraceID(e.Request.Context()); trace != "" {
-		fmt.Fprintf(&w.b, "[%s] ", trace)
-	}
-}
-
-func (w *logWriter) Dump(e middleware.LogEntry) {
-	if err := w.dump(e); err != nil {
-		w.error(err)
-	}
-	w.sep()
-}
-
-func (w *logWriter) dump(e middleware.LogEntry) error {
-	mv := messageview.New()
-	mv.SkipBody(!w.body || (e.Request.Method == http.MethodConnect && e.Status/100 == 2))
-
-	// Dump request.
-	{
-		if err := mv.SnapshotRequest(e.Request); err != nil {
-			return err
-		}
-		r, err := mv.Reader()
-		if err != nil {
-			return err
-		}
-		if _, err := io.Copy(&w.b, r); err != nil {
-			return err
-		}
-	}
-
-	// Dump response.
-	{
-		if e.Response == nil {
-			return nil
-		}
-		if err := mv.SnapshotResponse(e.Response); err != nil {
-			return err
-		}
-		r, err := mv.Reader()
-		if err != nil {
-			return err
-		}
-		if _, err := io.Copy(&w.b, r); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (w *logWriter) error(err error) {
-	fmt.Fprintf(&w.b, "\nlogger error: %s\n", err)
-}
-
-func (w *logWriter) sep() {
-	fmt.Fprint(&w.b, "\n")
 }

--- a/httplog/httplog.go
+++ b/httplog/httplog.go
@@ -14,6 +14,7 @@ import (
 	"github.com/saucelabs/forwarder/middleware"
 )
 
+// Mode defines the logging verbosity.
 type Mode string
 
 const (
@@ -43,18 +44,7 @@ func SplitNameMode(val string) (name string, mode Mode, err error) {
 	}
 
 	switch mode {
-	case None:
-		mode = None
-	case ShortURL:
-		mode = ShortURL
-	case URL:
-		mode = URL
-	case Headers:
-		mode = Headers
-	case Body:
-		mode = Body
-	case Errors:
-		mode = Errors
+	case None, ShortURL, URL, Headers, Body, Errors:
 	default:
 		return "", "", fmt.Errorf("invalid mode %q", mode)
 	}

--- a/httplog/httplog_bench_test.go
+++ b/httplog/httplog_bench_test.go
@@ -1,0 +1,113 @@
+// Copyright 2022-2024 Sauce Labs Inc., all rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package httplog
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/saucelabs/forwarder/middleware"
+)
+
+var (
+	message   string
+	arguments []any
+)
+
+func dummyLogFunc(msg string, args ...any) {
+	message = msg
+	arguments = args
+}
+
+// benchmarkLogger runs the given logger for a fixed log entry.
+func benchmarkLogger(b *testing.B, logFunc middleware.Logger) {
+	b.Helper()
+
+	reqBody := "sample request body"
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", io.NopCloser(strings.NewReader(reqBody)))
+	if err != nil {
+		b.Fatal(err)
+	}
+	req.Header.Add("X-Custom-Request-1", "RequestHeaderValue")
+	req.Header.Add("X-Custom-Request-2", "RequestHeaderValue")
+	req.Header.Add("X-Custom-Request-3", "RequestHeaderValue")
+	req.TransferEncoding = []string{"chunked"}
+	req.Trailer = http.Header{"X-Trailer-Request": []string{"TrailerValue"}}
+
+	res := &http.Response{
+		StatusCode:       http.StatusOK,
+		Status:           "200 OK",
+		Proto:            "HTTP/1.1",
+		Header:           make(http.Header),
+		TransferEncoding: []string{"chunked"},
+	}
+	res.Header.Add("X-Custom-Response", "ResponseHeaderValue")
+	res.Header.Add("X-Custom-Response-1", "ResponseHeaderValue")
+	res.Header.Add("X-Custom-Response-2", "ResponseHeaderValue")
+	res.Header.Add("X-Custom-Response-3", "ResponseHeaderValue")
+	res.Header.Add("X-Custom-Response-4", "ResponseHeaderValue")
+	res.Header.Add("X-Custom-Response-5", "ResponseHeaderValue")
+	res.Header.Add("X-Custom-Response-6", "ResponseHeaderValue")
+	res.Header.Add("X-Custom-Response-7", "ResponseHeaderValue")
+	res.Header.Add("X-Custom-Response-8", "ResponseHeaderValue")
+	res.Header.Add("X-Custom-Response-9", "ResponseHeaderValue")
+	resBody := "sample response body"
+	res.Body = io.NopCloser(strings.NewReader(resBody))
+	res.ContentLength = int64(len(resBody))
+	res.Trailer = http.Header{"X-Trailer-Response": []string{"TrailerValue"}}
+
+	entry := middleware.LogEntry{
+		Request:  req,
+		Response: res,
+		Status:   res.StatusCode,
+		Duration: 100 * time.Millisecond,
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logFunc(entry)
+	}
+}
+
+// BenchmarkNormalShortURL benchmarks a normal (non-structured) logger in ShortURL mode.
+func BenchmarkNormalShortURL(b *testing.B) {
+	logger := NewLogger(dummyLogFunc, ShortURL)
+	benchmarkLogger(b, logger.LogFunc())
+}
+
+// BenchmarkNormalHeaders benchmarks a normal (non-structured) logger in Headers mode.
+func BenchmarkNormalHeaders(b *testing.B) {
+	logger := NewLogger(dummyLogFunc, Headers)
+	benchmarkLogger(b, logger.LogFunc())
+}
+
+// BenchmarkNormalBody benchmarks a normal (non-structured) logger in Body mode.
+func BenchmarkNormalBody(b *testing.B) {
+	logger := NewLogger(dummyLogFunc, Body)
+	benchmarkLogger(b, logger.LogFunc())
+}
+
+// BenchmarkStructuredShortURL benchmarks a structured logger in ShortURL mode.
+func BenchmarkStructuredShortURL(b *testing.B) {
+	logger := NewStructuredLogger(dummyLogFunc, ShortURL)
+	benchmarkLogger(b, logger.LogFunc())
+}
+
+// BenchmarkStructuredHeaders benchmarks a structured logger in Headers mode.
+func BenchmarkStructuredHeaders(b *testing.B) {
+	logger := NewStructuredLogger(dummyLogFunc, Headers)
+	benchmarkLogger(b, logger.LogFunc())
+}
+
+// BenchmarkStructuredBody benchmarks a structured logger in Body mode.
+func BenchmarkStructuredBody(b *testing.B) {
+	logger := NewStructuredLogger(dummyLogFunc, Body)
+	benchmarkLogger(b, logger.LogFunc())
+}

--- a/httplog/logwriter.go
+++ b/httplog/logwriter.go
@@ -1,0 +1,116 @@
+// Copyright 2022-2024 Sauce Labs Inc., all rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package httplog
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/saucelabs/forwarder/internal/martian"
+	"github.com/saucelabs/forwarder/internal/martian/messageview"
+	"github.com/saucelabs/forwarder/middleware"
+)
+
+type logWriter struct {
+	b    bytes.Buffer
+	body bool
+}
+
+func (w *logWriter) String() string {
+	return w.b.String()
+}
+
+func (w *logWriter) URLLine(e middleware.LogEntry) {
+	w.trace(e)
+	fmt.Fprintf(&w.b, "%s %s status=%v duration=%s\n",
+		e.Request.Method,
+		e.Request.URL.Redacted(),
+		e.Status,
+		e.Duration,
+	)
+}
+
+func (w *logWriter) ShortURLLine(e middleware.LogEntry) {
+	w.trace(e)
+
+	u := e.Request.URL
+	scheme, host, path := u.Scheme, u.Host, u.Path
+	if scheme != "" {
+		scheme += "://"
+	}
+	if path != "" && path[0] != '/' {
+		path = "/" + path
+	}
+
+	fmt.Fprintf(&w.b, "%s %s status=%v duration=%s\n",
+		e.Request.Method,
+		scheme+host+path,
+		e.Status,
+		e.Duration,
+	)
+}
+
+func (w *logWriter) trace(e middleware.LogEntry) {
+	if trace := martian.ContextTraceID(e.Request.Context()); trace != "" {
+		fmt.Fprintf(&w.b, "[%s] ", trace)
+	}
+}
+
+func (w *logWriter) Dump(e middleware.LogEntry) {
+	if err := w.dump(e); err != nil {
+		w.error(err)
+	}
+	w.sep()
+}
+
+func (w *logWriter) dump(e middleware.LogEntry) error {
+	mv := messageview.New()
+	mv.SkipBody(!w.body || (e.Request.Method == http.MethodConnect && e.Status/100 == 2))
+
+	// Dump request.
+	{
+		if err := mv.SnapshotRequest(e.Request); err != nil {
+			return err
+		}
+		r, err := mv.Reader()
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(&w.b, r); err != nil {
+			return err
+		}
+	}
+
+	// Dump response.
+	{
+		if e.Response == nil {
+			return nil
+		}
+		if err := mv.SnapshotResponse(e.Response); err != nil {
+			return err
+		}
+		r, err := mv.Reader()
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(&w.b, r); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (w *logWriter) error(err error) {
+	fmt.Fprintf(&w.b, "\nlogger error: %s\n", err)
+}
+
+func (w *logWriter) sep() {
+	fmt.Fprint(&w.b, "\n")
+}

--- a/httplog/slog.go
+++ b/httplog/slog.go
@@ -87,14 +87,12 @@ func (b *structuredLogBuilder) initBasicFields(e middleware.LogEntry, urlStr str
 	b.id = martian.ContextTraceID(req.Context())
 }
 
+// WithHeaders copies headers, trailers, and other metadata from the request and response.
 func (b *structuredLogBuilder) WithHeaders(e middleware.LogEntry) {
 	req := e.Request
 
 	b.req.Host = req.Host
-	b.req.Headers = make(map[string][]string, len(req.Header))
-	for k, vs := range req.Header {
-		b.req.Headers[k] = vs
-	}
+	b.req.Headers = req.Header.Clone()
 	if len(req.TransferEncoding) > 0 {
 		b.req.TransferEncoding = req.TransferEncoding
 	}
@@ -102,10 +100,7 @@ func (b *structuredLogBuilder) WithHeaders(e middleware.LogEntry) {
 		b.req.ContentLength = req.ContentLength
 	}
 	if len(req.Trailer) > 0 {
-		b.req.Trailers = make(map[string][]string, len(req.Trailer))
-		for k, vs := range req.Trailer {
-			b.req.Trailers[k] = vs
-		}
+		b.req.Trailers = req.Trailer.Clone()
 	}
 
 	res := e.Response
@@ -118,10 +113,7 @@ func (b *structuredLogBuilder) WithHeaders(e middleware.LogEntry) {
 	if len(parts) == 2 {
 		b.res.StatusText = parts[1]
 	}
-	b.res.Headers = make(map[string][]string, len(res.Header))
-	for k, vs := range res.Header {
-		b.res.Headers[k] = vs
-	}
+	b.res.Headers = res.Header.Clone()
 	if len(res.TransferEncoding) > 0 {
 		b.res.TransferEncoding = res.TransferEncoding
 	}
@@ -129,10 +121,7 @@ func (b *structuredLogBuilder) WithHeaders(e middleware.LogEntry) {
 		b.res.ContentLength = res.ContentLength
 	}
 	if len(res.Trailer) > 0 {
-		b.res.Trailers = make(map[string][]string, len(res.Trailer))
-		for k, vs := range res.Trailer {
-			b.res.Trailers[k] = vs
-		}
+		b.res.Trailers = res.Trailer.Clone()
 	}
 }
 

--- a/httplog/slog.go
+++ b/httplog/slog.go
@@ -1,0 +1,171 @@
+// Copyright 2022-2024 Sauce Labs Inc., all rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package httplog
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/saucelabs/forwarder/internal/martian"
+	"github.com/saucelabs/forwarder/middleware"
+)
+
+// request represents an HTTP request for structured logging.
+type request struct {
+	Protocol         string              `json:"protocol,omitempty"`
+	Method           string              `json:"method,omitempty"`
+	URL              string              `json:"url,omitempty"`
+	Host             string              `json:"host,omitempty"`
+	Headers          map[string][]string `json:"headers,omitempty"`
+	TransferEncoding []string            `json:"transfer_encoding,omitempty"`
+	ContentLength    int64               `json:"content_length,omitempty"`
+	Body             string              `json:"body,omitempty"`
+	BodyError        string              `json:"body_error,omitempty"`
+	Trailers         map[string][]string `json:"trailers,omitempty"`
+}
+
+// response represents an HTTP response for structured logging.
+type response struct {
+	Protocol         string              `json:"protocol,omitempty"`
+	StatusCode       int                 `json:"status_code,omitempty"`
+	StatusText       string              `json:"status_text,omitempty"`
+	Headers          map[string][]string `json:"headers,omitempty"`
+	TransferEncoding []string            `json:"transfer_encoding,omitempty"`
+	ContentLength    int64               `json:"content_length,omitempty"`
+	Body             string              `json:"body,omitempty"`
+	BodyError        string              `json:"body_error,omitempty"`
+	Trailers         map[string][]string `json:"trailers,omitempty"`
+}
+
+type structuredLogBuilder struct {
+	req      request
+	res      response
+	duration string
+	id       string
+}
+
+func (b *structuredLogBuilder) WithShortURL(e middleware.LogEntry) {
+	req := e.Request
+	b.req.Protocol = fmt.Sprintf("HTTP/%d.%d", req.ProtoMajor, req.ProtoMinor)
+	b.req.Method = req.Method
+	b.req.URL = buildShortURL(req.URL)
+
+	b.res.StatusCode = e.Status
+
+	b.duration = e.Duration.String()
+	b.id = martian.ContextTraceID(req.Context())
+}
+
+func buildShortURL(u *url.URL) string {
+	scheme, host, path := u.Scheme, u.Host, u.Path
+	if scheme != "" {
+		scheme += "://"
+	}
+	if path != "" && path[0] != '/' {
+		path = "/" + path
+	}
+	return scheme + host + path
+}
+
+func (b *structuredLogBuilder) WithURL(e middleware.LogEntry) {
+	req := e.Request
+	b.req.Protocol = fmt.Sprintf("HTTP/%d.%d", req.ProtoMajor, req.ProtoMinor)
+	b.req.Method = req.Method
+	b.req.URL = req.URL.Redacted()
+
+	b.res.StatusCode = e.Status
+
+	b.duration = e.Duration.String()
+	b.id = martian.ContextTraceID(req.Context())
+}
+
+func (b *structuredLogBuilder) WithHeaders(e middleware.LogEntry) {
+	req := e.Request
+
+	b.req.Host = req.Host
+	b.req.Headers = make(map[string][]string, len(req.Header))
+	for k, vs := range req.Header {
+		b.req.Headers[k] = vs
+	}
+	if len(req.TransferEncoding) > 0 {
+		b.req.TransferEncoding = req.TransferEncoding
+	}
+	if req.ContentLength >= 0 {
+		b.req.ContentLength = req.ContentLength
+	}
+	if len(req.Trailer) > 0 {
+		b.req.Trailers = make(map[string][]string, len(req.Trailer))
+		for k, vs := range req.Trailer {
+			b.req.Trailers[k] = vs
+		}
+	}
+
+	res := e.Response
+	if res == nil {
+		return
+	}
+
+	b.res.Protocol = fmt.Sprintf("HTTP/%d.%d", res.ProtoMajor, res.ProtoMinor)
+	parts := strings.SplitN(res.Status, " ", 2)
+	if len(parts) == 2 {
+		b.res.StatusText = parts[1]
+	}
+	b.res.Headers = make(map[string][]string, len(res.Header))
+	for k, vs := range res.Header {
+		b.res.Headers[k] = vs
+	}
+	if len(res.TransferEncoding) > 0 {
+		b.res.TransferEncoding = res.TransferEncoding
+	}
+	if res.ContentLength >= 0 {
+		b.res.ContentLength = res.ContentLength
+	}
+	if len(res.Trailer) > 0 {
+		b.res.Trailers = make(map[string][]string, len(res.Trailer))
+		for k, vs := range res.Trailer {
+			b.res.Trailers[k] = vs
+		}
+	}
+}
+
+func (b *structuredLogBuilder) WithBody(e middleware.LogEntry) {
+	req := e.Request
+	if req.Method == http.MethodConnect && e.Status/100 == 2 {
+		return
+	}
+
+	if req.Body != nil {
+		data, err := io.ReadAll(req.Body)
+		if err != nil {
+			b.req.BodyError = err.Error()
+		} else {
+			b.req.Body = string(data)
+			// Restore the body for further processing.
+			req.Body = io.NopCloser(bytes.NewReader(data))
+		}
+	}
+
+	res := e.Response
+	if res != nil && res.Body != nil {
+		data, err := io.ReadAll(res.Body)
+		if err != nil {
+			b.res.BodyError = err.Error()
+		} else {
+			b.res.Body = string(data)
+			// Restore the body.
+			res.Body = io.NopCloser(bytes.NewReader(data))
+		}
+	}
+}
+
+func (b *structuredLogBuilder) Args() []any {
+	return []any{"request", b.req, "response", b.res, "duration", b.duration, "id", b.id}
+}

--- a/httplog/slog.go
+++ b/httplog/slog.go
@@ -125,6 +125,8 @@ func (b *structuredLogBuilder) WithHeaders(e middleware.LogEntry) {
 	}
 }
 
+// WithBody reads and logs the body of the request and response.
+// Note: For CONNECT requests with successful responses, the body is skipped.
 func (b *structuredLogBuilder) WithBody(e middleware.LogEntry) {
 	req := e.Request
 	if req.Method == http.MethodConnect && e.Status/100 == 2 {
@@ -155,6 +157,7 @@ func (b *structuredLogBuilder) WithBody(e middleware.LogEntry) {
 	}
 }
 
+// Args returns a slice of key-value pairs for logging purposes.
 func (b *structuredLogBuilder) Args() []any {
 	return []any{"request", b.req, "response", b.res, "duration", b.duration, "id", b.id}
 }

--- a/httplog/slog.go
+++ b/httplog/slog.go
@@ -54,6 +54,9 @@ type structuredLogBuilder struct {
 
 // WithShortURL sets the URL using a short form along with basic fields.
 func (b *structuredLogBuilder) WithShortURL(e middleware.LogEntry) {
+	if e.Request == nil {
+		return
+	}
 	shortURL := buildShortURL(e.Request.URL)
 	b.initBasicFields(e, shortURL)
 }
@@ -71,6 +74,9 @@ func buildShortURL(u *url.URL) string {
 
 // WithURL sets the URL using the redacted form along with basic fields.
 func (b *structuredLogBuilder) WithURL(e middleware.LogEntry) {
+	if e.Request == nil {
+		return
+	}
 	redactedURL := e.Request.URL.Redacted()
 	b.initBasicFields(e, redactedURL)
 }
@@ -90,6 +96,9 @@ func (b *structuredLogBuilder) initBasicFields(e middleware.LogEntry, urlStr str
 // WithHeaders copies headers, trailers, and other metadata from the request and response.
 func (b *structuredLogBuilder) WithHeaders(e middleware.LogEntry) {
 	req := e.Request
+	if req == nil {
+		return
+	}
 
 	b.req.Host = req.Host
 	b.req.Headers = req.Header.Clone()
@@ -129,7 +138,7 @@ func (b *structuredLogBuilder) WithHeaders(e middleware.LogEntry) {
 // Note: For CONNECT requests with successful responses, the body is skipped.
 func (b *structuredLogBuilder) WithBody(e middleware.LogEntry) {
 	req := e.Request
-	if req.Method == http.MethodConnect && e.Status/100 == 2 {
+	if req == nil || req.Method == http.MethodConnect && e.Status/100 == 2 {
 		return
 	}
 


### PR DESCRIPTION
Structured http logs will be needed once we migrate to `log/slog`. 

