### PR TITLE
switch to structured logging

### DIFF
--- a/credentials_test.go
+++ b/credentials_test.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/saucelabs/forwarder/log/stdlog"
+	"github.com/saucelabs/forwarder/log/slog"
 )
 
 func TestUserInfoMatcherMatch(t *testing.T) {
@@ -70,7 +70,7 @@ func TestUserInfoMatcherMatch(t *testing.T) {
 				}
 			}
 
-			m, err := NewCredentialsMatcher(credentials, stdlog.Default())
+			m, err := NewCredentialsMatcher(credentials, slog.Default())
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -392,7 +392,7 @@ func (hp *HTTPProxy) middlewareStack() (martian.RequestResponseModifier, *martia
 	}
 
 	if hp.config.LogHTTPMode != httplog.None {
-		lf := httplog.NewLogger(hp.log.Info, hp.config.LogHTTPMode).LogFunc()
+		lf := httplog.NewStructuredLogger(hp.log.Info, hp.config.LogHTTPMode).LogFunc()
 		fg.AddResponseModifier(lf)
 	}
 

--- a/http_proxy_errors.go
+++ b/http_proxy_errors.go
@@ -66,7 +66,7 @@ func (hp *HTTPProxy) errorResponse(req *http.Request, err error) *http.Response 
 		}
 	}
 	if code == 0 {
-		hp.log.Debugf("error response: unexpected error type: %T", err)
+		hp.log.Debug("error response: unexpected error", "type", fmt.Sprintf("%T", err))
 		code = http.StatusInternalServerError
 		msg = "encountered an unexpected error"
 		label = "unexpected_error"

--- a/http_proxy_test.go
+++ b/http_proxy_test.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/saucelabs/forwarder/log/stdlog"
+	"github.com/saucelabs/forwarder/log/slog"
 	"golang.org/x/net/http2"
 )
 
@@ -26,7 +26,7 @@ func TestAbortIf(t *testing.T) {
 	cfg := DefaultHTTPProxyConfig()
 	cfg.BasicAuth = url.UserPassword("user", "pass")
 
-	p, err := NewHTTPProxy(cfg, nil, nil, nil, stdlog.Default())
+	p, err := NewHTTPProxy(cfg, nil, nil, nil, slog.Default())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +91,7 @@ func TestNopDialer(t *testing.T) {
 		},
 	}
 
