### PR TITLE
utils/cobrautil: add OneLine format 

### DIFF
--- a/command/pac/server/server.go
+++ b/command/pac/server/server.go
@@ -50,21 +50,23 @@ func (c *command) runE(cmd *cobra.Command, _ []string) (cmdErr error) {
 	}()
 
 	{
-		var args map[string]any
+		var cfg []byte
 
-		args = cobrautil.FlagsDescriber{
-			Format:          cobrautil.JSON,
+		//nolint:errcheck // OneLine never fails.
+		cfg, _ = cobrautil.FlagsDescriber{
+			Format:          cobrautil.OneLine,
 			ShowChangedOnly: true,
 			ShowHidden:      true,
-		}.DescribeFlagsToMap(cmd.Flags())
-		logger.Info("configuration", "args", args)
+		}.DescribeFlags(cmd.Flags())
+		logger.Info("configuration: " + string(cfg))
 
-		args = cobrautil.FlagsDescriber{
-			Format:          cobrautil.JSON,
+		//nolint:errcheck // OneLine never fails.
+		cfg, _ = cobrautil.FlagsDescriber{
+			Format:          cobrautil.OneLine,
 			ShowChangedOnly: false,
 			ShowHidden:      true,
-		}.DescribeFlagsToMap(cmd.Flags())
-		logger.Debug("all configuration", "cfg", args)
+		}.DescribeFlags(cmd.Flags())
+		logger.Debug("all configuration: " + string(cfg))
 	}
 
 	if len(c.dnsConfig.Servers) > 0 {

--- a/command/run/run.go
+++ b/command/run/run.go
@@ -90,34 +90,34 @@ func (c *command) runE(cmd *cobra.Command, _ []string) (cmdErr error) {
 	var ep []forwarder.APIEndpoint
 
 	{
-		var args map[string]any
+		var cfg []byte
 
-		args = cobrautil.FlagsDescriber{
-			Format:          cobrautil.JSON,
+		//nolint:errcheck // OneLine never fails.
+		cfg, _ = cobrautil.FlagsDescriber{
+			Format:          cobrautil.OneLine,
 			ShowChangedOnly: true,
 			ShowHidden:      true,
-		}.DescribeFlagsToMap(cmd.Flags())
-		if len(args) > 0 {
-			logger.Info("configuration", "args", args)
+		}.DescribeFlags(cmd.Flags())
+		if len(cfg) > 0 {
+			logger.Info("configuration: " + string(cfg))
 		} else {
 			logger.Info("using default configuration")
 		}
 
-		args = cobrautil.FlagsDescriber{
-			Format:          cobrautil.JSON,
+		//nolint:errcheck // OneLine never fails.
+		cfg, _ = cobrautil.FlagsDescriber{
+			Format:          cobrautil.OneLine,
 			ShowChangedOnly: false,
 			ShowHidden:      true,
-		}.DescribeFlagsToMap(cmd.Flags())
-		logger.Debug("all configuration", "cfg", args)
+		}.DescribeFlags(cmd.Flags())
+		logger.Debug("all configuration: " + string(cfg))
 
-		cfg, err := cobrautil.FlagsDescriber{
+		//nolint:errcheck // Plain never fails.
+		cfg, _ = cobrautil.FlagsDescriber{
 			Format:          cobrautil.Plain,
 			ShowChangedOnly: false,
 			ShowHidden:      true,
 		}.DescribeFlags(cmd.Flags())
-		if err != nil {
-			return err
-		}
 		ep = append(ep, forwarder.APIEndpoint{
 			Path:    "/configz",
 			Handler: httphandler.SendFile("text/plain", cfg),

--- a/command/test/grpc/grpc.go
+++ b/command/test/grpc/grpc.go
@@ -53,21 +53,23 @@ func (c *command) runE(cmd *cobra.Command, _ []string) (cmdErr error) {
 	}()
 
 	{
-		var args map[string]any
+		var cfg []byte
 
-		args = cobrautil.FlagsDescriber{
-			Format:          cobrautil.JSON,
+		//nolint:errcheck // OneLine never fails.
+		cfg, _ = cobrautil.FlagsDescriber{
+			Format:          cobrautil.OneLine,
 			ShowChangedOnly: true,
 			ShowHidden:      true,
-		}.DescribeFlagsToMap(cmd.Flags())
-		logger.Info("configuration", "args", args)
+		}.DescribeFlags(cmd.Flags())
+		logger.Info("configuration: " + string(cfg))
 
-		args = cobrautil.FlagsDescriber{
-			Format:          cobrautil.JSON,
+		//nolint:errcheck // OneLine never fails.
+		cfg, _ = cobrautil.FlagsDescriber{
+			Format:          cobrautil.OneLine,
 			ShowChangedOnly: false,
 			ShowHidden:      true,
-		}.DescribeFlagsToMap(cmd.Flags())
-		logger.Debug("all configuration", "cfg", args)
+		}.DescribeFlags(cmd.Flags())
+		logger.Debug("all configuration: " + string(cfg))
 	}
 
 	g := runctx.NewGroup()

--- a/command/test/httpbin/httpbin.go
+++ b/command/test/httpbin/httpbin.go
@@ -48,21 +48,23 @@ func (c *command) runE(cmd *cobra.Command, _ []string) (cmdErr error) {
 	}()
 
 	{
-		var args map[string]any
+		var cfg []byte
 
-		args = cobrautil.FlagsDescriber{
-			Format:          cobrautil.JSON,
+		//nolint:errcheck // OneLine never fails.
+		cfg, _ = cobrautil.FlagsDescriber{
+			Format:          cobrautil.OneLine,
 			ShowChangedOnly: true,
 			ShowHidden:      true,
-		}.DescribeFlagsToMap(cmd.Flags())
-		logger.Info("configuration", "args", args)
+		}.DescribeFlags(cmd.Flags())
+		logger.Info("configuration: " + string(cfg))
 
-		args = cobrautil.FlagsDescriber{
-			Format:          cobrautil.JSON,
+		//nolint:errcheck // OneLine never fails.
+		cfg, _ = cobrautil.FlagsDescriber{
+			Format:          cobrautil.OneLine,
 			ShowChangedOnly: false,
 			ShowHidden:      true,
-		}.DescribeFlagsToMap(cmd.Flags())
-		logger.Debug("all configuration", "cfg", args)
+		}.DescribeFlags(cmd.Flags())
+		logger.Debug("all configuration: " + string(cfg))
 	}
 
 	g := runctx.NewGroup()

--- a/utils/cobrautil/describe.go
+++ b/utils/cobrautil/describe.go
@@ -25,6 +25,7 @@ const (
 	Plain DescribeFormat = iota
 	JSON
 	YAML
+	OneLine
 )
 
 type FlagsDescriber struct {
@@ -57,6 +58,17 @@ func (d FlagsDescriber) DescribeFlags(fs *pflag.FlagSet) ([]byte, error) {
 		}
 		if err := enc.Close(); err != nil {
 			return nil, err
+		}
+		return buf.Bytes(), nil
+	case OneLine:
+		keys := maps.Keys(args)
+		sort.Strings(keys)
+		var buf bytes.Buffer
+		for i, name := range keys {
+			if i > 0 {
+				buf.WriteString(", ")
+			}
+			buf.WriteString(fmt.Sprintf("%s=%s", name, args[name]))
 		}
 		return buf.Bytes(), nil
 	default:


### PR DESCRIPTION
<!-- Thank you for your hard work on this pull request! -->
This fits better with the structured log.
```
message="configuration: dns-server=[1.1.1.1:53 8.8.8.8:53], log-level=debug"
```
```
message="all configuration: address=:3128, api-address=localhost:10000, api-basic-auth=, api-idle-timeout=1h0m0s, api-read-header-timeout=1m0s, api-read-limit=0, api-shutdown-timeout=30s, api-write-limit=0, basic-auth=, cacert-file=[], config-file=, connect-header=[], connect-to=[], credentials=[], deny-domains=[], direct-domains=[], dns-round-robin=false, dns-server=[1.1.1.1:53 8.8.8.8:53], dns-timeout=5s, goleak=false, header=[], http-dial-attempts=3, http-dial-backoff=1s, http-dial-timeout=25s, http-idle-conn-timeout=1m30s, http-response-header-timeout=0s, http-tls-handshake-timeout=10s, http-tls-keylog-file=, idle-timeout=1h0m0s, insecure=false, log-file=, log-format=text, log-http=[api:errors proxy:errors], log-http-request-id-header=X-Request-Id, log-level=debug, mitm=false, mitm-cacert-file=, mitm-cache-size=1024, mitm-cache-ttl=6h0m0s, mitm-cakey-file=, mitm-domains=[], mitm-org=Forwarder Proxy MITM, mitm-validity=24h0m0s, name=forwarder, pac=, protocol=http, proxy=, proxy-header=[], proxy-localhost=deny, proxy-protocol-listener=false, proxy-protocol-read-header-timeout=5s, read-header-timeout=1m0s, read-limit=0, response-header=[], shutdown-timeout=30s, tls-cert-file=, tls-handshake-timeout=10s, tls-key-file=, write-limit=0"
```