### PR TITLE
martian: return to main handle loop after establishing mitm

### DIFF
--- a/internal/martian/proxy_conn.go
+++ b/internal/martian/proxy_conn.go
@@ -200,12 +200,12 @@ func (p *proxyConn) handleMITM(req *http.Request) error {
 		p.secure = true
 		p.cs = cs
 
-		return p.handle()
+		return nil
 	}
 
 	// Prepend the previously read data to be read again by http.ReadRequest.
 	p.brw.Reader.Reset(io.MultiReader(bytes.NewReader(buf), p.conn))
-	return p.handle()
+	return nil
 }
 
 func (p *proxyConn) handleConnectRequest(req *http.Request) error {


### PR DESCRIPTION
There is no need to invoke another handle function. Simply return to the main handle loop. This improves readiblity and reduces calls to handle() to 1.

<!-- Thank you for your hard work on this pull request! -->