-	p, err := NewHTTPProxy(DefaultHTTPProxyConfig(), nil, nil, tr, stdlog.Default())
+	p, err := NewHTTPProxy(DefaultHTTPProxyConfig(), nil, nil, tr, slog.Default())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestNopDialer(t *testing.T) {
 
 func TestIsLocalhost(t *testing.T) {
 	cfg := DefaultHTTPProxyConfig()
-	p, err := NewHTTPProxy(cfg, nil, nil, nil, stdlog.Default())
+	p, err := NewHTTPProxy(cfg, nil, nil, nil, slog.Default())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,7 +151,7 @@ func TestErrorResponse(t *testing.T) {
 	cfg := DefaultHTTPProxyConfig()
 	cfg.ProxyLocalhost = AllowProxyLocalhost
 
-	h, err := NewHTTPProxyHandler(cfg, nil, nil, nil, stdlog.Default())
+	h, err := NewHTTPProxyHandler(cfg, nil, nil, nil, slog.Default())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/http_server.go
+++ b/http_server.go
@@ -161,7 +161,7 @@ func withMiddleware(cfg *HTTPServerConfig, log log.StructuredLogger, h http.Hand
 
 	// Logger middleware must immediately follow the Prometheus middleware because it uses the Prometheus delegator.
 	if cfg.LogHTTPMode != httplog.None {
-		h = httplog.NewLogger(log.Info, cfg.LogHTTPMode).LogFunc().Wrap(h)
+		h = httplog.NewStructuredLogger(log.Info, cfg.LogHTTPMode).LogFunc().Wrap(h)
 	}
 
 	// Prometheus middleware must be the first one to be executed to collect metrics for all other middlewares.

--- a/internal/martian/log/log.go
+++ b/internal/martian/log/log.go
@@ -7,10 +7,10 @@ import (
 )
 
 type StructuredLogger interface {
-	Error(ctx context.Context, msg string, args ...any)
-	Warn(ctx context.Context, msg string, args ...any)
-	Info(ctx context.Context, msg string, args ...any)
-	Debug(ctx context.Context, msg string, args ...any)
+	ErrorContext(ctx context.Context, msg string, args ...any)
+	WarnContext(ctx context.Context, msg string, args ...any)
+	InfoContext(ctx context.Context, msg string, args ...any)
+	DebugContext(ctx context.Context, msg string, args ...any)
 
 	With(args ...any) StructuredLogger
 }
@@ -25,17 +25,17 @@ func SetLogger(l StructuredLogger) {
 }
 
 func Error(ctx context.Context, msg string, args ...any) {
-	log.Error(ctx, msg, args...)
+	log.ErrorContext(ctx, msg, args...)
 }
 
 func Warn(ctx context.Context, msg string, args ...any) {
-	log.Warn(ctx, msg, args...)
+	log.WarnContext(ctx, msg, args...)
 }
 
 func Info(ctx context.Context, msg string, args ...any) {
-	log.Info(ctx, msg, args...)
+	log.InfoContext(ctx, msg, args...)
 }
 
 func Debug(ctx context.Context, msg string, args ...any) {
-	log.Debug(ctx, msg, args...)
+	log.DebugContext(ctx, msg, args...)
 }

--- a/internal/martian/log/nop.go
+++ b/internal/martian/log/nop.go
@@ -10,9 +10,9 @@ type nopLogger struct{}
 
 var _ StructuredLogger = nopLogger{}
 
-func (nopLogger) Error(_ context.Context, _ string, _ ...any) {}
-func (nopLogger) Warn(_ context.Context, _ string, _ ...any)  {}
-func (nopLogger) Info(_ context.Context, _ string, _ ...any)  {}
-func (nopLogger) Debug(_ context.Context, _ string, _ ...any) {}
+func (nopLogger) ErrorContext(_ context.Context, _ string, _ ...any) {}
+func (nopLogger) WarnContext(_ context.Context, _ string, _ ...any)  {}
+func (nopLogger) InfoContext(_ context.Context, _ string, _ ...any)  {}
+func (nopLogger) DebugContext(_ context.Context, _ string, _ ...any) {}
 
 func (nopLogger) With(_ ...any) StructuredLogger { return nopLogger{} }

--- a/internal/martian/trace.go
+++ b/internal/martian/trace.go
@@ -44,27 +44,31 @@ func (t traceID) Duration() time.Duration {
 var _ log.StructuredLogger = TraceIDAppendingLogger{}
 
 type TraceIDAppendingLogger struct {
-	log.StructuredLogger
+	sl log.StructuredLogger
 }
 
-func (l TraceIDAppendingLogger) Error(ctx context.Context, msg string, args ...any) {
-	l.StructuredLogger.Error(ctx, msg, l.args(ctx, args...)...)
+func NewTraceIDAppendingLogger(sl log.StructuredLogger) TraceIDAppendingLogger {
+	return TraceIDAppendingLogger{sl: sl}
 }
 
-func (l TraceIDAppendingLogger) Warn(ctx context.Context, msg string, args ...any) {
-	l.StructuredLogger.Warn(ctx, msg, l.args(ctx, args...)...)
+func (l TraceIDAppendingLogger) ErrorContext(ctx context.Context, msg string, args ...any) {
+	l.sl.ErrorContext(ctx, msg, l.args(ctx, args...)...)
 }
 
-func (l TraceIDAppendingLogger) Info(ctx context.Context, msg string, args ...any) {
-	l.StructuredLogger.Info(ctx, msg, l.args(ctx, args...)...)
+func (l TraceIDAppendingLogger) WarnContext(ctx context.Context, msg string, args ...any) {
+	l.sl.WarnContext(ctx, msg, l.args(ctx, args...)...)
 }
 
-func (l TraceIDAppendingLogger) Debug(ctx context.Context, msg string, args ...any) {
-	l.StructuredLogger.Debug(ctx, msg, l.args(ctx, args...)...)
+func (l TraceIDAppendingLogger) InfoContext(ctx context.Context, msg string, args ...any) {
+	l.sl.InfoContext(ctx, msg, l.args(ctx, args...)...)
+}
+
+func (l TraceIDAppendingLogger) DebugContext(ctx context.Context, msg string, args ...any) {
+	l.sl.DebugContext(ctx, msg, l.args(ctx, args...)...)
 }
 
 func (l TraceIDAppendingLogger) With(args ...any) log.StructuredLogger {
-	return TraceIDAppendingLogger{l.StructuredLogger.With(args...)}
+	return TraceIDAppendingLogger{l.sl.With(args...)}
 }
 
 func (l TraceIDAppendingLogger) args(ctx context.Context, args ...any) []any {

--- a/log/adapter.go
+++ b/log/adapter.go
@@ -1,0 +1,78 @@
+// Copyright 2022-2024 Sauce Labs Inc., all rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package log
+
+import (
+	"context"
+	"fmt"
+)
+
+func NewStructuredLoggerAdapter(log Logger) *StructuredLoggerAdapter {
+	return &StructuredLoggerAdapter{log: log}
+}
+
+type StructuredLoggerAdapter struct {
+	log  Logger
+	args []any
+}
+
+func (l *StructuredLoggerAdapter) Error(msg string, args ...any) {
+	l.log.Errorf("%s", formatMessage(msg, append(l.args, args...)...))
+}
+
+func (l *StructuredLoggerAdapter) Warn(msg string, args ...any) {
+	l.log.Infof("[WARN] %s", formatMessage(msg, append(l.args, args...)...))
+}
+
+func (l *StructuredLoggerAdapter) Info(msg string, args ...any) {
+	l.log.Infof("%s", formatMessage(msg, append(l.args, args...)...))
+}
+
+func (l *StructuredLoggerAdapter) Debug(msg string, args ...any) {
+	l.log.Debugf("%s", formatMessage(msg, append(l.args, args...)...))
+}
+
+func (l *StructuredLoggerAdapter) ErrorContext(_ context.Context, msg string, args ...any) {
+	l.log.Errorf("%s", formatMessage(msg, append(l.args, args...)...))
+}
+
+func (l *StructuredLoggerAdapter) WarnContext(_ context.Context, msg string, args ...any) {
+	l.log.Infof("[WARN] %s", formatMessage(msg, append(l.args, args...)...))
+}
+
+func (l *StructuredLoggerAdapter) InfoContext(_ context.Context, msg string, args ...any) {
+	l.log.Infof("%s", formatMessage(msg, append(l.args, args...)...))
+}
+
+func (l *StructuredLoggerAdapter) DebugContext(_ context.Context, msg string, args ...any) {
+	l.log.Debugf("%s", formatMessage(msg, append(l.args, args...)...))
+}
+
+func (l *StructuredLoggerAdapter) With(args ...any) StructuredLogger {
+	return &StructuredLoggerAdapter{
+		log:  l.log,
+		args: append(l.args, args...),
+	}
+}
+
+// formatMessage converts a message and its arguments into a single string formatted as:
+// "msg arg0=arg1 arg2=arg3 ...".
+func formatMessage(msg string, args ...any) string {
+	result := msg
+	for i := 0; i < len(args); i += 2 {
+		if i+1 < len(args) {
+			if args[i] == "id" { // Use old id format.
+				result = "[" + fmt.Sprintf("%v", args[i+1]) + "] " + result
+			} else {
+				result += " " + fmt.Sprintf("%v=%v", args[i], args[i+1])
+			}
+		} else {
+			result += " " + fmt.Sprintf("%v", args[i])
+		}
+	}
+	return result
+}

--- a/log/level.go
+++ b/log/level.go
@@ -6,14 +6,16 @@
 
 package log
 
-type Level int32
+type Level int
 
+// Levels start from 1 to avoid zero value in help printer.
 const (
 	ErrorLevel Level = 1 + iota
+	WarnLevel
 	InfoLevel
 	DebugLevel
 )
 
 func (l Level) String() string {
-	return [3]string{"error", "info", "debug"}[l-1]
+	return [4]string{"error", "warn", "info", "debug"}[l-1]
 }

--- a/log/log.go
+++ b/log/log.go
@@ -33,20 +33,6 @@ type StructuredLogger interface {
 	With(args ...any) StructuredLogger
 }
 
-// NopLogger is a logger that does nothing.
-var NopLogger = nopLogger{} //nolint:gochecknoglobals // nop implementation
-
-type nopLogger struct{}
-
-func (l nopLogger) Errorf(_ string, _ ...any) {
-}
-
-func (l nopLogger) Infof(_ string, _ ...any) {
-}
-
-func (l nopLogger) Debugf(_ string, _ ...any) {
-}
-
 var (
 	DefaultFileFlags = os.O_CREATE | os.O_APPEND | os.O_WRONLY
 

--- a/log/log.go
+++ b/log/log.go
@@ -7,6 +7,7 @@
 package log
 
 import (
+	"context"
 	"os"
 )
 
@@ -15,6 +16,21 @@ type Logger interface {
 	Errorf(format string, args ...any)
 	Infof(format string, args ...any)
 	Debugf(format string, args ...any)
+}
+
+// StructuredLogger is the preferred logging interface.
+type StructuredLogger interface {
+	Error(msg string, args ...any)
+	Warn(msg string, args ...any)
+	Info(msg string, args ...any)
+	Debug(msg string, args ...any)
+
+	ErrorContext(ctx context.Context, msg string, args ...any)
+	WarnContext(ctx context.Context, msg string, args ...any)
+	InfoContext(ctx context.Context, msg string, args ...any)
+	DebugContext(ctx context.Context, msg string, args ...any)
+
+	With(args ...any) StructuredLogger
 }
 
 // NopLogger is a logger that does nothing.

--- a/log/martianlog/adapter.go
+++ b/log/martianlog/adapter.go
@@ -7,59 +7,19 @@
 package martianlog
 
 import (
-	"context"
-	"fmt"
-
 	martianlog "github.com/saucelabs/forwarder/internal/martian/log"
 	"github.com/saucelabs/forwarder/log"
 )
 
-func newStructuredLoggerAdapter(log log.Logger) *structuredLoggerAdapter {
-	return &structuredLoggerAdapter{log: log}
+func newStructuredLoggerAdapter(log log.StructuredLogger) *structuredLoggerAdapter {
+	return &structuredLoggerAdapter{log}
 }
 
 type structuredLoggerAdapter struct {
-	log  log.Logger
-	args []any
-}
-
-func (l *structuredLoggerAdapter) ErrorContext(_ context.Context, msg string, args ...any) {
-	l.log.Errorf("%s", formatMessage(msg, append(l.args, args...)...))
-}
-
-func (l *structuredLoggerAdapter) WarnContext(_ context.Context, msg string, args ...any) {
-	l.log.Infof("[WARN] %s", formatMessage(msg, append(l.args, args...)...))
-}
-
-func (l *structuredLoggerAdapter) InfoContext(_ context.Context, msg string, args ...any) {
-	l.log.Infof("%s", formatMessage(msg, append(l.args, args...)...))
-}
-
-func (l *structuredLoggerAdapter) DebugContext(_ context.Context, msg string, args ...any) {
-	l.log.Debugf("%s", formatMessage(msg, append(l.args, args...)...))
+	log.StructuredLogger
 }
 
 func (l *structuredLoggerAdapter) With(args ...any) martianlog.StructuredLogger {
-	return &structuredLoggerAdapter{
-		log:  l.log,
-		args: append(l.args, args...),
-	}
-}
-
-// formatMessage converts a message and its arguments into a single string formatted as:
-// "msg arg0=arg1 arg2=arg3 ...".
-func formatMessage(msg string, args ...any) string {
-	result := msg
-	for i := 0; i < len(args); i += 2 {
-		if i+1 < len(args) {
-			if args[i] == "id" { // Use old id format.
-				result = "[" + fmt.Sprintf("%v", args[i+1]) + "] " + result
-			} else {
-				result += " " + fmt.Sprintf("%v=%v", args[i], args[i+1])
-			}
-		} else {
-			result += " " + fmt.Sprintf("%v", args[i])
-		}
-	}
-	return result
+	slog := l.StructuredLogger.With(args...)
+	return &structuredLoggerAdapter{slog}
 }

--- a/log/martianlog/adapter.go
+++ b/log/martianlog/adapter.go
@@ -23,19 +23,19 @@ type structuredLoggerAdapter struct {
 	args []any
 }
 
-func (l *structuredLoggerAdapter) Error(_ context.Context, msg string, args ...any) {
+func (l *structuredLoggerAdapter) ErrorContext(_ context.Context, msg string, args ...any) {
 	l.log.Errorf("%s", formatMessage(msg, append(l.args, args...)...))
 }
 
-func (l *structuredLoggerAdapter) Warn(_ context.Context, msg string, args ...any) {
+func (l *structuredLoggerAdapter) WarnContext(_ context.Context, msg string, args ...any) {
 	l.log.Infof("[WARN] %s", formatMessage(msg, append(l.args, args...)...))
 }
 
-func (l *structuredLoggerAdapter) Info(_ context.Context, msg string, args ...any) {
+func (l *structuredLoggerAdapter) InfoContext(_ context.Context, msg string, args ...any) {
 	l.log.Infof("%s", formatMessage(msg, append(l.args, args...)...))
 }
 
-func (l *structuredLoggerAdapter) Debug(_ context.Context, msg string, args ...any) {
+func (l *structuredLoggerAdapter) DebugContext(_ context.Context, msg string, args ...any) {
 	l.log.Debugf("%s", formatMessage(msg, append(l.args, args...)...))
 }
 

--- a/log/martianlog/martianlog.go
+++ b/log/martianlog/martianlog.go
@@ -12,7 +12,7 @@ import (
 	"github.com/saucelabs/forwarder/log"
 )
 
-func SetLogger(l log.Logger) {
+func SetLogger(l log.StructuredLogger) {
 	sl := newStructuredLoggerAdapter(l)
 	tl := martian.NewTraceIDAppendingLogger(sl)
 	martianlog.SetLogger(tl)

--- a/log/martianlog/martianlog.go
+++ b/log/martianlog/martianlog.go
@@ -14,5 +14,6 @@ import (
 
 func SetLogger(l log.Logger) {
 	sl := newStructuredLoggerAdapter(l)
-	martianlog.SetLogger(martian.TraceIDAppendingLogger{StructuredLogger: sl})
+	tl := martian.NewTraceIDAppendingLogger(sl)
+	martianlog.SetLogger(tl)
 }

--- a/log/nop.go
+++ b/log/nop.go
@@ -1,0 +1,37 @@
+// Copyright 2022-2024 Sauce Labs Inc., all rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package log
+
+import (
+	"context"
+)
+
+// NopLogger is a logger that does nothing.
+var NopLogger = nopLogger{} //nolint:gochecknoglobals // nop implementation
+
+var (
+	_ Logger           = &nopLogger{}
+	_ StructuredLogger = &nopLogger{}
+)
+
+type nopLogger struct{}
+
+func (l nopLogger) Errorf(_ string, _ ...any) {}
+func (l nopLogger) Infof(_ string, _ ...any)  {}
+func (l nopLogger) Debugf(_ string, _ ...any) {}
+
+func (l nopLogger) Error(_ string, _ ...any) {}
+func (l nopLogger) Warn(_ string, _ ...any)  {}
+func (l nopLogger) Info(_ string, _ ...any)  {}
+func (l nopLogger) Debug(_ string, _ ...any) {}
+
+func (l nopLogger) ErrorContext(_ context.Context, _ string, _ ...any) {}
+func (l nopLogger) WarnContext(_ context.Context, _ string, _ ...any)  {}
+func (l nopLogger) InfoContext(_ context.Context, _ string, _ ...any)  {}
+func (l nopLogger) DebugContext(_ context.Context, _ string, _ ...any) {}
+
+func (l nopLogger) With(_ ...any) StructuredLogger { return l }

--- a/log/slog/opts.go
+++ b/log/slog/opts.go
@@ -1,0 +1,14 @@
+// Copyright 2022-2024 Sauce Labs Inc., all rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package slog
+
+// WithOnError allows to set a function that is called when an error is logged.
+func WithOnError(f func(name string)) Option {
+	return func(l *Logger) {
+		l.onError = f
+	}
+}

--- a/log/slog/slog.go
+++ b/log/slog/slog.go
@@ -1,0 +1,155 @@
+// Copyright 2022-2024 Sauce Labs Inc., all rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package slog
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+
+	flog "github.com/saucelabs/forwarder/log"
+)
+
+func Default() *Logger {
+	return New(flog.DefaultConfig())
+}
+
+func Debug() *Logger {
+	return New(&flog.Config{Level: flog.DebugLevel})
+}
+
+var _ flog.StructuredLogger = &Logger{}
+
+type Option func(*Logger)
+
+type Logger struct {
+	log     *slog.Logger
+	file    *flog.RotatableFile
+	name    string
+	onError func(name string)
+}
+
+func New(cfg *flog.Config, opts ...Option) *Logger {
+	var w io.Writer = os.Stdout
+
+	var f *flog.RotatableFile
+	if cfg.File != nil {
+		f = flog.NewRotatableFile(cfg.File)
+		w = f
+	}
+
+	hops := &slog.HandlerOptions{Level: flogToSlogLevel(cfg.Level), ReplaceAttr: replaceSLAttr}
+	handler := slog.NewJSONHandler(w, hops)
+	logger := slog.New(handler)
+
+	l := &Logger{
+		log:  logger,
+		file: f,
+	}
+	for _, opt := range opts {
+		opt(l)
+	}
+
+	return l
+}
+
+func (l *Logger) Handler() slog.Handler {
+	return l.log.Handler()
+}
+
+func (l *Logger) Error(msg string, args ...any) {
+	if l.onError != nil {
+		l.onError(l.name)
+	}
+	l.log.Error(msg, args...)
+}
+
+func (l *Logger) ErrorContext(ctx context.Context, msg string, args ...any) {
+	if l.onError != nil {
+		l.onError(l.name)
+	}
+	l.log.ErrorContext(ctx, msg, args...)
+}
+
+func (l *Logger) Warn(msg string, args ...any) {
+	l.log.Warn(msg, args...)
+}
+
+func (l *Logger) WarnContext(ctx context.Context, msg string, args ...any) {
+	l.log.WarnContext(ctx, msg, args...)
+}
+
+func (l *Logger) Info(msg string, args ...any) {
+	l.log.Info(msg, args...)
+}
+
+func (l *Logger) InfoContext(ctx context.Context, msg string, args ...any) {
+	l.log.InfoContext(ctx, msg, args...)
+}
+
+func (l *Logger) Debug(msg string, args ...any) {
+	l.log.Debug(msg, args...)
+}
+
+func (l *Logger) DebugContext(ctx context.Context, msg string, args ...any) {
+	l.log.DebugContext(ctx, msg, args...)
+}
+
+func (l *Logger) With(args ...any) flog.StructuredLogger {
+	c := *l
+	c.log = c.log.With(args...)
+	return &c
+}
+
+func (l *Logger) Named(name string) flog.StructuredLogger {
+	c := *l
+	c.name = name
+	c.log = c.log.With("name", name)
+	return &c
+}
+
+func (l *Logger) Reopen() error {
+	if l.file == nil {
+		return nil
+	}
+	return l.file.Reopen()
+}
+
+func (l *Logger) Close() error {
+	if l.file == nil {
+		return nil
+	}
+	return l.file.Close()
+}
+
+func flogToSlogLevel(level flog.Level) slog.Level {
+	switch level {
+	case flog.ErrorLevel:
+		return slog.LevelError
+	case flog.WarnLevel:
+		return slog.LevelWarn
+	case flog.InfoLevel:
+		return slog.LevelInfo
+	case flog.DebugLevel:
+		return slog.LevelDebug
+	default:
+		return slog.Level(level)
+	}
+}
+
+func replaceSLAttr(_ []string, a slog.Attr) slog.Attr {
+	switch a.Key {
+	case slog.TimeKey:
+		a.Key = "timestamp"
+	case slog.LevelKey:
+		a.Key = "severity"
+	case slog.MessageKey:
+		a.Key = "message"
+	}
+	return a
+}

--- a/pac.go
+++ b/pac.go
@@ -20,15 +20,15 @@ type PACResolver interface {
 
 type LoggingPACResolver struct {
 	Resolver PACResolver
-	Logger   log.Logger
+	Logger   log.StructuredLogger
 }
 
 func (r *LoggingPACResolver) FindProxyForURL(u *url.URL, hostname string) (string, error) {
 	s, err := r.Resolver.FindProxyForURL(u, hostname)
 	if err != nil {
-		r.Logger.Errorf("FindProxyForURL(%q, %q) failed: %s", u.Redacted(), hostname, err)
+		r.Logger.Error("FindProxyForURL failed", "url", u.Redacted(), "hostname", hostname, "error", err)
 	} else {
-		r.Logger.Debugf("FindProxyForURL(%q, %q) -> %q", u.Redacted(), hostname, s)
+		r.Logger.Debug("FindProxyForURL", "url", u.Redacted(), "hostname", hostname, "result", s)
 	}
 	return s, err
 }


### PR DESCRIPTION
This patch transitions forwarder logging to a structured one. 
So far there is only `json` mode for production usage, but there will shortly be a `text` mode, that is more human friendly.

This brakes compatibility, so we provided adapter that takes old logger interface and produces a structured one (see `forwarder/log.StrucuredLoggerAdapter`).