### PR TITLE
martian: switch to structured logging 

### DIFF
--- a/internal/martian/h2/h2.go
+++ b/internal/martian/h2/h2.go
@@ -55,7 +55,7 @@ type Config struct {
 // h2 is being used. Since no browsers use h2c, it's safe to assume all traffic uses TLS.
 func (c *Config) Proxy(closing chan bool, cc io.ReadWriter, url *url.URL) error {
 	if c.EnableDebugLogs {
-		log.Infof(context.TODO(), "\u001b[1;35mProxying %v with HTTP/2\u001b[0m", url)
+		log.Info(context.TODO(), "\u001b[1;35mProxying with HTTP/2\u001b[0m", "url", url)
 	}
 	sc, err := tls.Dial("tcp", url.Host, &tls.Config{
 		MinVersion: tls.VersionTLS12,
@@ -105,13 +105,13 @@ func (c *Config) Proxy(closing chan bool, cc io.ReadWriter, url *url.URL) error 
 	go func() { // Forwards frames from client to server.
 		defer wg.Done()
 		if err := cToS.relayFrames(closing); err != nil {
-			log.Errorf(context.TODO(), "relaying frame from client to %v: %v", url, err)
+			log.Error(context.TODO(), "relaying frame from client", "url", url, "error", err)
 		}
 	}()
 	go func() { // Forwards frames from server to client.
 		defer wg.Done()
 		if err := sToC.relayFrames(closing); err != nil {
-			log.Errorf(context.TODO(), "relaying frame from %v to client: %v", url, err)
+			log.Error(context.TODO(), "relaying frame to client", "url", url, "error", err)
 		}
 	}()
 	wg.Wait()

--- a/internal/martian/h2/relay.go
+++ b/internal/martian/h2/relay.go
@@ -206,7 +206,7 @@ func (r *relay) relayFrames(closing chan bool) error {
 				return fmt.Errorf("processing frame: %w", err)
 			}
 			if *r.enableDebugLogs {
-				log.Infof(context.TODO(), "%s--%v-->%s", r.srcLabel, frame, r.destLabel)
+				log.Info(context.TODO(), fmt.Sprintf("%s--%v-->%s", r.srcLabel, frame, r.destLabel))
 			}
 		case err := <-writerErr:
 			return fmt.Errorf("sending frame: %w", err)
@@ -532,7 +532,7 @@ func (r *relay) encodeFull(headers []hpack.HeaderField) ([]byte, error) {
 		}
 	}
 	if *r.enableDebugLogs {
-		log.Infof(context.TODO(), "sending headers %s -> %s:\n%s", r.srcLabel, r.destLabel, buf.Bytes())
+		log.Info(context.TODO(), "sending headers", "src", r.srcLabel, "dst", r.destLabel, "buf", buf.Bytes())
 	}
 	return r.reencoded.Bytes(), nil
 }

--- a/internal/martian/log/log.go
+++ b/internal/martian/log/log.go
@@ -6,32 +6,36 @@ import (
 	"context"
 )
 
-type Logger interface {
-	Infof(ctx context.Context, format string, args ...any)
-	Debugf(ctx context.Context, format string, args ...any)
-	Errorf(ctx context.Context, format string, args ...any)
+type StructuredLogger interface {
+	Error(ctx context.Context, msg string, args ...any)
+	Warn(ctx context.Context, msg string, args ...any)
+	Info(ctx context.Context, msg string, args ...any)
+	Debug(ctx context.Context, msg string, args ...any)
+
+	With(args ...any) StructuredLogger
 }
 
-var log Logger = nopLogger{}
+var log StructuredLogger = nopLogger{}
 
 // SetLogger changes the default logger. This must be called very first,
 // before interacting with rest of the martian package. Changing it at
 // runtime is not supported.
-func SetLogger(l Logger) {
+func SetLogger(l StructuredLogger) {
 	log = l
 }
 
-// Infof logs an info message.
-func Infof(ctx context.Context, format string, args ...any) {
-	log.Infof(ctx, format, args...)
+func Error(ctx context.Context, msg string, args ...any) {
+	log.Error(ctx, msg, args...)
 }
 
-// Debugf logs a debug message.
-func Debugf(ctx context.Context, format string, args ...any) {
-	log.Debugf(ctx, format, args...)
+func Warn(ctx context.Context, msg string, args ...any) {
+	log.Warn(ctx, msg, args...)
 }
 
-// Errorf logs an error message.
-func Errorf(ctx context.Context, format string, args ...any) {
-	log.Errorf(ctx, format, args...)
+func Info(ctx context.Context, msg string, args ...any) {
+	log.Info(ctx, msg, args...)
+}
+
+func Debug(ctx context.Context, msg string, args ...any) {
+	log.Debug(ctx, msg, args...)
 }

--- a/internal/martian/log/nop.go
+++ b/internal/martian/log/nop.go
@@ -8,10 +8,11 @@ import (
 
 type nopLogger struct{}
 
-var _ Logger = nopLogger{}
+var _ StructuredLogger = nopLogger{}
 
-func (nopLogger) Infof(_ context.Context, _ string, _ ...any) {}
+func (nopLogger) Error(_ context.Context, _ string, _ ...any) {}
+func (nopLogger) Warn(_ context.Context, _ string, _ ...any)  {}
+func (nopLogger) Info(_ context.Context, _ string, _ ...any)  {}
+func (nopLogger) Debug(_ context.Context, _ string, _ ...any) {}
 
-func (nopLogger) Debugf(_ context.Context, _ string, _ ...any) {}
-
-func (nopLogger) Errorf(_ context.Context, _ string, _ ...any) {}
+func (nopLogger) With(_ ...any) StructuredLogger { return nopLogger{} }

--- a/internal/martian/log/test.go
+++ b/internal/martian/log/test.go
@@ -18,25 +18,35 @@ package log
 
 import (
 	"context"
-	stdlog "log"
+	"log/slog"
 )
 
-type testLogger struct{}
+var _ StructuredLogger = testLogger{}
 
-var _ Logger = testLogger{}
-
-func (testLogger) Infof(_ context.Context, format string, args ...any) {
-	stdlog.Printf("INFO: "+format, args...)
+type testLogger struct {
+	*slog.Logger
 }
 
-func (testLogger) Debugf(_ context.Context, format string, args ...any) {
-	stdlog.Printf("DEBUG: "+format, args...)
+func (l testLogger) Error(ctx context.Context, msg string, args ...any) {
+	l.ErrorContext(ctx, msg, args...)
 }
 
-func (testLogger) Errorf(_ context.Context, format string, args ...any) {
-	stdlog.Printf("ERROR: "+format, args...)
+func (l testLogger) Warn(ctx context.Context, msg string, args ...any) {
+	l.WarnContext(ctx, msg, args...)
+}
+
+func (l testLogger) Info(ctx context.Context, msg string, args ...any) {
+	l.InfoContext(ctx, msg, args...)
+}
+
+func (l testLogger) Debug(ctx context.Context, msg string, args ...any) {
+	l.DebugContext(ctx, msg, args...)
+}
+
+func (l testLogger) With(args ...any) StructuredLogger {
+	return testLogger{l.Logger.With(args...)}
 }
 
 func SetTestLogger() {
-	SetLogger(testLogger{})
+	SetLogger(testLogger{slog.Default()})
 }

--- a/internal/martian/mitm/mitm.go
+++ b/internal/martian/mitm/mitm.go
@@ -246,7 +246,7 @@ func (c *Config) cert(ctx context.Context, hostname string) (*tls.Certificate, e
 
 	tlsc, ok := c.certs.Get(hostname)
 	if ok {
-		log.Debugf(ctx, "mitm: cache hit for %s", hostname)
+		log.Debug(ctx, "mitm: cache hit", "hostname", hostname)
 
 		// Check validity of the certificate for hostname match, expiry, etc. In
 		// particular, if the cached certificate has expired, create a new one.
@@ -257,10 +257,10 @@ func (c *Config) cert(ctx context.Context, hostname string) (*tls.Certificate, e
 			return tlsc, nil
 		}
 
-		log.Debugf(ctx, "mitm: invalid certificate in cache for %s", hostname)
+		log.Debug(ctx, "mitm: invalid certificate in cache", "hostname", hostname)
 	}
 
-	log.Debugf(ctx, "mitm: cache miss for %s", hostname)
+	log.Debug(ctx, "mitm: cache miss", "hostname", hostname)
 
 	serial, err := rand.Int(rand.Reader, MaxSerialNumber)
 	if err != nil {

--- a/internal/martian/proxy_test.go
+++ b/internal/martian/proxy_test.go
@@ -298,27 +298,27 @@ func TestIntegrationHTTP100Continue(t *testing.T) {
 	go func() {
 		conn, err := sl.Accept()
 		if err != nil {
-			log.Errorf(context.TODO(), "proxy_test: failed to accept connection: %v", err)
+			log.Error(context.TODO(), "proxy_test: failed to accept connection", "error", err)
 			return
 		}
 		defer conn.Close()
 
-		log.Infof(context.TODO(), "proxy_test: accepted connection: %s", conn.RemoteAddr())
+		log.Info(context.TODO(), "proxy_test: accepted connection", "address", conn.RemoteAddr())
 
 		req, err := http.ReadRequest(bufio.NewReader(conn))
 		if err != nil {
-			log.Errorf(context.TODO(), "proxy_test: failed to read request: %v", err)
+			log.Error(context.TODO(), "proxy_test: failed to read request", "error", err)
 			return
 		}
 
 		if req.Header.Get("Expect") == "100-continue" {
-			log.Infof(context.TODO(), "proxy_test: received 100-continue request")
+			log.Info(context.TODO(), "proxy_test: received 100-continue request")
 
 			conn.Write([]byte("HTTP/1.1 100 Continue\r\n\r\n"))
 
-			log.Infof(context.TODO(), "proxy_test: sent 100-continue response")
+			log.Info(context.TODO(), "proxy_test: sent 100-continue response")
 		} else {
-			log.Infof(context.TODO(), "proxy_test: received non 100-continue request")
+			log.Info(context.TODO(), "proxy_test: received non 100-continue request")
 
 			res := proxyutil.NewResponse(417, nil, req)
 			res.Header.Set("Connection", "close")
@@ -330,7 +330,7 @@ func TestIntegrationHTTP100Continue(t *testing.T) {
 		res.Header.Set("Connection", "close")
 		res.Write(conn)
 
-		log.Infof(context.TODO(), "proxy_test: sent 200 response")
+		log.Info(context.TODO(), "proxy_test: sent 200 response")
 	}()
 
 	conn, cancel := h.proxyConn(t)
@@ -401,34 +401,34 @@ func TestIntegrationHTTP101SwitchingProtocols(t *testing.T) {
 	go func() {
 		conn, err := sl.Accept()
 		if err != nil {
-			log.Errorf(context.TODO(), "proxy_test: failed to accept connection: %v", err)
+			log.Error(context.TODO(), "proxy_test: failed to accept connection", "error", err)
 			return
 		}
 		defer conn.Close()
 
-		log.Infof(context.TODO(), "proxy_test: accepted connection: %s", conn.RemoteAddr())
+		log.Info(context.TODO(), "proxy_test: accepted connection", "address", conn.RemoteAddr())
 
 		req, err := http.ReadRequest(bufio.NewReader(conn))
 		if err != nil {
-			log.Errorf(context.TODO(), "proxy_test: failed to read request: %v", err)
+			log.Error(context.TODO(), "proxy_test: failed to read request", "error", err)
 			return
 		}
 
 		if reqUpType := upgradeType(req.Header); reqUpType != "" {
-			log.Infof(context.TODO(), "proxy_test: received upgrade request")
+			log.Info(context.TODO(), "proxy_test: received upgrade request")
 
 			res := proxyutil.NewResponse(101, nil, req)
 			res.Header.Set("Connection", "upgrade")
 			res.Header.Set("Upgrade", reqUpType)
 
 			res.Write(conn)
-			log.Infof(context.TODO(), "proxy_test: sent 101 response")
+			log.Info(context.TODO(), "proxy_test: sent 101 response")
 
 			if _, err := io.Copy(conn, conn); err != nil {
-				log.Errorf(context.TODO(), "proxy_test: failed to copy connection: %v", err)
+				log.Error(context.TODO(), "proxy_test: failed to copy connection", "error", err)
 			}
 		} else {
-			log.Infof(context.TODO(), "proxy_test: received non upgrade request")
+			log.Info(context.TODO(), "proxy_test: received non upgrade request")
 
 			res := proxyutil.NewResponse(417, nil, req)
 			res.Header.Set("Connection", "close")
@@ -436,7 +436,7 @@ func TestIntegrationHTTP101SwitchingProtocols(t *testing.T) {
 			return
 		}
 
-		log.Infof(context.TODO(), "proxy_test: closed connection")
+		log.Info(context.TODO(), "proxy_test: closed connection")
 	}()
 
 	conn, cancel := h.proxyConn(t)
@@ -508,25 +508,25 @@ func TestIntegrationHTTP304NotModified(t *testing.T) {
 	go func() {
 		conn, err := sl.Accept()
 		if err != nil {
-			log.Errorf(context.TODO(), "proxy_test: failed to accept connection: %v", err)
+			log.Error(context.TODO(), "proxy_test: failed to accept connection", "error", err)
 			return
 		}
 		defer conn.Close()
 
-		log.Infof(context.TODO(), "proxy_test: accepted connection: %s", conn.RemoteAddr())
+		log.Info(context.TODO(), "proxy_test: accepted connection", "address", conn.RemoteAddr())
 
 		req, err := http.ReadRequest(bufio.NewReader(conn))
 		if err != nil {
-			log.Errorf(context.TODO(), "proxy_test: failed to read request: %v", err)
+			log.Error(context.TODO(), "proxy_test: failed to read request", "error", err)
 			return
 		}
 
 		res := proxyutil.NewResponse(304, http.NoBody, req)
 		res.Header.Set("Content-Length", "13")
 		res.Write(conn)
-		log.Infof(context.TODO(), "proxy_test: sent 304 response")
+		log.Info(context.TODO(), "proxy_test: sent 304 response")
 
-		log.Infof(context.TODO(), "proxy_test: closed connection")
+		log.Info(context.TODO(), "proxy_test: closed connection")
 	}()
 
 	conn, cancel := h.proxyConn(t)
@@ -580,16 +580,16 @@ func TestIntegrationUnexpectedUpstreamFailure(t *testing.T) {
 		time.Sleep(1 * time.Second)
 		conn, err := sl.Accept()
 		if err != nil {
-			log.Errorf(context.TODO(), "proxy_test: failed to accept connection: %v", err)
+			log.Error(context.TODO(), "proxy_test: failed to accept connection", "error", err)
 			return
 		}
 		defer conn.Close()
 
-		log.Infof(context.TODO(), "proxy_test: accepted connection: %s\n", conn.RemoteAddr())
+		log.Info(context.TODO(), "proxy_test: accepted connection", "address", conn.RemoteAddr())
 
 		req, err := http.ReadRequest(bufio.NewReader(conn))
 		if err != nil {
-			log.Errorf(context.TODO(), "proxy_test: failed to read request: %v", err)
+			log.Error(context.TODO(), "proxy_test: failed to read request", "error", err)
 			return
 		}
 
@@ -609,7 +609,7 @@ func TestIntegrationUnexpectedUpstreamFailure(t *testing.T) {
 		res.Write(conn)
 		conn.Close()
 
-		log.Infof(context.TODO(), "proxy_test: sent 200 response\n")
+		log.Info(context.TODO(), "proxy_test: sent 200 response")
 	}()
 
 	conn, cancel := h.proxyConn(t)

--- a/log/martianlog/adapter.go
+++ b/log/martianlog/adapter.go
@@ -1,0 +1,65 @@
+// Copyright 2022-2024 Sauce Labs Inc., all rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package martianlog
+
+import (
+	"context"
+	"fmt"
+
+	martianlog "github.com/saucelabs/forwarder/internal/martian/log"
+	"github.com/saucelabs/forwarder/log"
+)
+
+func newStructuredLoggerAdapter(log log.Logger) *structuredLoggerAdapter {
+	return &structuredLoggerAdapter{log: log}
+}
+
+type structuredLoggerAdapter struct {
+	log  log.Logger
+	args []any
+}
+
+func (l *structuredLoggerAdapter) Error(_ context.Context, msg string, args ...any) {
+	l.log.Errorf("%s", formatMessage(msg, append(l.args, args...)...))
+}
+
+func (l *structuredLoggerAdapter) Warn(_ context.Context, msg string, args ...any) {
+	l.log.Infof("[WARN] %s", formatMessage(msg, append(l.args, args...)...))
+}
+
+func (l *structuredLoggerAdapter) Info(_ context.Context, msg string, args ...any) {
+	l.log.Infof("%s", formatMessage(msg, append(l.args, args...)...))
+}
+
+func (l *structuredLoggerAdapter) Debug(_ context.Context, msg string, args ...any) {
+	l.log.Debugf("%s", formatMessage(msg, append(l.args, args...)...))
+}
+
+func (l *structuredLoggerAdapter) With(args ...any) martianlog.StructuredLogger {
+	return &structuredLoggerAdapter{
+		log:  l.log,
+		args: append(l.args, args...),
+	}
+}
+
+// formatMessage converts a message and its arguments into a single string formatted as:
+// "msg arg0=arg1 arg2=arg3 ...".
+func formatMessage(msg string, args ...any) string {
+	result := msg
+	for i := 0; i < len(args); i += 2 {
+		if i+1 < len(args) {
+			if args[i] == "id" { // Use old id format.
+				result = "[" + fmt.Sprintf("%v", args[i+1]) + "] " + result
+			} else {
+				result += " " + fmt.Sprintf("%v=%v", args[i], args[i+1])
+			}
+		} else {
+			result += " " + fmt.Sprintf("%v", args[i])
+		}
+	}
+	return result
+}

--- a/log/martianlog/dial.go
+++ b/log/martianlog/dial.go
@@ -19,14 +19,14 @@ import (
 // It allows us to log the network and address of the connection being established together with the trace ID.
 func LoggingDialContext(dial func(context.Context, string, string) (net.Conn, error)) func(context.Context, string, string) (net.Conn, error) {
 	return func(ctx context.Context, network, address string) (conn net.Conn, err error) {
-		martianlog.Debugf(ctx, "opening connection to %s %s", network, address)
+		martianlog.Debug(ctx, "opening connection", "network", network, "address", address)
 
 		start := time.Now()
 		conn, err = dial(ctx, network, address)
 		if err != nil {
-			martianlog.Debugf(ctx, "failed to establish connection to %s %s duration=%s", network, address, time.Since(start))
+			martianlog.Debug(ctx, "failed to establish connection", "network", network, "address", address, "duration", time.Since(start))
 		} else {
-			martianlog.Debugf(ctx, "connection to %s %s established duration=%s", network, address, time.Since(start))
+			martianlog.Debug(ctx, "connection established", "network", network, "address", address, "duration", time.Since(start))
 		}
 
 		return

--- a/log/martianlog/martianlog.go
+++ b/log/martianlog/martianlog.go
@@ -7,34 +7,12 @@
 package martianlog
 
 import (
-	"context"
-
 	"github.com/saucelabs/forwarder/internal/martian"
 	martianlog "github.com/saucelabs/forwarder/internal/martian/log"
 	"github.com/saucelabs/forwarder/log"
 )
 
 func SetLogger(l log.Logger) {
-	martianlog.SetLogger(martian.TraceIDPrependingLogger{
-		Logger: contextLogger{l},
-	})
-}
-
-// contextLogger is a wrapper around log.Logger that implements the martian log.Logger interface.
-type contextLogger struct {
-	log.Logger
-}
-
-var _ martianlog.Logger = contextLogger{}
-
-func (l contextLogger) Errorf(_ context.Context, format string, args ...any) {
-	l.Logger.Errorf(format, args...)
-}
-
-func (l contextLogger) Infof(_ context.Context, format string, args ...any) {
-	l.Logger.Infof(format, args...)
-}
-
-func (l contextLogger) Debugf(_ context.Context, format string, args ...any) {
-	l.Logger.Debugf(format, args...)
+	sl := newStructuredLoggerAdapter(l)
+	martianlog.SetLogger(martian.TraceIDAppendingLogger{StructuredLogger: sl})
 }


### PR DESCRIPTION
We are working on introducing a new Sauce Labs logging policy.
This patch brings us a step closer by replacing internal logger interface with a structured one.