### PR TITLE
support renaming heades to non-canonicalized case

### DIFF
--- a/docs/content/cli/forwarder_run.md
+++ b/docs/content/cli/forwarder_run.md
@@ -217,6 +217,7 @@ Use the format:
 - name; to set the header to empty value
 - -name to remove the header
 - -name* to remove headers by prefix
+- %name to disable header name canonicalization for particular header name
 
 The header name will be normalized to canonical form.
 The header value should not contain any newlines or carriage returns.
@@ -226,6 +227,25 @@ The following example removes the User-Agent header and all headers starting wit
 ```
 -H "-User-Agent" -H "-X-*"
 ```
+
+#### Disabling header canonicalization
+
+By default all headers received from a request are being canonicalized and this can not be disabled. In some rare cases
+destination HTTP servers or load balancers break HTTP standards
+and treat header names as case sensitive. 
+
+So if browser sends `header-a`, forwarder canonicalizes the name to `Header-A` and the target application breaks, because it expects different name. The "%" option allows to change particular header case if needed.
+
+For example
+
+```
+ -H "%header-a"
+```
+
+If any case form of provided header name exists in request it will be renamed to the exact form provided. In that case browser can send
+`header-a`, forwarder will canonicalize it
+to `Header-A` but this option will rename it back to `header-a`.
+
 
 ### `-p, --pac` {#pac}
 

--- a/header/header_test.go
+++ b/header/header_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseHeader(t *testing.T) {
@@ -18,6 +19,13 @@ func TestParseHeader(t *testing.T) {
 		input    string
 		expected Header
 	}{
+		{
+			input: "%rename-me",
+			expected: Header{
+				Name:   "rename-me",
+				Action: RenameCase,
+			},
+		},
 		{
 			input: "-RemoveMe",
 			expected: Header{
@@ -159,4 +167,23 @@ func TestRemoveHeadersByPrefix(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReplaceCaseHeaderApply(t *testing.T) {
+	// force header to be in non-canonicalised form according to pattern
+	header := Header{
+		Name:   "rename-mE",
+		Action: RenameCase,
+	}
+
+	httpHeader := make(http.Header)
+
+	httpHeader.Add("Rename-Me", "true")
+	header.Apply(httpHeader)
+
+	_, ok := httpHeader["rename-mE"] //nolint
+	require.True(t, ok)
+
+	_, ok = httpHeader["Rename-Me"]
+	require.False(t, ok)
 }


### PR DESCRIPTION
Support header renaming to use non-canonicalized names.

See changed docs for more explanation.
