### PR TITLE
log/slog: do not use custom sl attribute names

### DIFF
--- a/log/slog/slog.go
+++ b/log/slog/slog.go
@@ -43,7 +43,7 @@ func New(cfg *flog.Config, opts ...Option) *Logger {
 		w = f
 	}
 
-	hops := &slog.HandlerOptions{Level: flogToSlogLevel(cfg.Level), ReplaceAttr: replaceSLAttr}
+	hops := &slog.HandlerOptions{Level: flogToSlogLevel(cfg.Level)}
 	var handler slog.Handler
 	if cfg.Format == flog.JSONFormat {
 		handler = slog.NewJSONHandler(w, hops)
@@ -145,16 +145,4 @@ func flogToSlogLevel(level flog.Level) slog.Level {
 	default:
 		return slog.Level(level)
 	}
-}
-
-func replaceSLAttr(_ []string, a slog.Attr) slog.Attr {
-	switch a.Key {
-	case slog.TimeKey:
-		a.Key = "timestamp"
-	case slog.LevelKey:
-		a.Key = "severity"
-	case slog.MessageKey:
-		a.Key = "message"
-	}
-	return a
 }


### PR DESCRIPTION
It should be made configurable, not hard-coded. Removing for now.

That makes the logs look less heavy:
```
time=2025-07-01T15:44:38.159+02:00 level=INFO msg=Forwarder version=Unknown commit=Unknown
time=2025-07-01T15:44:38.159+02:00 level=INFO msg="using default configuration"
time=2025-07-01T15:44:38.159+02:00 level=INFO msg="no upstream proxy specified" module=proxy
time=2025-07-01T15:44:38.159+02:00 level=INFO msg="proxy localhost" module=proxy mode=deny
time=2025-07-01T15:44:38.160+02:00 level=INFO msg="PROXY server listen" module=proxy address=[::]:3128 protocol=http
time=2025-07-01T15:44:38.163+02:00 level=INFO msg="HTTP server listen" module=api address=127.0.0.1:10000 protocol=http
```