### PR TITLE
Add --behavior-force-ntlm-instead-negotiate switch

### DIFF
--- a/.golangci-fmt.bck.yml
+++ b/.golangci-fmt.bck.yml
@@ -1,0 +1,15 @@
+---
+run:
+  build-tags:
+    - e2e
+  tests: true
+
+linters:
+  disable-all: true
+  enable:
+    - gci
+    - gofumpt
+
+issues:
+  exclude-files:
+    - mock_.*\\.go

--- a/.golangci-fmt.yml
+++ b/.golangci-fmt.yml
@@ -1,16 +1,31 @@
----
+version: "2"
 run:
-  deadline: 5m
   build-tags:
     - e2e
   tests: true
-
 linters:
-  disable-all: true
+  default: none
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - mock_.*\\.go
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
   enable:
     - gci
     - gofumpt
-
-issues:
-  exclude-files:
-    - mock_.*\\.go
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - mock_.*\\.go
+      - third_party$
+      - builtin$
+      - examples$

--- a/bind/flag.go
+++ b/bind/flag.go
@@ -127,6 +127,11 @@ func ResponseHeaders(fs *pflag.FlagSet, headers *[]header.Header) {
 			"See the documentation for the -H, --header flag for more details on the format. ")
 }
 
+func BehaviorModificationConfig(fs *pflag.FlagSet, cfg *forwarder.BehaviorModificationConfig) {
+	fs.BoolVar(&cfg.UseNTLMInsteadOfNegotiate, "behavior-force-ntlm-instead-negotiate", cfg.UseNTLMInsteadOfNegotiate,
+		"If server presents both WWW-Authenticate options: Negotiate and NTLM, remove Negotiate value. This forces browser to use plain NTLM auth. ")
+}
+
 func HTTPProxyConfig(fs *pflag.FlagSet, cfg *forwarder.HTTPProxyConfig, lcfg *log.Config) {
 	HTTPServerConfig(fs, &cfg.HTTPServerConfig, "", forwarder.HTTPScheme, forwarder.HTTPSScheme)
 	LogConfig(fs, lcfg)
@@ -260,7 +265,7 @@ func HTTPTransportConfig(fs *pflag.FlagSet, cfg *forwarder.HTTPTransportConfig) 
 
 	fs.IntVar(&cfg.MaxConnsPerHost,
 		"http-max-conns-per-host", cfg.MaxConnsPerHost,
-		"The maximum number of connections active for givern host:port pair. ")
+		"The maximum number of connections active for given host:port pair. ")
 
 	fs.DurationVar(&cfg.ResponseHeaderTimeout,
 		"http-response-header-timeout", cfg.ResponseHeaderTimeout,

--- a/bind/flag.go
+++ b/bind/flag.go
@@ -128,7 +128,7 @@ func ResponseHeaders(fs *pflag.FlagSet, headers *[]header.Header) {
 }
 
 func BehaviorModificationConfig(fs *pflag.FlagSet, cfg *forwarder.BehaviorModificationConfig) {
-	fs.BoolVar(&cfg.UseNTLMInsteadOfNegotiate, "behavior-force-ntlm-instead-negotiate", cfg.UseNTLMInsteadOfNegotiate,
+	fs.BoolVar(&cfg.ForceNTLMInsteadOfNegotiate, "behavior-force-ntlm-instead-negotiate", cfg.ForceNTLMInsteadOfNegotiate,
 		"If server presents both WWW-Authenticate options: Negotiate and NTLM, remove Negotiate value. This forces browser to use plain NTLM auth. ")
 }
 

--- a/command/run/run.go
+++ b/command/run/run.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -219,6 +220,7 @@ func (c *command) runE(cmd *cobra.Command, _ []string) (cmdErr error) {
 	}
 
 	c.configureHeadersModifiers()
+	c.configureBehaviorModifiers()
 
 	if c.mitm || c.mitmConfig.CACertFile != "" || len(c.mitmDomains) > 0 {
 		c.httpProxyConfig.MITM = c.mitmConfig
@@ -344,6 +346,39 @@ func (c *command) configureHeadersModifiers() {
 		})
 		c.httpProxyConfig.ResponseModifiers = append(c.httpProxyConfig.ResponseModifiers, m)
 	}
+}
+
+func (c *command) configureBehaviorModifiers() {
+	if c.httpProxyConfig.BehaviorModification.UseNTLMInsteadOfNegotiate {
+		// if response header contain WWW-Authenticate Negotiate and WWW-Authenticate NTLM,
+		// remove Negotiate to force NTLM
+
+		m := forwarder.ResponseModifierFunc(func(resp *http.Response) error {
+			wwwAuthenticateValues := resp.Header.Values("WWW-Authenticate")
+
+			if len(wwwAuthenticateValues) < 2 {
+				return nil
+			}
+
+			if slices.Contains(wwwAuthenticateValues, "Negotiate") && slices.Contains(wwwAuthenticateValues, "NTLM") {
+				negotiatePosition := slices.Index(wwwAuthenticateValues, "Negotiate")
+
+				if negotiatePosition == -1 { // should not happen ever at this point
+					return nil
+				}
+
+				updatedHeaderValues := slices.Delete(wwwAuthenticateValues, negotiatePosition, negotiatePosition)
+				resp.Header.Del("WWW-Authenticate")
+
+				for _, value := range updatedHeaderValues {
+					resp.Header.Add("WWW-Authenticate", value)
+				}
+			} // if slices.Contains
+			return nil
+		})
+
+		c.httpProxyConfig.ResponseModifiers = append(c.httpProxyConfig.ResponseModifiers, m)
+	} // if UseNTLM...
 }
 
 // Configure upstream proxy transport - connect headers and/or Kerberos auth.
