### PR TITLE
martian: fix trace wrote response is called once per request

### DIFF
--- a/internal/martian/proxy_conn.go
+++ b/internal/martian/proxy_conn.go
@@ -242,7 +242,7 @@ func (p *proxyConn) handleConnectRequest(req *http.Request) error {
 		return p.writeErrorResponse(req, err)
 	}
 
-	if res.StatusCode != http.StatusOK {
+	if res.StatusCode/100 != 2 {
 		log.Infof(ctx, "CONNECT rejected with status code: %d", res.StatusCode)
 		return p.writeResponse(res)
 	}

--- a/internal/martian/proxy_conn.go
+++ b/internal/martian/proxy_conn.go
@@ -123,7 +123,7 @@ func (p *proxyConn) readRequest() (*http.Request, error) {
 		}
 	}
 
-	return req, err
+	return req, nil
 }
 
 func (p *proxyConn) handleMITM(req *http.Request) error {

--- a/internal/martian/proxy_handler.go
+++ b/internal/martian/proxy_handler.go
@@ -17,6 +17,7 @@
 package martian
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -147,6 +148,7 @@ func (p proxyHandler) handleUpgradeResponse(rw http.ResponseWriter, req *http.Re
 	uconn, ok := res.Body.(io.ReadWriteCloser)
 	if !ok {
 		log.Errorf(ctx, "%s tunnel: internal error: switching protocols response with non-ReadWriteCloser body", resUpType)
+		p.traceWroteResponse(res, errors.New("switching protocols response with non-writable body"))
 		panic(http.ErrAbortHandler)
 	}
 	res.Body = panicBody
@@ -394,5 +396,7 @@ func (p proxyHandler) writeResponse(rw http.ResponseWriter, res *http.Response) 
 		}
 	}
 
-	p.traceWroteResponse(res, err)
+	if !skipTraceWroteResponse(res, err) {
+		p.traceWroteResponse(res, err)
+	}
 }

--- a/internal/martian/proxy_handler.go
+++ b/internal/martian/proxy_handler.go
@@ -129,7 +129,7 @@ func (p proxyHandler) handleConnectRequest(rw http.ResponseWriter, req *http.Req
 		return
 	}
 
-	if res.StatusCode != http.StatusOK {
+	if res.StatusCode/100 != 2 {
 		log.Infof(ctx, "CONNECT rejected with status code: %d", res.StatusCode)
 		p.writeResponse(rw, res)
 		return

--- a/internal/martian/proxy_test.go
+++ b/internal/martian/proxy_test.go
@@ -2050,8 +2050,6 @@ func TestReadHeaderConnectionReset(t *testing.T) {
 func TestTunnelGracefulClose(t *testing.T) {
 	t.Parallel()
 
-	t.Skip("panic: close of closed channel, See #1013")
-
 	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatalf("net.Listen(): got %v, want no error", err)


### PR DESCRIPTION
traceWroteResponse would be called multiple times when handling CONNECT and protocol upgrade requests.
This patch assures there is exactly one call to wroteResponse per one call to readRequest.