### PR TITLE
log/slog: rename log name attribute from "name" to "module"

### DIFF
--- a/command/pac/server/server.go
+++ b/command/pac/server/server.go
@@ -71,7 +71,7 @@ func (c *command) runE(cmd *cobra.Command, _ []string) (cmdErr error) {
 
 	if len(c.dnsConfig.Servers) > 0 {
 		s := strings.ReplaceAll(fmt.Sprintf("%s", c.dnsConfig.Servers), " ", ", ")
-		logger.With("name", "dns").Info("using DNS servers", "servers", s)
+		logger.Named("dns").Info("using DNS servers", "servers", s)
 		if err := c.dnsConfig.Apply(); err != nil {
 			return fmt.Errorf("configure DNS: %w", err)
 		}
@@ -90,7 +90,7 @@ func (c *command) runE(cmd *cobra.Command, _ []string) (cmdErr error) {
 		return err
 	}
 
-	s, err := forwarder.NewHTTPServer(c.httpServerConfig, servePAC(script), logger.With("name", "server"))
+	s, err := forwarder.NewHTTPServer(c.httpServerConfig, servePAC(script), logger.Named("server"))
 	if err != nil {
 		return err
 	}

--- a/command/run/run.go
+++ b/command/run/run.go
@@ -128,7 +128,7 @@ func (c *command) runE(cmd *cobra.Command, _ []string) (cmdErr error) {
 
 	if len(c.dnsConfig.Servers) > 0 {
 		s := strings.ReplaceAll(fmt.Sprintf("%s", c.dnsConfig.Servers), " ", ", ")
-		logger.With("name", "dns").Info("using DNS servers", "servers", s)
+		logger.Named("dns").Info("using DNS servers", "servers", s)
 		if err := c.dnsConfig.Apply(); err != nil {
 			return fmt.Errorf("configure dns: %w", err)
 		}
@@ -165,7 +165,7 @@ func (c *command) runE(cmd *cobra.Command, _ []string) (cmdErr error) {
 		}
 		pr = &forwarder.LoggingPACResolver{
 			Resolver: pr,
-			Logger:   logger.With("name", "pac"),
+			Logger:   logger.Named("pac"),
 		}
 
 		ep = append(ep, forwarder.APIEndpoint{
@@ -174,7 +174,7 @@ func (c *command) runE(cmd *cobra.Command, _ []string) (cmdErr error) {
 		})
 	}
 
-	cm, err := forwarder.NewCredentialsMatcher(c.credentials, logger.With("name", "credentials"))
+	cm, err := forwarder.NewCredentialsMatcher(c.credentials, logger.Named("credentials"))
 	if err != nil {
 		return fmt.Errorf("credentials: %w", err)
 	}
@@ -222,7 +222,7 @@ func (c *command) runE(cmd *cobra.Command, _ []string) (cmdErr error) {
 		rt.DialContext = martianlog.LoggingDialContext(rt.DialContext)
 		c.transportWithProxyConnectHeader(rt)
 
-		p, err := forwarder.NewHTTPProxy(c.httpProxyConfig, pr, cm, rt, logger.With("name", "proxy"))
+		p, err := forwarder.NewHTTPProxy(c.httpProxyConfig, pr, cm, rt, logger.Named("proxy"))
 		if err != nil {
 			return err
 		}
@@ -261,13 +261,13 @@ func (c *command) runE(cmd *cobra.Command, _ []string) (cmdErr error) {
 
 		if os.Getenv("PLATFORM") == "container" {
 			g.Add(func(ctx context.Context) error {
-				logger.With("name", "api").Info("HTTP server listen", "socket", forwarder.APIUnixSocket)
+				logger.Named("api").Info("HTTP server listen", "socket", forwarder.APIUnixSocket)
 				return httpx.ServeUnixSocket(ctx, h, forwarder.APIUnixSocket)
 			})
 		}
 
 		if c.apiServerConfig.Address != "" {
-			a, err := forwarder.NewHTTPServer(c.apiServerConfig, h, logger.With("name", "api"))
+			a, err := forwarder.NewHTTPServer(c.apiServerConfig, h, logger.Named("api"))
 			if err != nil {
 				return err
 			}

--- a/command/test/httpbin/httpbin.go
+++ b/command/test/httpbin/httpbin.go
@@ -69,7 +69,7 @@ func (c *command) runE(cmd *cobra.Command, _ []string) (cmdErr error) {
 
 	g := runctx.NewGroup()
 
-	s, err := forwarder.NewHTTPServer(c.httpServerConfig, httpbin.Handler(), logger.With("name", "server"))
+	s, err := forwarder.NewHTTPServer(c.httpServerConfig, httpbin.Handler(), logger.Named("server"))
 	if err != nil {
 		return err
 	}
@@ -77,7 +77,7 @@ func (c *command) runE(cmd *cobra.Command, _ []string) (cmdErr error) {
 	g.Add(s.Run)
 
 	g.Add(func(ctx context.Context) error {
-		logger.With("name", "api").Info("HTTP server listen", "socket", forwarder.APIUnixSocket)
+		logger.Named("api").Info("HTTP server listen", "socket", forwarder.APIUnixSocket)
 		r := prometheus.NewRegistry()
 		h := forwarder.NewAPIHandler("HTTPBin "+version.Version, r, nil)
 		return httpx.ServeUnixSocket(ctx, h, forwarder.APIUnixSocket)

--- a/log/slog/slog.go
+++ b/log/slog/slog.go
@@ -114,7 +114,7 @@ func (l *Logger) With(args ...any) flog.StructuredLogger {
 func (l *Logger) Named(name string) *Logger {
 	c := *l
 	c.name = name
-	c.log = c.log.With("name", name)
+	c.log = c.log.With("module", name)
 	return &c
 }
 


### PR DESCRIPTION
<!-- Thank you for your hard work on this pull request! -->
It's not entirely clear what the name attribute refers to.
In my opinion, log would be a better fit—it clearly indicates that it's related to the application's logging module.