@@ -477,6 +512,7 @@ func Command() *cobra.Command {
 	bind.RequestHeaders(fs, &c.requestHeaders)
 	bind.ResponseHeaders(fs, &c.responseHeaders)
 	bind.HTTPProxyConfig(fs, c.httpProxyConfig, c.logConfig)
+	bind.BehaviorModificationConfig(fs, &c.httpProxyConfig.BehaviorModification)
 	bind.MITMConfig(fs, &c.mitm, c.mitmConfig)
 	bind.MITMDomains(fs, &c.mitmDomains)
 	bind.ProxyProtocol(fs, &c.proxyProtocol, c.proxyProtocolConfig)

--- a/command/run/run.go
+++ b/command/run/run.go
@@ -349,7 +349,7 @@ func (c *command) configureHeadersModifiers() {
 }
 
 func (c *command) configureBehaviorModifiers() {
-	if c.httpProxyConfig.BehaviorModification.UseNTLMInsteadOfNegotiate {
+	if c.httpProxyConfig.BehaviorModification.ForceNTLMInsteadOfNegotiate {
 		// if response header contain WWW-Authenticate Negotiate and WWW-Authenticate NTLM,
 		// remove Negotiate to force NTLM
 
@@ -378,7 +378,7 @@ func (c *command) configureBehaviorModifiers() {
 		})
 
 		c.httpProxyConfig.ResponseModifiers = append(c.httpProxyConfig.ResponseModifiers, m)
-	} // if UseNTLM...
+	}
 }
 
 // Configure upstream proxy transport - connect headers and/or Kerberos auth.

--- a/docs/content/cli/forwarder_run.md
+++ b/docs/content/cli/forwarder_run.md
@@ -375,6 +375,21 @@ Organization name to use in the generated MITM certificates.
 
 Validity period of the generated MITM certificates.
 
+## Behavior modification options
+
+### `--behavior-force-ntlm-instead-negotiate` {#behavior-force-ntlm}
+
+* Environment variable: `FORWARDER_BEHAVIOR_FORCE_NTLM_INSTEAD_NEGOTIATE`
+* Value Format: `<value>`
+* Default value: `false`
+
+If a server presents WWW-Authenticate headers for both `Negotiate` and `NTLM` - remove `Negotiate` header on the fly before passing response to the client to force the client to use "basic" NTLM.
+
+This is a workaround to an issue with Negotiate authentication with Windows servers resulting in 401 errors. Errors are caused by NTLM 3-step negotiation and token (not to be confused with "basic" NTLM) being bound by design to a particular TCP socket.
+
+As forwarder multiplexes multiple connections from clients into one or more TCP connections to a server, those sessions conflict with each other and invalidate themselves (a race condition).
+
+
 ## DNS options
 
 ### `--dns-round-robin` {#dns-round-robin}
