### PR TITLE
SC-5230: TLS certificate expiration monitoring

### DIFF
--- a/http_proxy.go
+++ b/http_proxy.go
@@ -282,7 +282,9 @@ func (hp *HTTPProxy) configureProxy() error {
 		}
 		registerMITMCacheMetrics(hp.config.PromRegistry, hp.config.PromNamespace+"_mitm_", mc.CacheMetrics)
 		hp.mitmCACert = mc.CACert()
-
+		if err := registerCertExpirationMetric(hp.config.PromConfig, hp.mitmCACert, "mitm"); err != nil {
+			return fmt.Errorf("report mitm cert expiration: %w", err)
+		}
 		hp.proxy.MITMConfig = mc
 
 		if hp.config.MITMDomains != nil {

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -172,6 +172,10 @@ func NewHTTPProxy(cfg *HTTPProxyConfig, pr PACResolver, cm *CredentialsMatcher, 
 		if err := hp.configureHTTPS(); err != nil {
 			return nil, err
 		}
+
+		if err := reportTLSCertsExpiration(hp.config.PromConfig, hp.tlsConfig, "proxy"); err != nil {
+			return nil, err
+		}
 	}
 
 	lh, err := hostsfile.LocalhostAliases()


### PR DESCRIPTION
This change adds a prometheus gauge metric `days_until_cert_expiring` that reports the number of days remaining until a TLS certificate expires. It includes a `cn` and `dns_names` labels to identify the certificate. This enables alerting and helps prevent outages due to expired certificates.








