### PR TITLE
log: support logging source code file and line

### DIFF
--- a/bind/flag.go
+++ b/bind/flag.go
@@ -452,6 +452,9 @@ func LogConfig(fs *pflag.FlagSet, cfg *log.Config) {
 	fs.Var(anyflag.NewValue[log.Format](cfg.Format, &cfg.Format, anyflag.EnumParser[log.Format](logMode...)),
 		"log-format", "<text, json>"+
 			"Use json for production workload logs and text for more human-readable output.")
+
+	fs.BoolVar(&cfg.AddSource, "log-add-source-line", cfg.AddSource,
+		"Add source code file and line number to logs (for debugging and development purposes)")
 }
 
 func MarkFlagHidden(cmd *cobra.Command, names ...string) {

--- a/log/config.go
+++ b/log/config.go
@@ -12,16 +12,18 @@ import (
 
 // Config is a configuration for the loggers.
 type Config struct {
-	File   *os.File
-	Level  Level
-	Format Format
+	File      *os.File
+	Level     Level
+	Format    Format
+	AddSource bool
 }
 
 func DefaultConfig() *Config {
 	return &Config{
-		File:   nil,
-		Level:  InfoLevel,
-		Format: TextFormat,
+		File:      nil,
+		Level:     InfoLevel,
+		Format:    TextFormat,
+		AddSource: false,
 	}
 }
 


### PR DESCRIPTION
Add switch `log-add-source-line` to enable logging source code file and line number for development/debugging purposes.

example:

```
time=2025-10-13T16:27:47.544+02:00 level=INFO source=github.com/saucelabs/forwarder/http_proxy.go:312 msg="no upstream proxy specified" module=proxy
```

cc: @markamsauce 