@@ -479,12 +494,7 @@ Zero means no limit.
 MaxConnsPerHost optionally limits the total number of onnections per host, including connections in the dialing,
 active, and idle states. On limit violation, dials will block.
 
-If you are using NTLM web authorization protocol and you observe hard to explain 401 errors - set this value to 1.
-
-NTLM authorization breaks in forwarder because in NTLM challenge and token must be transmitter over same socket connection. If
-forwarder load-balances requests to a host over a pool - some requests with authorization token may end up on a different
-socket connection and server will respond with 401 error.
-
+This may greatly limit forwarder performance and response times - use with caution.
 
 ### `--http-response-header-timeout` {#http-response-header-timeout}
 

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -83,7 +83,7 @@ type (
 var ErrConnectFallback = martian.ErrConnectFallback
 
 type BehaviorModificationConfig struct {
-	UseNTLMInsteadOfNegotiate bool
+	ForceNTLMInsteadOfNegotiate bool
 }
 
 type HTTPProxyConfig struct {
@@ -132,7 +132,7 @@ func DefaultHTTPProxyConfig() *HTTPProxyConfig {
 }
 
 func DefaultBehaviorModificationConfig() *BehaviorModificationConfig {
-	return &BehaviorModificationConfig{UseNTLMInsteadOfNegotiate: false}
+	return &BehaviorModificationConfig{ForceNTLMInsteadOfNegotiate: false}
 }
 
 func (c *HTTPProxyConfig) Validate() error {
@@ -467,8 +467,8 @@ func (hp *HTTPProxy) middlewareStack() (martian.RequestResponseModifier, *martia
 		fg.AddResponseModifier(m)
 	}
 
-	if hp.config.BehaviorModification.UseNTLMInsteadOfNegotiate {
-		fg.AddResponseModifier(martian.ResponseModifierFunc(middleware.BehaviorUseNTLMInsteadOfNegotiateModifier))
+	if hp.config.BehaviorModification.ForceNTLMInsteadOfNegotiate {
+		fg.AddResponseModifier(martian.ResponseModifierFunc(middleware.BehaviorForceNTLMInsteadOfNegotiateModifier))
 	}
 
 	if hp.config.LogHTTPMode != httplog.None {

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -82,25 +82,30 @@ type (
 // that the CONNECT request should be handled by martian.
 var ErrConnectFallback = martian.ErrConnectFallback
 
+type BehaviorModificationConfig struct {
+	UseNTLMInsteadOfNegotiate bool
+}
+
 type HTTPProxyConfig struct {
 	HTTPServerConfig
 
-	ExtraListeners    []NamedListenerConfig
-	Name              string
-	MITM              *MITMConfig
-	MITMDomains       Matcher
-	ProxyLocalhost    ProxyLocalhostMode
-	UpstreamProxy     *url.URL
-	UpstreamProxyFunc ProxyFunc
-	DenyDomains       Matcher
-	DirectDomains     Matcher
-	RequestIDHeader   string
-	RequestModifiers  []RequestModifier
-	ResponseModifiers []ResponseModifier
-	ConnectFunc       ConnectFunc
-	ConnectTimeout    time.Duration
-	PromHTTPOpts      []middleware.PrometheusOpt
-	AllowTimeFrame    []ruleset.TimeFrameEntry
+	ExtraListeners       []NamedListenerConfig
+	Name                 string
+	MITM                 *MITMConfig
+	MITMDomains          Matcher
+	ProxyLocalhost       ProxyLocalhostMode
+	UpstreamProxy        *url.URL
+	UpstreamProxyFunc    ProxyFunc
+	DenyDomains          Matcher
+	DirectDomains        Matcher
+	RequestIDHeader      string
+	RequestModifiers     []RequestModifier
+	ResponseModifiers    []ResponseModifier
+	ConnectFunc          ConnectFunc
+	ConnectTimeout       time.Duration
+	PromHTTPOpts         []middleware.PrometheusOpt
+	AllowTimeFrame       []ruleset.TimeFrameEntry
+	BehaviorModification BehaviorModificationConfig
 	// TestingHTTPHandler uses Martian's [http.Handler] implementation
 	// over [http.Server] instead of the default TCP server.
 	TestingHTTPHandler bool
@@ -118,11 +123,16 @@ func DefaultHTTPProxyConfig() *HTTPProxyConfig {
 				HandshakeTimeout: 10 * time.Second,
 			},
 		},
-		Name:            "forwarder",
-		ProxyLocalhost:  DenyProxyLocalhost,
-		RequestIDHeader: "X-Request-Id",
-		ConnectTimeout:  60 * time.Second, // http.Transport sets a constant 1m timeout for CONNECT requests.
+		Name:                 "forwarder",
+		ProxyLocalhost:       DenyProxyLocalhost,
+		RequestIDHeader:      "X-Request-Id",
+		ConnectTimeout:       60 * time.Second, // http.Transport sets a constant 1m timeout for CONNECT requests.
+		BehaviorModification: *DefaultBehaviorModificationConfig(),
 	}
+}
+
+func DefaultBehaviorModificationConfig() *BehaviorModificationConfig {
+	return &BehaviorModificationConfig{UseNTLMInsteadOfNegotiate: false}
 }
 
 func (c *HTTPProxyConfig) Validate() error {
@@ -455,6 +465,10 @@ func (hp *HTTPProxy) middlewareStack() (martian.RequestResponseModifier, *martia
 
 	for _, m := range hp.config.ResponseModifiers {
 		fg.AddResponseModifier(m)
+	}
+
+	if hp.config.BehaviorModification.UseNTLMInsteadOfNegotiate {
+		fg.AddResponseModifier(martian.ResponseModifierFunc(middleware.BehaviorUseNTLMInsteadOfNegotiateModifier))
 	}
 
 	if hp.config.LogHTTPMode != httplog.None {

--- a/http_proxy_test.go
+++ b/http_proxy_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -277,5 +278,74 @@ func TestAllowTimeFrame(t *testing.T) {
 		res := rw.Result()
 
 		assert.Equal(t, http.StatusUnavailableForLegalReasons, res.StatusCode)
+	})
+}
+
+func TestBehaviorForceNTLMInsteadNegotiate(t *testing.T) {
+	t.Run("handleHTTPRequestWhenDisabled", func(t *testing.T) {
+		cfg := DefaultHTTPProxyConfig()
+		cfg.ProxyLocalhost = AllowProxyLocalhost
+
+		cfg.BehaviorModification.UseNTLMInsteadOfNegotiate = false
+
+		h, err := NewHTTPProxyHandler(cfg, nil, nil, nil, slog.Default(), nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Add("WWW-Authenticate", "Negotiate")
+			w.Header().Add("WWW-Authenticate", "NTLM")
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer s.Close()
+
+		req, err := http.NewRequest(http.MethodGet, "http://"+s.Listener.Addr().String(), http.NoBody)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rw := httptest.NewRecorder()
+		h.ServeHTTP(rw, req)
+
+		res := rw.Result()
+
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+		authenticateValues := res.Header.Values("WWW-Authenticate")
+		assert.True(t, slices.Contains(authenticateValues, "Negotiate"))
+		assert.True(t, slices.Contains(authenticateValues, "NTLM"))
+	})
+
+	t.Run("handleHTTPRequestWhenEnabled", func(t *testing.T) {
+		cfg := DefaultHTTPProxyConfig()
+		cfg.ProxyLocalhost = AllowProxyLocalhost
+		cfg.BehaviorModification.UseNTLMInsteadOfNegotiate = true
+
+		h, err := NewHTTPProxyHandler(cfg, nil, nil, nil, slog.Default(), nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Add("WWW-Authenticate", "Negotiate")
+			w.Header().Add("WWW-Authenticate", "NTLM")
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer s.Close()
+
+		req, err := http.NewRequest(http.MethodGet, "http://"+s.Listener.Addr().String(), http.NoBody)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rw := httptest.NewRecorder()
+		h.ServeHTTP(rw, req)
+
+		res := rw.Result()
+
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+		authenticateValues := res.Header.Values("WWW-Authenticate")
+		assert.Len(t, res.Header.Values("WWW-Authenticate"), 1)
+		assert.True(t, slices.Contains(authenticateValues, "NTLM"))
 	})
 }

--- a/http_proxy_test.go
+++ b/http_proxy_test.go
@@ -286,7 +286,7 @@ func TestBehaviorForceNTLMInsteadNegotiate(t *testing.T) {
 		cfg := DefaultHTTPProxyConfig()
 		cfg.ProxyLocalhost = AllowProxyLocalhost
 
-		cfg.BehaviorModification.UseNTLMInsteadOfNegotiate = false
+		cfg.BehaviorModification.ForceNTLMInsteadOfNegotiate = false
 
 		h, err := NewHTTPProxyHandler(cfg, nil, nil, nil, slog.Default(), nil)
 		if err != nil {
@@ -319,7 +319,7 @@ func TestBehaviorForceNTLMInsteadNegotiate(t *testing.T) {
 	t.Run("handleHTTPRequestWhenEnabled", func(t *testing.T) {
 		cfg := DefaultHTTPProxyConfig()
 		cfg.ProxyLocalhost = AllowProxyLocalhost
-		cfg.BehaviorModification.UseNTLMInsteadOfNegotiate = true
+		cfg.BehaviorModification.ForceNTLMInsteadOfNegotiate = true
 
 		h, err := NewHTTPProxyHandler(cfg, nil, nil, nil, slog.Default(), nil)
 		if err != nil {

--- a/middleware/use_ntlm_instead_negotiate.go
+++ b/middleware/use_ntlm_instead_negotiate.go
@@ -5,7 +5,7 @@ import (
 	"slices"
 )
 
-func BehaviorUseNTLMInsteadOfNegotiateModifier(resp *http.Response) error {
+func BehaviorForceNTLMInsteadOfNegotiateModifier(resp *http.Response) error {
 	// if response header contain WWW-Authenticate Negotiate and WWW-Authenticate NTLM,
 	// remove Negotiate to force NTLM
 

--- a/middleware/use_ntlm_instead_negotiate.go
+++ b/middleware/use_ntlm_instead_negotiate.go
@@ -1,0 +1,33 @@
+package middleware
+
+import (
+	"net/http"
+	"slices"
+)
+
+func BehaviorUseNTLMInsteadOfNegotiateModifier(resp *http.Response) error {
+	// if response header contain WWW-Authenticate Negotiate and WWW-Authenticate NTLM,
+	// remove Negotiate to force NTLM
+
+	wwwAuthenticateValues := resp.Header.Values("WWW-Authenticate")
+
+	if len(wwwAuthenticateValues) < 2 {
+		return nil
+	}
+
+	if slices.Contains(wwwAuthenticateValues, "Negotiate") && slices.Contains(wwwAuthenticateValues, "NTLM") {
+		negotiatePosition := slices.Index(wwwAuthenticateValues, "Negotiate")
+
+		if negotiatePosition == -1 { // should not happen ever at this point
+			return nil
+		}
+
+		updatedHeaderValues := slices.Delete(wwwAuthenticateValues, negotiatePosition, negotiatePosition+1)
+		resp.Header.Del("WWW-Authenticate")
+
+		for _, value := range updatedHeaderValues {
+			resp.Header.Add("WWW-Authenticate", value)
+		}
+	}
+	return nil
+}

--- a/middleware/use_ntlm_instead_negotiate_test.go
+++ b/middleware/use_ntlm_instead_negotiate_test.go
@@ -1,0 +1,54 @@
+// Copyright 2022-2026 Sauce Labs Inc., all rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package middleware
+
+import (
+	"net/http"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUseNTLMInsteadNegotiate(t *testing.T) {
+	resp := http.Response{Header: http.Header{}}
+	resp.Header.Add("WWW-Authenticate", "Negotiate")
+	resp.Header.Add("WWW-Authenticate", "NTLM")
+
+	err := BehaviorUseNTLMInsteadOfNegotiateModifier(&resp)
+	require.NoError(t, err)
+
+	require.Len(t, resp.Header.Values("WWW-Authenticate"), 1)
+	require.Equal(t, "NTLM", resp.Header.Get("WWW-Authenticate"))
+}
+
+func TestUseNTLMInsteadNegotiateReversedOrder(t *testing.T) {
+	resp := http.Response{Header: http.Header{}}
+	resp.Header.Add("WWW-Authenticate", "NTLM")
+	resp.Header.Add("WWW-Authenticate", "Negotiate")
+
+	err := BehaviorUseNTLMInsteadOfNegotiateModifier(&resp)
+	require.NoError(t, err)
+
+	require.Len(t, resp.Header.Values("WWW-Authenticate"), 1)
+	require.Equal(t, "NTLM", resp.Header.Get("WWW-Authenticate"))
+}
+
+func TestUseNTLMInsteadNegotiateMultipleHeaders(t *testing.T) {
+	resp := http.Response{Header: http.Header{}}
+	resp.Header.Add("WWW-Authenticate", "Fake1")
+	resp.Header.Add("WWW-Authenticate", "NTLM")
+	resp.Header.Add("WWW-Authenticate", "Fake2")
+	resp.Header.Add("WWW-Authenticate", "Negotiate")
+	resp.Header.Add("WWW-Authenticate", "Fake3")
+
+	err := BehaviorUseNTLMInsteadOfNegotiateModifier(&resp)
+	require.NoError(t, err)
+
+	require.Len(t, resp.Header.Values("WWW-Authenticate"), 4)
+	require.False(t, slices.Contains(resp.Header.Values("WWW-Authenticate"), "Negotiate"))
+}

--- a/middleware/use_ntlm_instead_negotiate_test.go
+++ b/middleware/use_ntlm_instead_negotiate_test.go
@@ -14,31 +14,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUseNTLMInsteadNegotiate(t *testing.T) {
+func TestForceNTLMInsteadNegotiate(t *testing.T) {
 	resp := http.Response{Header: http.Header{}}
 	resp.Header.Add("WWW-Authenticate", "Negotiate")
 	resp.Header.Add("WWW-Authenticate", "NTLM")
 
-	err := BehaviorUseNTLMInsteadOfNegotiateModifier(&resp)
+	err := BehaviorForceNTLMInsteadOfNegotiateModifier(&resp)
 	require.NoError(t, err)
 
 	require.Len(t, resp.Header.Values("WWW-Authenticate"), 1)
 	require.Equal(t, "NTLM", resp.Header.Get("WWW-Authenticate"))
 }
 
-func TestUseNTLMInsteadNegotiateReversedOrder(t *testing.T) {
+func TestForceNTLMInsteadNegotiateReversedOrder(t *testing.T) {
 	resp := http.Response{Header: http.Header{}}
 	resp.Header.Add("WWW-Authenticate", "NTLM")
 	resp.Header.Add("WWW-Authenticate", "Negotiate")
 
-	err := BehaviorUseNTLMInsteadOfNegotiateModifier(&resp)
+	err := BehaviorForceNTLMInsteadOfNegotiateModifier(&resp)
 	require.NoError(t, err)
 
 	require.Len(t, resp.Header.Values("WWW-Authenticate"), 1)
 	require.Equal(t, "NTLM", resp.Header.Get("WWW-Authenticate"))
 }
 
-func TestUseNTLMInsteadNegotiateMultipleHeaders(t *testing.T) {
+func TestForceNTLMInsteadNegotiateMultipleHeaders(t *testing.T) {
 	resp := http.Response{Header: http.Header{}}
 	resp.Header.Add("WWW-Authenticate", "Fake1")
 	resp.Header.Add("WWW-Authenticate", "NTLM")
@@ -46,7 +46,7 @@ func TestUseNTLMInsteadNegotiateMultipleHeaders(t *testing.T) {
 	resp.Header.Add("WWW-Authenticate", "Negotiate")
 	resp.Header.Add("WWW-Authenticate", "Fake3")
 
-	err := BehaviorUseNTLMInsteadOfNegotiateModifier(&resp)
+	err := BehaviorForceNTLMInsteadOfNegotiateModifier(&resp)
 	require.NoError(t, err)
 
 	require.Len(t, resp.Header.Values("WWW-Authenticate"), 4)

--- a/pac/pac.go
+++ b/pac/pac.go
@@ -72,7 +72,7 @@ func NewProxyResolver(cfg *ProxyResolverConfig, r *net.Resolver, opts ...Option)
 
 	// Set additional options before evaluating the PAC script.
 	for _, opt := range opts {
-		(opt)(pr.vm)
+		opt(pr.vm)
 	}
 
 	// Evaluate the PAC script.


### PR DESCRIPTION
Add a switch to force NTLM auth negotiation when server responds with both "Negotiate" and NTLM (by removing the "Negotiate" header). 

Rationale explained in the docs.
