### PR TITLE
[SC-5424] Sanitize malformed query with unicode replacements

### DIFF
--- a/command/ready/ready.go
+++ b/command/ready/ready.go
@@ -38,6 +38,7 @@ func DefaultConfig() Config {
 
 type command struct {
 	Config
+
 	apiAddr string
 }
 

--- a/internal/martian/proxy_conn.go
+++ b/internal/martian/proxy_conn.go
@@ -106,11 +106,11 @@ func (p *proxyConn) readRequest() (*http.Request, error) {
 		log.Error(context.TODO(), "can't set read header deadline", "error", deadlineErr)
 	}
 
-	br, err := sanitizeRequestLine(p.brw.Reader, p.conn)
-	if err != nil {
-		return nil, err
+	if br, err := sanitizeRequestLine(p.brw.Reader, p.conn); err != nil {
+		log.Error(context.TODO(), "can't sanitize request line", "error", err)
+	} else {
+		p.brw.Reader = br
 	}
-	p.brw.Reader = br
 
 	req, err := http.ReadRequest(p.brw.Reader)
 	if err != nil {

--- a/internal/martian/proxy_conn.go
+++ b/internal/martian/proxy_conn.go
@@ -106,6 +106,12 @@ func (p *proxyConn) readRequest() (*http.Request, error) {
 		log.Error(context.TODO(), "can't set read header deadline", "error", deadlineErr)
 	}
 
+	br, err := sanitizeRequestLine(p.brw.Reader, p.conn)
+	if err != nil {
+		return nil, err
+	}
+	p.brw.Reader = br
+
 	req, err := http.ReadRequest(p.brw.Reader)
 	if err != nil {
 		return nil, err

--- a/internal/martian/reqline.go
+++ b/internal/martian/reqline.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Sauce Labs Inc., all rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package martian
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"net"
+)
+
+// sanitizeRequestLine peeks the first request line from br and, if the URL
+// portion contains bare `%` characters that don't form a valid %XX escape
+// (e.g. "%PUBLIC_URL%"), rewrites them to `%25` so http.ReadRequest can parse
+// the URL. Origin servers decode `%25` back to `%`, so the request semantics
+// are preserved end-to-end.
+func sanitizeRequestLine(br *bufio.Reader, conn net.Conn) (*bufio.Reader, error) {
+	line, ok := peekRequestLine(br)
+	if !ok {
+		return br, nil
+	}
+	fixed, changed := escapeInvalidPercent(line)
+	if !changed {
+		return br, nil
+	}
+
+	if _, err := br.Discard(len(line)); err != nil {
+		return br, err
+	}
+	rest, _ := br.Peek(br.Buffered())
+
+	prefix := make([]byte, 0, len(fixed)+len(rest))
+	prefix = append(prefix, fixed...)
+	prefix = append(prefix, rest...)
+
+	return bufio.NewReader(io.MultiReader(bytes.NewReader(prefix), conn)), nil
+}
+
+// peekRequestLine returns the first line (up to and including \n) from br
+// without consuming it, using only bytes already buffered. Returns
+// (nil, false) if the line does not end within the currently buffered data.
+//
+// Peeking only what's buffered avoids blocking on a socket read that may
+// never return (e.g. an idle keep-alive connection waiting for the next
+// request). In the common case, the caller has already triggered a fill via
+// bufio.Reader.Peek(1) before this is called, and the whole request line
+// arrives in a single Read, so it will be in the buffer.
+func peekRequestLine(br *bufio.Reader) ([]byte, bool) {
+	buf, _ := br.Peek(br.Buffered())
+	if i := bytes.IndexByte(buf, '\n'); i >= 0 {
+		return buf[:i+1], true
+	}
+	return nil, false
+}
+
+// escapeInvalidPercent rewrites the URL slice of an HTTP/1.x request line,
+// replacing any `%` not followed by two hex digits with `%25`. Returns the
+// (possibly reallocated) line and whether any substitution was made.
+func escapeInvalidPercent(line []byte) ([]byte, bool) {
+	sp1 := bytes.IndexByte(line, ' ')
+	if sp1 < 0 {
+		return line, false
+	}
+	sp2 := bytes.IndexByte(line[sp1+1:], ' ')
+	if sp2 < 0 {
+		return line, false
+	}
+	sp2 += sp1 + 1
+
+	urlPart := line[sp1+1 : sp2]
+	if !hasBarePercent(urlPart) {
+		return line, false
+	}
+
+	out := make([]byte, 0, len(line)+8)
+	out = append(out, line[:sp1+1]...)
+	for i := range len(urlPart) {
+		if urlPart[i] == '%' && !validEscape(urlPart, i) {
+			out = append(out, '%', '2', '5')
+			continue
+		}
+		out = append(out, urlPart[i])
+	}
+	out = append(out, line[sp2:]...)
+	return out, true
+}
+
+func hasBarePercent(s []byte) bool {
+	for i := range len(s) {
+		if s[i] == '%' && !validEscape(s, i) {
+			return true
+		}
+	}
+	return false
+}
+
+func validEscape(s []byte, i int) bool {
+	return i+2 < len(s) && isHex(s[i+1]) && isHex(s[i+2])
+}
+
+func isHex(c byte) bool {
+	return c >= '0' && c <= '9' || c >= 'a' && c <= 'f' || c >= 'A' && c <= 'F'
+}

--- a/internal/martian/reqline.go
+++ b/internal/martian/reqline.go
@@ -68,31 +68,17 @@ func peekRequestLine(br *bufio.Reader) ([]byte, bool) {
 // replacing any `%` not followed by two hex digits with `%25`. Returns the
 // (possibly reallocated) line and whether any substitution was made.
 func escapeInvalidPercent(line []byte) ([]byte, bool) {
-	sp1 := bytes.IndexByte(line, ' ')
-	if sp1 < 0 {
+	if !hasBarePercent(line) {
 		return line, false
 	}
-	sp2 := bytes.IndexByte(line[sp1+1:], ' ')
-	if sp2 < 0 {
-		return line, false
-	}
-	sp2 += sp1 + 1
-
-	urlPart := line[sp1+1 : sp2]
-	if !hasBarePercent(urlPart) {
-		return line, false
-	}
-
 	out := make([]byte, 0, len(line)+8)
-	out = append(out, line[:sp1+1]...)
-	for i := range len(urlPart) {
-		if urlPart[i] == '%' && !validEscape(urlPart, i) {
+	for i := range len(line) {
+		if line[i] == '%' && !validEscape(line, i) {
 			out = append(out, '%', '2', '5')
 			continue
 		}
-		out = append(out, urlPart[i])
+		out = append(out, line[i])
 	}
-	out = append(out, line[sp2:]...)
 	return out, true
 }
 

--- a/internal/martian/reqline_test.go
+++ b/internal/martian/reqline_test.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Sauce Labs Inc., all rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package martian
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestEscapeInvalidPercent(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		changed bool
+	}{
+		{
+			name:    "no percent",
+			in:      "GET /foo/bar HTTP/1.1\r\n",
+			want:    "GET /foo/bar HTTP/1.1\r\n",
+			changed: false,
+		},
+		{
+			name:    "valid escape untouched",
+			in:      "GET /foo%20bar HTTP/1.1\r\n",
+			want:    "GET /foo%20bar HTTP/1.1\r\n",
+			changed: false,
+		},
+		{
+			name:    "bare percent single",
+			in:      "GET /foo/%PUBLIC_URL%/bar HTTP/1.1\r\n",
+			want:    "GET /foo/%25PUBLIC_URL%25/bar HTTP/1.1\r\n",
+			changed: true,
+		},
+		{
+			name:    "absolute URL from proxy client",
+			in:      "GET http://google.com/stock-search/%PUBLIC_URL%/favicon.ico HTTP/1.1\r\n",
+			want:    "GET http://google.com/stock-search/%25PUBLIC_URL%25/favicon.ico HTTP/1.1\r\n",
+			changed: true,
+		},
+		{
+			name:    "percent at end of URL",
+			in:      "GET /foo% HTTP/1.1\r\n",
+			want:    "GET /foo%25 HTTP/1.1\r\n",
+			changed: true,
+		},
+		{
+			name:    "percent with one hex digit",
+			in:      "GET /foo%2 HTTP/1.1\r\n",
+			want:    "GET /foo%252 HTTP/1.1\r\n",
+			changed: true,
+		},
+		{
+			name:    "mixed valid and invalid",
+			in:      "GET /a%20b%PUBLIC%/c%2F HTTP/1.1\r\n",
+			want:    "GET /a%20b%25PUBLIC%25/c%2F HTTP/1.1\r\n",
+			changed: true,
+		},
+		{
+			name:    "hex case-insensitive is valid",
+			in:      "GET /foo%aB HTTP/1.1\r\n",
+			want:    "GET /foo%aB HTTP/1.1\r\n",
+			changed: false,
+		},
+		{
+			name:    "only method no url",
+			in:      "GET\r\n",
+			want:    "GET\r\n",
+			changed: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, changed := escapeInvalidPercent([]byte(tc.in))
+			if changed != tc.changed {
+				t.Errorf("changed: got %v, want %v", changed, tc.changed)
+			}
+			if string(got) != tc.want {
+				t.Errorf("out:\n  got  %q\n  want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSanitizeRequestLine_ProducesParseableRequest confirms that a request
+// line rejected by http.ReadRequest becomes parseable after sanitization,
+// and that the URL round-trips to the origin with %25-escaped percents.
+func TestSanitizeRequestLine_ProducesParseableRequest(t *testing.T) {
+	const raw = "GET http://google.com/stock-search/%PUBLIC_URL%/favicon.ico HTTP/1.1\r\n" +
+		"Host: google.com\r\n\r\n"
+
+	// Sanity: stock http.ReadRequest rejects this.
+	if _, err := http.ReadRequest(bufio.NewReader(newFakeConn(raw))); err == nil {
+		t.Fatal("expected http.ReadRequest to fail on unsanitized input")
+	}
+
+	conn := newFakeConn(raw)
+	initial := bufio.NewReader(conn)
+	// Mirror the real caller: proxyConn does Peek(1) before sanitize, which
+	// forces bufio to fill from the underlying reader.
+	if _, err := initial.Peek(1); err != nil {
+		t.Fatalf("Peek(1): %v", err)
+	}
+	br, err := sanitizeRequestLine(initial, conn)
+	if err != nil {
+		t.Fatalf("sanitizeRequestLine: %v", err)
+	}
+
+	req, err := http.ReadRequest(br)
+	if err != nil {
+		t.Fatalf("http.ReadRequest after sanitize: %v", err)
+	}
+
+	want := "/stock-search/%25PUBLIC_URL%25/favicon.ico"
+	if got := req.URL.RequestURI(); got != want {
+		t.Errorf("req.URL.RequestURI() = %q, want %q", got, want)
+	}
+	if got := req.Host; got != "google.com" {
+		t.Errorf("req.Host = %q, want google.com", got)
+	}
+}
+
+// TestSanitizeRequestLine_NoOpForCleanRequest confirms the fast path leaves
+// the reader untouched when there are no bare `%` chars.
+func TestSanitizeRequestLine_NoOpForCleanRequest(t *testing.T) {
+	const raw = "GET /foo HTTP/1.1\r\nHost: x\r\n\r\n"
+
+	conn := newFakeConn(raw)
+	original := bufio.NewReader(conn)
+	if _, err := original.Peek(1); err != nil {
+		t.Fatalf("Peek(1): %v", err)
+	}
+	br, err := sanitizeRequestLine(original, conn)
+	if err != nil {
+		t.Fatalf("sanitizeRequestLine: %v", err)
+	}
+	if br != original {
+		t.Fatal("expected reader to be returned unchanged on clean input")
+	}
+}
+
+// fakeConn is a net.Conn backed by a byte string for reads and a no-op for
+// writes, sufficient for exercising sanitizeRequestLine.
+type fakeConn struct {
+	r io.Reader
+}
+
+func newFakeConn(s string) *fakeConn {
+	return &fakeConn{r: newEOFReader(s)}
+}
+
+// newEOFReader returns a reader that yields s then EOF. Using strings.NewReader
+// works but we want an io.Reader without importing strings just for this.
+func newEOFReader(s string) io.Reader { return &stringReader{s: s} }
+
+type stringReader struct {
+	s string
+	i int
+}
+
+func (r *stringReader) Read(p []byte) (int, error) {
+	if r.i >= len(r.s) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.s[r.i:])
+	r.i += n
+	return n, nil
+}
+
+func (c *fakeConn) Read(p []byte) (int, error)         { return c.r.Read(p) }
+func (c *fakeConn) Write(p []byte) (int, error)        { return len(p), nil }
+func (c *fakeConn) Close() error                       { return nil }
+func (c *fakeConn) LocalAddr() net.Addr                { return &net.TCPAddr{} }
+func (c *fakeConn) RemoteAddr() net.Addr               { return &net.TCPAddr{} }
+func (c *fakeConn) SetDeadline(t time.Time) error      { return nil }
+func (c *fakeConn) SetReadDeadline(t time.Time) error  { return nil }
+func (c *fakeConn) SetWriteDeadline(t time.Time) error { return nil }

--- a/internal/martian/reqline_test.go
+++ b/internal/martian/reqline_test.go
@@ -84,6 +84,12 @@ func TestEscapeInvalidPercent(t *testing.T) {
 			want:    "GET\r\n",
 			changed: false,
 		},
+		{
+			name:    "multiple spaces around URL",
+			in:      "GET     /foo/%PUBLIC_URL%/bar                  HTTP/1.1\r\n",
+			want:    "GET     /foo/%25PUBLIC_URL%25/bar                  HTTP/1.1\r\n",
+			changed: true,
+		},
 	}
 
 	for _, tc := range tests {

--- a/net.go
+++ b/net.go
@@ -230,8 +230,9 @@ func DefaultListenerConfig(addr string) *ListenerConfig {
 }
 
 type NamedListenerConfig struct {
-	Name string
 	ListenerConfig
+
+	Name string
 }
 
 // MultiListener is a builder for multiple listeners sharing the same prometheus configuration.
@@ -239,9 +240,10 @@ type NamedListenerConfig struct {
 //
 //nolint:recvcheck // This is intentional.
 type MultiListener struct {
+	PromConfig
+
 	ListenerConfigs []NamedListenerConfig
 	TLSConfig       func(NamedListenerConfig) *tls.Config
-	PromConfig
 }
 
 func (ml MultiListener) Listen() (_ []net.Listener, ferr error) {
@@ -274,11 +276,11 @@ func (ml MultiListener) Listen() (_ []net.Listener, ferr error) {
 
 type Listener struct {
 	ListenerConfig
-	TLSConfig *tls.Config
 	PromConfig
 
-	listener net.Listener
-	metrics  *listenerMetrics
+	TLSConfig *tls.Config
+	listener  net.Listener
+	metrics   *listenerMetrics
 }
 
 func (l *Listener) Listen() error {

--- a/ratelimit/conn.go
+++ b/ratelimit/conn.go
@@ -15,6 +15,7 @@ import (
 
 type Conn struct {
 	net.Conn
+
 	rxLimiter *rate.Limiter
 	txLimiter *rate.Limiter
 }


### PR DESCRIPTION
Following this change, the forwarder will forward requests with bare % in the URL by escaping to %25, to sanitize malformed queries and redirect them towards the sanitized URLs.
<!-- Thank you for your hard work on this pull request! -->
